### PR TITLE
[receiver/kafka] Extract partition worker without behavior change

### DIFF
--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -8,453 +8,219 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadata"
 )
+
+func loadConfig(t *testing.T, name string) (*Config, error) {
+	t.Helper()
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+
+	cfg := NewFactory().CreateDefaultConfig()
+	sub, err := cm.Sub(name)
+	require.NoError(t, err)
+	require.NoError(t, sub.Unmarshal(cfg))
+	return cfg.(*Config), confmap.Validate(cfg)
+}
 
 func TestLoadConfig(t *testing.T) {
 	t.Parallel()
 
-	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
-	require.NoError(t, err)
-
-	tests := []struct {
-		id          component.ID
-		expected    component.Config
-		expectedErr error
+	cases := []struct {
+		name        string
+		expected    *Config
+		expectedErr string
 	}{
 		{
-			id: component.NewIDWithName(metadata.Type, "logs"),
-			expected: &Config{
-				ClientConfig: func() configkafka.ClientConfig {
-					config := configkafka.NewDefaultClientConfig()
-					config.Brokers = []string{"coffee:123", "foobar:456"}
-					config.Metadata.Retry.Max = 10
-					config.Metadata.Retry.Backoff = 5 * time.Second
-					config.Authentication.SASL = &configkafka.SASLConfig{
-						Mechanism: "PLAIN",
-						Username:  "user",
-						Password:  "password",
-					}
-					config.TLS = &configtls.ClientConfig{
-						Config: configtls.Config{
-							CAFile:   "ca.pem",
-							CertFile: "cert.pem",
-							KeyFile:  "key.pem",
-						},
-					}
-					return config
-				}(),
-				ConsumerConfig: func() configkafka.ConsumerConfig {
-					config := configkafka.NewDefaultConsumerConfig()
-					config.InitialOffset = configkafka.EarliestOffset
-					config.SessionTimeout = 45 * time.Second
-					config.HeartbeatInterval = 15 * time.Second
-					return config
-				}(),
-				Logs: TopicEncodingConfig{
+			name: "kafka/logs",
+			expected: func() *Config {
+				cfg := NewFactory().CreateDefaultConfig().(*Config)
+				cfg.ClientConfig.Brokers = []string{"coffee:123", "foobar:456"}
+				cfg.ClientConfig.Metadata.Retry.Max = 10
+				cfg.ClientConfig.Metadata.Retry.Backoff = 5 * time.Second
+				cfg.ClientConfig.Authentication.SASL = &configkafka.SASLConfig{
+					Mechanism: "PLAIN",
+					Username:  "user",
+					Password:  "password",
+				}
+				cfg.ClientConfig.TLS = &configtls.ClientConfig{
+					Config: configtls.Config{
+						CAFile:   "ca.pem",
+						CertFile: "cert.pem",
+						KeyFile:  "key.pem",
+					},
+				}
+				cfg.ConsumerConfig.InitialOffset = configkafka.EarliestOffset
+				cfg.ConsumerConfig.SessionTimeout = 45 * time.Second
+				cfg.ConsumerConfig.HeartbeatInterval = 15 * time.Second
+				cfg.Logs = TopicEncodingConfig{
 					Topics:   []string{"logs"},
 					Encoding: "direct",
-				},
-				Metrics: TopicEncodingConfig{
-					Topics:   []string{"otlp_metrics"},
-					Encoding: "otlp_proto",
-				},
-				Traces: TopicEncodingConfig{
-					Topics:   []string{"otlp_spans"},
-					Encoding: "otlp_proto",
-				},
-				Profiles: TopicEncodingConfig{
-					Topics:   []string{"otlp_profiles"},
-					Encoding: "otlp_proto",
-				},
-				ErrorBackOff: configretry.BackOffConfig{
+				}
+				cfg.ErrorBackOff = configretry.BackOffConfig{
 					Enabled:         true,
 					InitialInterval: 1 * time.Second,
 					MaxInterval:     10 * time.Second,
 					MaxElapsedTime:  1 * time.Minute,
 					Multiplier:      1.5,
-				},
-			},
+				}
+				return cfg
+			}(),
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "rebalance_strategy"),
-			expected: &Config{
-				ClientConfig: configkafka.NewDefaultClientConfig(),
-				ConsumerConfig: func() configkafka.ConsumerConfig {
-					config := configkafka.NewDefaultConsumerConfig()
-					config.GroupRebalanceStrategy = "sticky"
-					config.GroupInstanceID = "test-instance"
-					return config
-				}(),
-				Logs: TopicEncodingConfig{
-					Topics:   []string{"otlp_logs"},
-					Encoding: "otlp_proto",
-				},
-				Metrics: TopicEncodingConfig{
-					Topics:   []string{"otlp_metrics"},
-					Encoding: "otlp_proto",
-				},
-				Traces: TopicEncodingConfig{
-					Topics:   []string{"otlp_spans"},
-					Encoding: "otlp_proto",
-				},
-				Profiles: TopicEncodingConfig{
-					Topics:   []string{"otlp_profiles"},
-					Encoding: "otlp_proto",
-				},
-				ErrorBackOff: configretry.BackOffConfig{
-					Enabled: false,
-				},
-			},
+			name: "kafka/rebalance_strategy",
+			expected: func() *Config {
+				cfg := NewFactory().CreateDefaultConfig().(*Config)
+				cfg.ConsumerConfig.GroupRebalanceStrategy = configkafka.StickyBalanceStrategy
+				cfg.ConsumerConfig.GroupInstanceID = "test-instance"
+				return cfg
+			}(),
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "rebalance_strategies"),
-			expected: &Config{
-				ClientConfig: configkafka.NewDefaultClientConfig(),
-				ConsumerConfig: func() configkafka.ConsumerConfig {
-					config := configkafka.NewDefaultConsumerConfig()
-					config.GroupRebalanceStrategies = []configkafka.GroupRebalanceStrategy{
-						configkafka.CooperativeStickyBalanceStrategy,
-						"my_balancer",
-					}
-					return config
-				}(),
-				Logs: TopicEncodingConfig{
-					Topics:   []string{"otlp_logs"},
-					Encoding: "otlp_proto",
-				},
-				Metrics: TopicEncodingConfig{
-					Topics:   []string{"otlp_metrics"},
-					Encoding: "otlp_proto",
-				},
-				Traces: TopicEncodingConfig{
-					Topics:   []string{"otlp_spans"},
-					Encoding: "otlp_proto",
-				},
-				Profiles: TopicEncodingConfig{
-					Topics:   []string{"otlp_profiles"},
-					Encoding: "otlp_proto",
-				},
-				ErrorBackOff: configretry.BackOffConfig{
-					Enabled: false,
-				},
-			},
+			name: "kafka/rebalance_strategies",
+			expected: func() *Config {
+				cfg := NewFactory().CreateDefaultConfig().(*Config)
+				cfg.ConsumerConfig.GroupRebalanceStrategies = []configkafka.GroupRebalanceStrategy{
+					configkafka.CooperativeStickyBalanceStrategy,
+					"my_balancer",
+				}
+				return cfg
+			}(),
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "message_marking"),
-			expected: &Config{
-				ClientConfig:   configkafka.NewDefaultClientConfig(),
-				ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
-				Logs: TopicEncodingConfig{
-					Topics:   []string{"otlp_logs"},
-					Encoding: "otlp_proto",
-				},
-				Metrics: TopicEncodingConfig{
-					Topics:   []string{"otlp_metrics"},
-					Encoding: "otlp_proto",
-				},
-				Traces: TopicEncodingConfig{
-					Topics:   []string{"otlp_spans"},
-					Encoding: "otlp_proto",
-				},
-				Profiles: TopicEncodingConfig{
-					Topics:   []string{"otlp_profiles"},
-					Encoding: "otlp_proto",
-				},
-				MessageMarking: MessageMarking{
+			name: "kafka/message_marking",
+			expected: func() *Config {
+				cfg := NewFactory().CreateDefaultConfig().(*Config)
+				cfg.MessageMarking = MessageMarking{
 					After:            true,
 					OnError:          true,
 					OnPermanentError: false,
-				},
-				ErrorBackOff: configretry.BackOffConfig{
-					Enabled: false,
-				},
-			},
+				}
+				return cfg
+			}(),
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "message_marking_not_specified"),
-			expected: &Config{
-				ClientConfig:   configkafka.NewDefaultClientConfig(),
-				ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
-				Logs: TopicEncodingConfig{
-					Topics:   []string{"otlp_logs"},
-					Encoding: "otlp_proto",
-				},
-				Metrics: TopicEncodingConfig{
-					Topics:   []string{"otlp_metrics"},
-					Encoding: "otlp_proto",
-				},
-				Traces: TopicEncodingConfig{
-					Topics:   []string{"otlp_spans"},
-					Encoding: "otlp_proto",
-				},
-				Profiles: TopicEncodingConfig{
-					Topics:   []string{"otlp_profiles"},
-					Encoding: "otlp_proto",
-				},
-				MessageMarking: MessageMarking{
-					After:            false,
-					OnError:          false,
-					OnPermanentError: false,
-				},
-				ErrorBackOff: configretry.BackOffConfig{
-					Enabled: false,
-				},
-			},
+			name:     "kafka/message_marking_not_specified",
+			expected: NewFactory().CreateDefaultConfig().(*Config),
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "message_marking_on_permanent_error_inherited"),
-			expected: &Config{
-				ClientConfig:   configkafka.NewDefaultClientConfig(),
-				ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
-				Logs: TopicEncodingConfig{
-					Topics:   []string{"otlp_logs"},
-					Encoding: "otlp_proto",
-				},
-				Metrics: TopicEncodingConfig{
-					Topics:   []string{"otlp_metrics"},
-					Encoding: "otlp_proto",
-				},
-				Traces: TopicEncodingConfig{
-					Topics:   []string{"otlp_spans"},
-					Encoding: "otlp_proto",
-				},
-				Profiles: TopicEncodingConfig{
-					Topics:   []string{"otlp_profiles"},
-					Encoding: "otlp_proto",
-				},
-				MessageMarking: MessageMarking{
+			name: "kafka/message_marking_on_permanent_error_inherited",
+			expected: func() *Config {
+				cfg := NewFactory().CreateDefaultConfig().(*Config)
+				cfg.MessageMarking = MessageMarking{
 					After:            true,
 					OnError:          true,
 					OnPermanentError: true,
-				},
-				ErrorBackOff: configretry.BackOffConfig{
-					Enabled: false,
-				},
-			},
+				}
+				return cfg
+			}(),
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "regex_topic_with_exclusion"),
-			expected: &Config{
-				ClientConfig:   configkafka.NewDefaultClientConfig(),
-				ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
-				Logs: TopicEncodingConfig{
+			name: "kafka/regex_topic_with_exclusion",
+			expected: func() *Config {
+				cfg := NewFactory().CreateDefaultConfig().(*Config)
+				cfg.Logs = TopicEncodingConfig{
 					Topics:        []string{"^logs-.*"},
 					ExcludeTopics: []string{"^logs-(test|dev)$"},
 					Encoding:      "otlp_proto",
-				},
-				Metrics: TopicEncodingConfig{
+				}
+				cfg.Metrics = TopicEncodingConfig{
 					Topics:        []string{"^metrics-.*"},
 					ExcludeTopics: []string{"^metrics-internal-.*$"},
 					Encoding:      "otlp_proto",
-				},
-				Traces: TopicEncodingConfig{
+				}
+				cfg.Traces = TopicEncodingConfig{
 					Topics:        []string{"^traces-.*"},
 					ExcludeTopics: []string{"^traces-debug-.*$"},
 					Encoding:      "otlp_proto",
-				},
-				Profiles: TopicEncodingConfig{
-					Topics:   []string{"otlp_profiles"},
-					Encoding: "otlp_proto",
-				},
-				ErrorBackOff: configretry.BackOffConfig{
-					Enabled: false,
-				},
-			},
+				}
+				return cfg
+			}(),
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "conn_idle_timeout"),
-			expected: &Config{
-				ClientConfig: func() configkafka.ClientConfig {
-					config := configkafka.NewDefaultClientConfig()
-					config.ConnIdleTimeout = 5 * time.Minute
-					return config
-				}(),
-				ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
-				Logs: TopicEncodingConfig{
-					Topics:   []string{"otlp_logs"},
-					Encoding: "otlp_proto",
-				},
-				Metrics: TopicEncodingConfig{
-					Topics:   []string{"otlp_metrics"},
-					Encoding: "otlp_proto",
-				},
-				Traces: TopicEncodingConfig{
-					Topics:   []string{"otlp_spans"},
-					Encoding: "otlp_proto",
-				},
-				Profiles: TopicEncodingConfig{
-					Topics:   []string{"otlp_profiles"},
-					Encoding: "otlp_proto",
-				},
-				ErrorBackOff: configretry.BackOffConfig{
-					Enabled: false,
-				},
-			},
+			name: "kafka/conn_idle_timeout",
+			expected: func() *Config {
+				cfg := NewFactory().CreateDefaultConfig().(*Config)
+				cfg.ClientConfig.ConnIdleTimeout = 5 * time.Minute
+				return cfg
+			}(),
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.id.String(), func(t *testing.T) {
-			factory := NewFactory()
-			cfg := factory.CreateDefaultConfig()
-
-			sub, err := cm.Sub(tt.id.String())
-			require.NoError(t, err)
-			require.NoError(t, sub.Unmarshal(cfg))
-
-			assert.NoError(t, confmap.Validate(cfg))
-			assert.Equal(t, tt.expected, cfg)
-		})
-	}
-}
-
-func TestConfigValidate(t *testing.T) {
-	tests := []struct {
-		name        string
-		config      *Config
-		expectedErr string
-	}{
 		{
-			name: "valid config with regex and exclude_topic",
-			config: &Config{
-				Logs: TopicEncodingConfig{
+			name: "kafka/valid_exclude_topics_logs",
+			expected: func() *Config {
+				cfg := NewFactory().CreateDefaultConfig().(*Config)
+				cfg.Logs = TopicEncodingConfig{
 					Topics:        []string{"^logs-.*"},
 					ExcludeTopics: []string{"^logs-test$"},
 					Encoding:      "otlp_proto",
-				},
-			},
-			expectedErr: "",
+				}
+				return cfg
+			}(),
 		},
 		{
-			name: "invalid config with non-regex topic and exclude_topic for logs",
-			config: &Config{
-				Logs: TopicEncodingConfig{
-					Topics:        []string{"logs"},
-					ExcludeTopics: []string{"^logs-test$"},
-					Encoding:      "otlp_proto",
-				},
-			},
+			name: "kafka/valid_logs_without_exclude",
+			expected: func() *Config {
+				cfg := NewFactory().CreateDefaultConfig().(*Config)
+				cfg.Logs = TopicEncodingConfig{
+					Topics:   []string{"logs"},
+					Encoding: "otlp_proto",
+				}
+				return cfg
+			}(),
+		},
+		{
+			name:        "kafka/invalid_exclude_topics_logs_non_regex",
 			expectedErr: "logs.exclude_topics is configured but none of the configured logs.topics use regex pattern (must start with '^')",
 		},
 		{
-			name: "invalid config with non-regex topic and exclude_topic for metrics",
-			config: &Config{
-				Metrics: TopicEncodingConfig{
-					Topics:        []string{"metrics"},
-					ExcludeTopics: []string{"^metrics-test$"},
-					Encoding:      "otlp_proto",
-				},
-			},
+			name:        "kafka/invalid_exclude_topics_metrics_non_regex",
 			expectedErr: "metrics.exclude_topics is configured but none of the configured metrics.topics use regex pattern (must start with '^')",
 		},
 		{
-			name: "invalid config with non-regex topic and exclude_topic for traces",
-			config: &Config{
-				Traces: TopicEncodingConfig{
-					Topics:        []string{"traces"},
-					ExcludeTopics: []string{"^traces-test$"},
-					Encoding:      "otlp_proto",
-				},
-			},
+			name:        "kafka/invalid_exclude_topics_traces_non_regex",
 			expectedErr: "traces.exclude_topics is configured but none of the configured traces.topics use regex pattern (must start with '^')",
 		},
 		{
-			name: "invalid config with non-regex topic and exclude_topic for profiles",
-			config: &Config{
-				Profiles: TopicEncodingConfig{
-					Topics:        []string{"profiles"},
-					ExcludeTopics: []string{"^profiles-test$"},
-					Encoding:      "otlp_proto",
-				},
-			},
+			name:        "kafka/invalid_exclude_topics_profiles_non_regex",
 			expectedErr: "profiles.exclude_topics is configured but none of the configured profiles.topics use regex pattern (must start with '^')",
 		},
 		{
-			name: "valid config without exclude_topic",
-			config: &Config{
-				Logs: TopicEncodingConfig{
-					Topics:   []string{"logs"},
-					Encoding: "otlp_proto",
-				},
-			},
-			expectedErr: "",
-		},
-		{
-			name: "invalid config with invalid regex in exclude_topic",
-			config: &Config{
-				Logs: TopicEncodingConfig{
-					Topics:        []string{"^logs-.*"},
-					ExcludeTopics: []string{"^logs-[invalid(regex"},
-					Encoding:      "otlp_proto",
-				},
-			},
+			name:        "kafka/invalid_exclude_topics_regex",
 			expectedErr: "logs.exclude_topic contains invalid regex pattern",
 		},
 		{
-			name: "invalid config with empty string in exclude_topics for logs",
-			config: &Config{
-				Logs: TopicEncodingConfig{
-					Topics:        []string{"^logs-.*"},
-					ExcludeTopics: []string{""},
-					Encoding:      "otlp_proto",
-				},
-			},
+			name:        "kafka/invalid_exclude_topics_logs_empty",
 			expectedErr: "logs.exclude_topics contains empty string",
 		},
 		{
-			name: "invalid config with empty string in exclude_topics for metrics",
-			config: &Config{
-				Metrics: TopicEncodingConfig{
-					Topics:        []string{"^metrics-.*"},
-					ExcludeTopics: []string{"", "^metrics-test$"},
-					Encoding:      "otlp_proto",
-				},
-			},
+			name:        "kafka/invalid_exclude_topics_metrics_empty",
 			expectedErr: "metrics.exclude_topics contains empty string",
 		},
 		{
-			name: "invalid config with empty string in exclude_topics for traces",
-			config: &Config{
-				Traces: TopicEncodingConfig{
-					Topics:        []string{"^traces-.*"},
-					ExcludeTopics: []string{"^traces-test$", ""},
-					Encoding:      "otlp_proto",
-				},
-			},
+			name:        "kafka/invalid_exclude_topics_traces_empty",
 			expectedErr: "traces.exclude_topics contains empty string",
 		},
 		{
-			name: "invalid config with empty string in exclude_topics for profiles",
-			config: &Config{
-				Profiles: TopicEncodingConfig{
-					Topics:        []string{"^profiles-.*"},
-					ExcludeTopics: []string{""},
-					Encoding:      "otlp_proto",
-				},
-			},
+			name:        "kafka/invalid_exclude_topics_profiles_empty",
 			expectedErr: "profiles.exclude_topics contains empty string",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.Validate()
-			if tt.expectedErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.expectedErr)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := loadConfig(t, tc.name)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
 			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, cfg)
 		})
 	}
 }

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -68,53 +68,6 @@ type franzConsumer struct {
 	stoppedOnce  sync.Once
 }
 
-// pc represents the partition consumer shared information.
-type pc struct {
-	logger *zap.Logger
-	attrs  attribute.Set
-
-	ctx    context.Context
-	cancel context.CancelCauseFunc
-	// Not safe for concurrent use, this field is never accessed concurrently.
-	backOff *backoff.ExponentialBackOff
-
-	mu sync.RWMutex // protects the fields below
-	// wg tracks the number of in-flight message processing goroutines for this
-	// partition. The wg must not be used directly; instead, the helper methods
-	// add() and done() should be called to safely mutate it. These methods ensure
-	// that no new goroutines are added once the partition consumer is stopping
-	// (i.e. after the partition is lost / revoked).
-	wg sync.WaitGroup
-}
-
-// add increments the wait group counter if the partition consumer is not
-// stopping. It returns true if the counter was incremented, false otherwise.
-func (p *pc) add(delta int) bool {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	select {
-	case <-p.ctx.Done():
-		return false
-	default:
-	}
-	p.wg.Add(delta)
-	return true
-}
-
-// cancelContext cancels the partition consumer context while holding the write
-// lock.
-func (p *pc) cancelContext(err error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.cancel(err)
-}
-
-// done decrements the wait group counter.
-func (p *pc) done() { p.wg.Done() }
-
-// wait waits for all in-flight goroutines to finish.
-func (p *pc) wait() { p.wg.Wait() }
-
 // newFranzKafkaConsumer creates a new franz-go based Kafka consumer
 func newFranzKafkaConsumer(
 	config *Config,
@@ -317,105 +270,11 @@ func (c *franzConsumer) consume(ctx context.Context, size int) bool {
 			zap.Int64("start_offset", p.Records[0].Offset),
 			zap.Int64("end_offset", p.Records[count-1].Offset),
 		)
-		go func(pc *pc, msgs []*kgo.Record) {
+		go func(pc *pc, partition kgo.FetchTopicPartition) {
 			defer wg.Done()
 			defer pc.done()
-			var fatalRecord *kgo.Record
-			fatalIsPermanent := false
-			var lastProcessed *kgo.Record
-			for _, msg := range msgs {
-				if !c.config.MessageMarking.After {
-					c.client.MarkCommitRecords(msg)
-				}
-				c.telemetryBuilder.KafkaReceiverCurrentOffset.Record(ctx, msg.Offset, metric.WithAttributeSet(pc.attrs))
-				if err := c.handleMessage(pc, msg); err != nil {
-					// Log at DEBUG level for shutdown/rebalance interruptions
-					// (context cancellation), ERROR for real processing failures.
-					if pc.ctx.Err() != nil {
-						pc.logger.Debug("message processing interrupted",
-							zap.Error(err),
-							zap.Int64("offset", msg.Offset),
-						)
-					} else {
-						pc.logger.Error("unable to process message",
-							zap.Error(err),
-							zap.Int64("offset", msg.Offset),
-						)
-					}
-					// Pause consumption for partitions that have fatal errors.
-					// handleMessage only returns an error when After=true and
-					// the message should not be marked, so checking !shouldMark
-					// here is consistent with that contract.
-					isPermanent := consumererror.IsPermanent(err)
-					shouldMark := (!isPermanent && c.config.MessageMarking.OnError) || (isPermanent && c.config.MessageMarking.OnPermanentError)
-
-					if !shouldMark {
-						fatalRecord = msg
-						fatalIsPermanent = isPermanent
-						break // Stop processing messages.
-					}
-				}
-				lastProcessed = msg // Store so we can commit later.
-			}
-			// Handle fatal processing errors. For non-permanent errors
-			// with backoff enabled, rewind the fetch cursor via SetOffsets
-			// so the failed record is retried on the next PollRecords call,
-			// consistent with how a rebalance restarts from the last
-			// committed offset. No pause/resume is needed because
-			// PollRecords is blocked on wg.Wait() until this goroutine
-			// finishes.
-			// Permanent errors and partitions without backoff configured
-			// are paused until a rebalance triggers assigned(), which
-			// calls ResumeFetchPartitions.
-			if fatalRecord != nil {
-				switch {
-				case c.config.ErrorBackOff.Enabled && !fatalIsPermanent:
-					// Skip rewind if the consumer is shutting down or the
-					// partition was lost. In these cases the error is from
-					// context cancellation, not a real processing failure,
-					// and calling SetOffsets could interfere with the final
-					// offset commit.
-					select {
-					case <-pc.ctx.Done():
-					case <-c.closing:
-					default:
-						c.client.SetOffsets(map[string]map[int32]kgo.EpochOffset{
-							p.Topic: {p.Partition: {
-								Epoch:  fatalRecord.LeaderEpoch,
-								Offset: fatalRecord.Offset,
-							}},
-						})
-						pc.logger.Info("rewinding partition to retry failed record on next poll",
-							zap.Int64("offset", fatalRecord.Offset),
-						)
-					}
-				case fatalIsPermanent:
-					tp := map[string][]int32{p.Topic: {p.Partition}}
-					c.client.PauseFetchPartitions(tp)
-					pc.logger.Error("pausing partition due to permanent processing error, partition will remain paused until rebalance",
-						zap.Int64("offset", fatalRecord.Offset),
-					)
-				default:
-					tp := map[string][]int32{p.Topic: {p.Partition}}
-					c.client.PauseFetchPartitions(tp)
-					pc.logger.Error("pausing partition due to processing error (no backoff configured), partition will remain paused until rebalance",
-						zap.Int64("offset", fatalRecord.Offset),
-					)
-				}
-			}
-			if lastProcessed == nil {
-				return // No metrics nor marks to update.
-			}
-			// Otherwise, publish consumer lag.
-			c.telemetryBuilder.KafkaReceiverOffsetLag.Record(
-				context.Background(),
-				(p.HighWatermark-1)-lastProcessed.Offset,
-				metric.WithAttributeSet(pc.attrs),
-			)
-			if c.config.MessageMarking.After {
-				c.client.MarkCommitRecords(lastProcessed)
-			}
-		}(assign, p.Records)
+			c.processPartitionBatch(ctx, pc, partition)
+		}(assign, p)
 	})
 	// Wait for all records to be processed and commit if autocommit=false.
 	wg.Wait()

--- a/receiver/kafkareceiver/partition_worker.go
+++ b/receiver/kafkareceiver/partition_worker.go
@@ -1,0 +1,162 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+)
+
+// pc represents the partition consumer shared information.
+type pc struct {
+	logger *zap.Logger
+	attrs  attribute.Set
+
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	// Not safe for concurrent use, this field is never accessed concurrently.
+	backOff *backoff.ExponentialBackOff
+
+	mu sync.RWMutex // protects the fields below
+	// wg tracks the number of in-flight message processing goroutines for this
+	// partition. The wg must not be used directly; instead, the helper methods
+	// add() and done() should be called to safely mutate it. These methods ensure
+	// that no new goroutines are added once the partition consumer is stopping
+	// (i.e. after the partition is lost / revoked).
+	wg sync.WaitGroup
+}
+
+// add increments the wait group counter if the partition consumer is not
+// stopping. It returns true if the counter was incremented, false otherwise.
+func (p *pc) add(delta int) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	select {
+	case <-p.ctx.Done():
+		return false
+	default:
+	}
+	p.wg.Add(delta)
+	return true
+}
+
+// cancelContext cancels the partition consumer context while holding the write
+// lock.
+func (p *pc) cancelContext(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancel(err)
+}
+
+// done decrements the wait group counter.
+func (p *pc) done() { p.wg.Done() }
+
+// wait waits for all in-flight goroutines to finish.
+func (p *pc) wait() { p.wg.Wait() }
+
+// processPartitionBatch processes one fetched partition batch in offset order.
+func (c *franzConsumer) processPartitionBatch(ctx context.Context, pc *pc, p kgo.FetchTopicPartition) {
+	var fatalRecord *kgo.Record
+	fatalIsPermanent := false
+	var lastProcessed *kgo.Record
+	for _, msg := range p.Records {
+		if !c.config.MessageMarking.After {
+			c.client.MarkCommitRecords(msg)
+		}
+		c.telemetryBuilder.KafkaReceiverCurrentOffset.Record(ctx, msg.Offset, metric.WithAttributeSet(pc.attrs))
+		if err := c.handleMessage(pc, msg); err != nil {
+			// Log at DEBUG level for shutdown/rebalance interruptions
+			// (context cancellation), ERROR for real processing failures.
+			if pc.ctx.Err() != nil {
+				pc.logger.Debug("message processing interrupted",
+					zap.Error(err),
+					zap.Int64("offset", msg.Offset),
+				)
+			} else {
+				pc.logger.Error("unable to process message",
+					zap.Error(err),
+					zap.Int64("offset", msg.Offset),
+				)
+			}
+			// Pause consumption for partitions that have fatal errors.
+			// handleMessage only returns an error when After=true and
+			// the message should not be marked, so checking !shouldMark
+			// here is consistent with that contract.
+			isPermanent := consumererror.IsPermanent(err)
+			shouldMark := (!isPermanent && c.config.MessageMarking.OnError) || (isPermanent && c.config.MessageMarking.OnPermanentError)
+
+			if !shouldMark {
+				fatalRecord = msg
+				fatalIsPermanent = isPermanent
+				break // Stop processing messages.
+			}
+		}
+		lastProcessed = msg // Store so we can commit later.
+	}
+	// Handle fatal processing errors. For non-permanent errors
+	// with backoff enabled, rewind the fetch cursor via SetOffsets
+	// so the failed record is retried on the next PollRecords call,
+	// consistent with how a rebalance restarts from the last
+	// committed offset. No pause/resume is needed because
+	// PollRecords is blocked on wg.Wait() until this goroutine
+	// finishes.
+	// Permanent errors and partitions without backoff configured
+	// are paused until a rebalance triggers assigned(), which
+	// calls ResumeFetchPartitions.
+	if fatalRecord != nil {
+		switch {
+		case c.config.ErrorBackOff.Enabled && !fatalIsPermanent:
+			// Skip rewind if the consumer is shutting down or the
+			// partition was lost. In these cases the error is from
+			// context cancellation, not a real processing failure,
+			// and calling SetOffsets could interfere with the final
+			// offset commit.
+			select {
+			case <-pc.ctx.Done():
+			case <-c.closing:
+			default:
+				c.client.SetOffsets(map[string]map[int32]kgo.EpochOffset{
+					p.Topic: {p.Partition: {
+						Epoch:  fatalRecord.LeaderEpoch,
+						Offset: fatalRecord.Offset,
+					}},
+				})
+				pc.logger.Info("rewinding partition to retry failed record on next poll",
+					zap.Int64("offset", fatalRecord.Offset),
+				)
+			}
+		case fatalIsPermanent:
+			tp := map[string][]int32{p.Topic: {p.Partition}}
+			c.client.PauseFetchPartitions(tp)
+			pc.logger.Error("pausing partition due to permanent processing error, partition will remain paused until rebalance",
+				zap.Int64("offset", fatalRecord.Offset),
+			)
+		default:
+			tp := map[string][]int32{p.Topic: {p.Partition}}
+			c.client.PauseFetchPartitions(tp)
+			pc.logger.Error("pausing partition due to processing error (no backoff configured), partition will remain paused until rebalance",
+				zap.Int64("offset", fatalRecord.Offset),
+			)
+		}
+	}
+	if lastProcessed == nil {
+		return // No metrics nor marks to update.
+	}
+	// Otherwise, publish consumer lag.
+	c.telemetryBuilder.KafkaReceiverOffsetLag.Record(
+		context.Background(),
+		(p.HighWatermark-1)-lastProcessed.Offset,
+		metric.WithAttributeSet(pc.attrs),
+	)
+	if c.config.MessageMarking.After {
+		c.client.MarkCommitRecords(lastProcessed)
+	}
+}

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -89,3 +89,91 @@ kafka/regex_topic_with_exclusion:
 
 kafka/conn_idle_timeout:
   conn_idle_timeout: 5m
+
+kafka/valid_exclude_topics_logs:
+  logs:
+    topics:
+    - "^logs-.*"
+    exclude_topics:
+    - "^logs-test$"
+    encoding: otlp_proto
+
+kafka/valid_logs_without_exclude:
+  logs:
+    topics:
+    - logs
+    encoding: otlp_proto
+
+kafka/invalid_exclude_topics_logs_non_regex:
+  logs:
+    topics:
+    - logs
+    exclude_topics:
+    - "^logs-test$"
+    encoding: otlp_proto
+
+kafka/invalid_exclude_topics_metrics_non_regex:
+  metrics:
+    topics:
+    - metrics
+    exclude_topics:
+    - "^metrics-test$"
+    encoding: otlp_proto
+
+kafka/invalid_exclude_topics_traces_non_regex:
+  traces:
+    topics:
+    - traces
+    exclude_topics:
+    - "^traces-test$"
+    encoding: otlp_proto
+
+kafka/invalid_exclude_topics_profiles_non_regex:
+  profiles:
+    topics:
+    - profiles
+    exclude_topics:
+    - "^profiles-test$"
+    encoding: otlp_proto
+
+kafka/invalid_exclude_topics_regex:
+  logs:
+    topics:
+    - "^logs-.*"
+    exclude_topics:
+    - "^logs-[invalid(regex"
+    encoding: otlp_proto
+
+kafka/invalid_exclude_topics_logs_empty:
+  logs:
+    topics:
+    - "^logs-.*"
+    exclude_topics:
+    - ""
+    encoding: otlp_proto
+
+kafka/invalid_exclude_topics_metrics_empty:
+  metrics:
+    topics:
+    - "^metrics-.*"
+    exclude_topics:
+    - ""
+    - "^metrics-test$"
+    encoding: otlp_proto
+
+kafka/invalid_exclude_topics_traces_empty:
+  traces:
+    topics:
+    - "^traces-.*"
+    exclude_topics:
+    - "^traces-test$"
+    - ""
+    encoding: otlp_proto
+
+kafka/invalid_exclude_topics_profiles_empty:
+  profiles:
+    topics:
+    - "^profiles-.*"
+    exclude_topics:
+    - ""
+    encoding: otlp_proto


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is a prep PR so independent partition processing can be reviewed on its own. I tried to do both in the same PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/50101, but it is too hard to review what's new and what's old.

These changes have no behavior change. We are just moving the code so it can be adapted, and refactoring the config tests.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50030.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tests remain.

<!--Describe the documentation added.-->
#### Documentation

N/A

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
