### PR TITLE
[receiver/fluentforwardreceiver] Accept nested map keys encoded as msgpack binary type

### DIFF
--- a/.chloggen/50235-fluentforward-nested-bin-key.yaml
+++ b/.chloggen/50235-fluentforward-nested-bin-key.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/fluent_forward
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Accept nested map keys encoded as msgpack binary type instead of string.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50235]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Fluentd's msgpack-ruby based senders tag ASCII-8BIT encoded strings as
+  msgpack "bin" rather than "str". Top-level record keys already tolerated
+  this, but keys inside nested maps were decoded via msgp.Reader.ReadIntf,
+  which requires "str" and returned an error, causing the whole batch to be
+  dropped. Nested map (and array) values are now decoded with a reader that
+  applies the same string/binary fallback used for top-level keys.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -145,6 +145,79 @@ func timeFromTimestamp(ts any) (time.Time, error) {
 	}
 }
 
+// readMapKey reads a msgpack map key, which is expected to be a string but,
+// as fluentd's msgpack-ruby based senders tag ASCII-8BIT encoded strings as
+// "bin" rather than "str", can also arrive as a binary type.
+func readMapKey(dc *msgp.Reader) (string, error) {
+	key, err := dc.ReadString()
+	if err != nil {
+		keyBytes, keyBytesErr := dc.ReadBytes(nil)
+		if keyBytesErr != nil {
+			return "", keyBytesErr
+		}
+		key = string(keyBytes)
+	}
+	return key, nil
+}
+
+// readIntf behaves like dc.ReadIntf() but tolerates map keys encoded as
+// binary type rather than string (see readMapKey) at any nesting depth,
+// which msgp.Reader.ReadIntf does not. depth guards against unbounded
+// recursion (e.g. a maliciously deeply-nested payload), mirroring the limit
+// dc.ReadIntf() itself enforces via its own unexported recursion counter.
+func readIntf(dc *msgp.Reader, depth int) (any, error) {
+	if depth >= dc.GetMaxRecursionDepth() {
+		return nil, msgp.ErrRecursion
+	}
+
+	t, err := dc.NextType()
+	if err != nil {
+		return nil, err
+	}
+
+	switch t {
+	case msgp.MapType:
+		sz, err := dc.ReadMapHeader()
+		if err != nil {
+			return nil, err
+		}
+		if sz > dc.GetMaxElements() {
+			return nil, msgp.ErrLimitExceeded
+		}
+		m := make(map[string]any, sz)
+		for range sz {
+			key, err := readMapKey(dc)
+			if err != nil {
+				return nil, err
+			}
+			val, err := readIntf(dc, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			m[key] = val
+		}
+		return m, nil
+	case msgp.ArrayType:
+		sz, err := dc.ReadArrayHeader()
+		if err != nil {
+			return nil, err
+		}
+		if sz > dc.GetMaxElements() {
+			return nil, msgp.ErrLimitExceeded
+		}
+		arr := make([]any, sz)
+		for i := range sz {
+			arr[i], err = readIntf(dc, depth+1)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return arr, nil
+	default:
+		return dc.ReadIntf()
+	}
+}
+
 func parseRecordToLogRecord(dc *msgp.Reader, lr plog.LogRecord) error {
 	tsIntf, err := dc.ReadIntf()
 	if err != nil {
@@ -165,17 +238,11 @@ func parseRecordToLogRecord(dc *msgp.Reader, lr plog.LogRecord) error {
 
 	for recordLen > 0 {
 		recordLen--
-		key, err := dc.ReadString()
+		key, err := readMapKey(dc)
 		if err != nil {
-			// The protocol doesn't specify this but apparently some map keys
-			// can be binary type instead of string
-			keyBytes, keyBytesErr := dc.ReadBytes(nil)
-			if keyBytesErr != nil {
-				return msgp.WrapError(keyBytesErr, "Record")
-			}
-			key = string(keyBytes)
+			return msgp.WrapError(err, "Record")
 		}
-		val, err := dc.ReadIntf()
+		val, err := readIntf(dc, 0)
 		if err != nil {
 			return msgp.WrapError(err, "Record", key)
 		}

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -118,6 +118,68 @@ func TestAttributeTypeConversion(t *testing.T) {
 	).ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0), le))
 }
 
+func TestNestedMapWithBinaryKey(t *testing.T) {
+	var b []byte
+
+	b = msgp.AppendArrayHeader(b, 3)
+	b = msgp.AppendString(b, "my-tag")
+	b = msgp.AppendInt(b, 5000)
+	b = msgp.AppendMapHeader(b, 1)
+	b = msgp.AppendString(b, "nested")
+	b = msgp.AppendMapHeader(b, 1)
+	// fluentd/msgpack-ruby tags ASCII-8BIT strings as "bin" instead of "str",
+	// so a nested map key can arrive as a binary type.
+	b = msgp.AppendBytes(b, []byte("host"))
+	b = msgp.AppendString(b, "example.com")
+
+	reader := msgp.NewReader(bytes.NewReader(b))
+
+	var event messageEventLogRecord
+	err := event.DecodeMsg(reader)
+	require.NoError(t, err)
+
+	le := event.LogRecords().At(0)
+
+	require.NoError(t, plogtest.CompareLogRecord(logConstructor(
+		log{
+			Timestamp: 5000000000000,
+			Body:      pcommon.NewValueEmpty(),
+			Attributes: map[string]any{
+				"fluent.tag": "my-tag",
+				"nested": map[string]any{
+					"host": "example.com",
+				},
+			},
+		},
+	).ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0), le))
+}
+
+func TestDeeplyNestedRecordValueIsRejected(t *testing.T) {
+	var b []byte
+
+	b = msgp.AppendArrayHeader(b, 3)
+	b = msgp.AppendString(b, "my-tag")
+	b = msgp.AppendInt(b, 5000)
+	b = msgp.AppendMapHeader(b, 1)
+	b = msgp.AppendString(b, "deep")
+
+	// A payload nested one level deeper than the reader's default recursion
+	// limit must be rejected rather than recursed into, to guard against a
+	// maliciously crafted, deeply-nested payload exhausting the call stack.
+	reader := msgp.NewReader(nil)
+	depth := reader.GetMaxRecursionDepth() + 1
+	for range depth {
+		b = msgp.AppendArrayHeader(b, 1)
+	}
+	b = msgp.AppendInt(b, 1)
+
+	reader = msgp.NewReader(bytes.NewReader(b))
+
+	var event messageEventLogRecord
+	err := event.DecodeMsg(reader)
+	require.ErrorContains(t, err, "recursion")
+}
+
 func TestEventMode(t *testing.T) {
 	require.Equal(t, "unknown", unknownMode.String())
 	require.Equal(t, "message", messageMode.String())


### PR DESCRIPTION
#### Description

Fluentd's msgpack-ruby senders can encode ASCII-8BIT strings as msgpack "bin" instead of "str". `fluentforwardreceiver` already tolerated a bin-typed key at the top level of a record, but nested map keys were still decoded through `msgp.Reader.ReadIntf()`, which hard-requires "str" keys and errors out otherwise. That error propagated up and caused the whole connection (and the in-flight batch) to be dropped.

This PR extends the existing top-level bin/str key fallback to nested map keys too, by replacing the call to the generic `ReadIntf()` with a helper that recurses manually and applies the same fallback at every depth. It re-checks the recursion-depth and element-count limits `ReadIntf()` already enforces, so it shouldn't weaken the existing protection against oversized or maliciously deep payloads on this network-facing receiver.

#### Link to tracking issue
Fixes #50235

#### Testing

`go test ./...`, `go vet ./...`, and `make lint` pass for the package. Added a test with a nested map using a bin-typed key, which fails on the pre-fix code and passes after. Added a second test confirming payloads past the recursion limit are still rejected.

#### Documentation

Added a `.chloggen` entry describing the fix.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

---
AI assistance: this PR was drafted with Claude Code.
