### PR TITLE
[pkg/datadog] Stop setting removed Agent config key `enable_sketch_stream_payload_serialization`

### DIFF
--- a/.chloggen/remove-deprecated-sketch-payload-serialization.yaml
+++ b/.chloggen/remove-deprecated-sketch-payload-serialization.yaml
@@ -10,7 +10,7 @@ component: pkg/datadog
 note: Stop setting the removed Agent config key `enable_sketch_stream_payload_serialization`, which fixes a spurious `unknown key` ERROR logged at Agent startup. The key was a no-op, so this changes no behavior.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [0]
+issues: [50238]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/remove-deprecated-sketch-payload-serialization.yaml
+++ b/.chloggen/remove-deprecated-sketch-payload-serialization.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Stop setting the removed Agent config key `enable_sketch_stream_payload_serialization`, which fixes a spurious `unknown key` ERROR logged at Agent startup. The key was a no-op, so this changes no behavior.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [0]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -253,7 +253,6 @@ func WithPayloadsConfig() ConfigOption {
 	return func(pkgconfig pkgconfigmodel.Config) {
 		pkgconfig.Set("enable_payloads.events", true, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("enable_payloads.json_to_v1_intake", true, pkgconfigmodel.SourceDefault)
-		pkgconfig.Set("enable_sketch_stream_payload_serialization", true, pkgconfigmodel.SourceDefault)
 	}
 }
 


### PR DESCRIPTION
#### Description

`WithPayloadsConfig` sets the Agent config key `enable_sketch_stream_payload_serialization`, which was deprecated in Datadog Agent 7.44.0 and has since been removed from the Agent config schema. With the Agent's newer `nodetreemodel` config, setting an unknown key logs a spurious error at startup:

```
| OTELCOL | ERROR | (pkg/config/nodetreemodel/config.go:225 in Set) | could not set 'enable_sketch_stream_payload_serialization' unknown key
```

The key has been a no-op since 7.44.0, so this removal changes no behavior — it only stops the misleading `ERROR` line.

#### Testing

`go test ./agentcomponents/` passes; `WithPayloadsConfig` is exercised by existing tests.

#### Documentation

Changelog entry added under `.chloggen/`.