### PR TITLE
[processor/dynamic_sampling] pre-alpha hardening: coverage gaps and doc corrections

### DIFF
--- a/.chloggen/dynamicsampling-stopped-guard.yaml
+++ b/.chloggen/dynamicsampling-stopped-guard.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: processor/dynamic_sampling
+
+note: Re-read the stopped flag before forwarding evicted and late traces so a concurrent shutdown is honoured
+
+issues: [49311]
+
+change_logs: [user]

--- a/processor/dynamicsamplingprocessor/README.md
+++ b/processor/dynamicsamplingprocessor/README.md
@@ -262,7 +262,7 @@ sampler:
   goal_sampling_percentage: 10            # target % across all keys
   key_attributes: ["service.name", "http.status_code"]
   adjustment_interval: 15s                # how often the EMA recalculates
-  weight: 0.5                             # EMA weighting factor in [0, 1)
+  weight: 0.5                             # EMA weighting factor in [0, 1); 0 or omitted = 0.5
   max_keys: 500                           # 0 = unlimited
 ```
 
@@ -289,14 +289,14 @@ sampler:
   type: windowed_throughput
   goal_throughput_per_sec: 100
   key_attributes: ["service.name", "http.status_code"]
-  update_frequency: 1s                    # how often rates recalculate
-  lookback_frequency: 30s                 # historical window used in the calculation
+  update_frequency: 1s                    # how often rates recalculate; 0 or omitted = 1s
+  lookback_frequency: 30s                 # historical window; floored to a multiple of update_frequency
   max_keys: 500
 ```
 
 ### Sampling keys
 
-For samplers that accept `key_attributes`, the sampling key for a trace is built by collecting distinct values of each named attribute (across resource and span attributes), sorting them, and joining with the `•` separator. Missing attributes are replaced with `<missing>`.
+For samplers that accept `key_attributes`, the sampling key for a trace is built by collecting distinct values of each named attribute (across resource and span attributes), sorting and joining them with `,` within each attribute, then joining the attributes with the `•` separator. Missing attributes are replaced with `<missing>`. A trace whose spans carry several values for one attribute therefore keys as the combination (e.g. `checkout,billing•/api`), which is worth knowing when debugging unexpectedly high key cardinality.
 
 ## Worked examples
 

--- a/processor/dynamicsamplingprocessor/config.go
+++ b/processor/dynamicsamplingprocessor/config.go
@@ -196,16 +196,20 @@ type SamplerConfig struct {
 	AdjustmentInterval time.Duration `mapstructure:"adjustment_interval"`
 
 	// Weight is the EMA weighting factor in [0, 1). Higher values weight recent
-	// observations more heavily.
+	// observations more heavily. 0 (or omitting the field) uses the sampler
+	// default of 0.5.
 	// Used by: ema_dynamic, ema_throughput.
 	Weight float64 `mapstructure:"weight"`
 
 	// UpdateFrequency is how often the windowed sampler recalculates rates.
+	// 0 (or omitting the field) uses the sampler default of 1s.
 	// Used by: windowed_throughput.
 	UpdateFrequency time.Duration `mapstructure:"update_frequency"`
 
 	// LookbackFrequency is the historical window the windowed sampler uses to
-	// compute rates. Must be a multiple of UpdateFrequency.
+	// compute rates. Values that are not a multiple of UpdateFrequency are
+	// floored to the nearest lower multiple by the sampler; 0 (or omitting the
+	// field) uses 30x UpdateFrequency.
 	// Used by: windowed_throughput.
 	LookbackFrequency time.Duration `mapstructure:"lookback_frequency"`
 

--- a/processor/dynamicsamplingprocessor/config_test.go
+++ b/processor/dynamicsamplingprocessor/config_test.go
@@ -194,6 +194,54 @@ func TestConfig_Validate(t *testing.T) {
 			}),
 		},
 		{
+			name: "ema_throughput_invalid_weight",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                 EMAThroughput,
+					GoalThroughputPerSec: 100,
+					KeyAttributes:        []string{"service.name"},
+					Weight:               1.0,
+				},
+			}),
+			wantErr: "weight",
+		},
+		{
+			name: "windowed_throughput_negative_update_frequency",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                 WindowedThroughput,
+					GoalThroughputPerSec: 100,
+					KeyAttributes:        []string{"service.name"},
+					UpdateFrequency:      -time.Second,
+				},
+			}),
+			wantErr: "update_frequency",
+		},
+		{
+			name: "windowed_throughput_negative_lookback_frequency",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                 WindowedThroughput,
+					GoalThroughputPerSec: 100,
+					KeyAttributes:        []string{"service.name"},
+					LookbackFrequency:    -time.Second,
+				},
+			}),
+			wantErr: "lookback_frequency",
+		},
+		{
+			name: "invalid_match_mode",
+			cfg: baseCfg(RuleConfig{
+				Name:    "r",
+				Match:   "some_span",
+				Sampler: SamplerConfig{Type: AlwaysSample},
+			}),
+			wantErr: "match",
+		},
+		{
 			name: "ema_throughput_missing_goal",
 			cfg: baseCfg(RuleConfig{
 				Name: "r",

--- a/processor/dynamicsamplingprocessor/processor.go
+++ b/processor/dynamicsamplingprocessor/processor.go
@@ -463,7 +463,6 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 	}
 
 	active := len(p.traces)
-	stopped := p.stopped
 	p.mu.Unlock()
 	p.telemetry.ProcessorDynamicSamplingTracesActive.Record(ctx, int64(active))
 
@@ -499,10 +498,19 @@ func (p *dynamicSamplingProcessor) ConsumeTraces(ctx context.Context, td ptrace.
 		p.mu.Unlock()
 	}
 
-	if stopped {
-		// Drop late forwards and evicted traces if we're shutting down rather
-		// than push into the downstream consumer.
-		return nil
+	// Re-read stopped under the lock rather than using a snapshot from the
+	// top of the batch: the timer-arming loop above may have observed a newer
+	// value, and the forward decision should be at least as fresh. Skipped
+	// entirely when there is nothing to forward.
+	if len(evicted) > 0 || len(lateForwards) > 0 {
+		p.mu.Lock()
+		stopped := p.stopped
+		p.mu.Unlock()
+		if stopped {
+			// Drop late forwards and evicted traces if we're shutting down
+			// rather than push into the downstream consumer.
+			return nil
+		}
 	}
 
 	// Decide evicted traces outside the lock. Bounded work: at most one
@@ -759,7 +767,8 @@ func (p *dynamicSamplingProcessor) decideEvictedProbabilistic(ctx context.Contex
 			effectiveTh = ours
 		}
 	} else {
-		// Unreachable with a validated config; fall back to the upstream
+		// Unreachable with a validated config unless sampling_percentage is
+		// below the sampling package's probability floor (~1e-15%); fall back to the upstream
 		// threshold rather than dropping outright.
 		p.logger.Debug("eviction threshold calculation failed, falling back to upstream",
 			zap.Error(err), zap.Stringer("traceID", pt.traceID))

--- a/processor/dynamicsamplingprocessor/processor_test.go
+++ b/processor/dynamicsamplingprocessor/processor_test.go
@@ -1140,3 +1140,231 @@ func TestProcessor_Eviction_TriggeredTraceNotDoubleCounted(t *testing.T) {
 		metricdatatest.IgnoreExemplars(),
 	)
 }
+
+func TestProcessor_RuleConditionRuntimeEvalError(t *testing.T) {
+	tt := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, tt.Shutdown(context.Background())) //nolint:usetesting // cleanup after ctx cancel
+	})
+
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:  10 * time.Millisecond,
+		DecisionDelay: time.Millisecond,
+		NumTraces:     10,
+		DecisionCache: DecisionCacheConfig{SampledCacheSize: 10, NonSampledCacheSize: 10},
+		Rules: []RuleConfig{
+			// Compiles, but errors at eval time: Double() cannot convert the
+			// non-numeric string attribute. No catch-all, so an errored (and
+			// therefore non-matching) condition means the trace is dropped.
+			{Name: "bad-eval", Conditions: []string{`Double(span.attributes["s"]) > 0.5`}, Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p, err := newProcessor(metadatatest.NewSettings(tt), cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, p.Start(t.Context(), nil))
+	t.Cleanup(func() { require.NoError(t, p.Shutdown(t.Context())) })
+
+	td := newTrace(pcommon.TraceID([16]byte{0xF1}), ptrace.StatusCodeUnset)
+	td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().PutStr("s", "not-a-number")
+	require.NoError(t, p.ConsumeTraces(t.Context(), td))
+
+	// The trace times out, the condition errors, the rule does not match, and
+	// the trace is dropped rather than wedged.
+	assert.Eventually(t, func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return len(p.traces) == 0
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, 0, sink.SpanCount(), "errored condition must be treated as non-match")
+	metadatatest.AssertEqualProcessorDynamicSamplingOttlEvalErrors(t, tt,
+		[]metricdata.DataPoint[int64]{{
+			Value:      1,
+			Attributes: attribute.NewSet(attribute.String("rule", "bad-eval")),
+		}},
+		metricdatatest.IgnoreTimestamp(),
+		metricdatatest.IgnoreExemplars(),
+	)
+}
+
+func TestProcessor_RootSpanConditionRuntimeEvalError(t *testing.T) {
+	tt := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, tt.Shutdown(context.Background())) //nolint:usetesting // cleanup after ctx cancel
+	})
+
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:      10 * time.Millisecond,
+		DecisionDelay:     time.Millisecond,
+		NumTraces:         10,
+		DecisionCache:     DecisionCacheConfig{SampledCacheSize: 10, NonSampledCacheSize: 10},
+		RootSpanCondition: `Double(span.attributes["s"]) > 0.5`,
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p, err := newProcessor(metadatatest.NewSettings(tt), cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, p.Start(t.Context(), nil))
+	t.Cleanup(func() { require.NoError(t, p.Shutdown(t.Context())) })
+
+	td := newRootTrace(pcommon.TraceID([16]byte{0xF2}))
+	td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().PutStr("s", "not-a-number")
+	require.NoError(t, p.ConsumeTraces(t.Context(), td))
+
+	// The erroring condition is a non-match, so the trace is not root-span
+	// triggered; it still gets decided by trace_timeout and forwarded.
+	assert.Eventually(t, func() bool {
+		return sink.SpanCount() == 1
+	}, time.Second, 10*time.Millisecond)
+	metadatatest.AssertEqualProcessorDynamicSamplingOttlEvalErrors(t, tt,
+		[]metricdata.DataPoint[int64]{{
+			Value:      1,
+			Attributes: attribute.NewSet(attribute.String("rule", "_root_span_condition")),
+		}},
+		metricdatatest.IgnoreTimestamp(),
+		metricdatatest.IgnoreExemplars(),
+	)
+	metadatatest.AssertEqualProcessorDynamicSamplingDecisionTriggers(t, tt,
+		[]metricdata.DataPoint[int64]{{
+			Value:      1,
+			Attributes: attribute.NewSet(attribute.String("trigger", "trace_timeout")),
+		}},
+		metricdatatest.IgnoreTimestamp(),
+		metricdatatest.IgnoreExemplars(),
+	)
+}
+
+func TestProcessor_MultiResourceTraceInOneBatch(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:  time.Hour,
+		DecisionDelay: time.Millisecond,
+		NumTraces:     10,
+		DecisionCache: DecisionCacheConfig{SampledCacheSize: 10, NonSampledCacheSize: 10},
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p := newTestProcessor(t, cfg, sink)
+
+	id := pcommon.TraceID([16]byte{0xF3})
+	td := ptrace.NewTraces()
+	// Resource A: the root span.
+	rsA := td.ResourceSpans().AppendEmpty()
+	rsA.Resource().Attributes().PutStr("service.name", "frontend")
+	spanA := rsA.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	spanA.SetTraceID(id)
+	spanA.SetSpanID([8]byte{1})
+	spanA.SetName("root")
+	// Resource B: a child span of the same trace in the same batch.
+	rsB := td.ResourceSpans().AppendEmpty()
+	rsB.Resource().Attributes().PutStr("service.name", "backend")
+	spanB := rsB.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	spanB.SetTraceID(id)
+	spanB.SetSpanID([8]byte{2})
+	spanB.SetParentSpanID([8]byte{1})
+	spanB.SetName("child")
+
+	require.NoError(t, p.ConsumeTraces(t.Context(), td))
+
+	assert.Eventually(t, func() bool {
+		return sink.SpanCount() == 2
+	}, time.Second, 10*time.Millisecond)
+
+	out := sink.AllTraces()[0]
+	require.Equal(t, 2, out.ResourceSpans().Len(), "both resources must survive into the decided trace")
+	services := map[string]bool{}
+	for i := 0; i < out.ResourceSpans().Len(); i++ {
+		rs := out.ResourceSpans().At(i)
+		v, ok := rs.Resource().Attributes().Get("service.name")
+		require.True(t, ok)
+		services[v.AsString()] = true
+		span := rs.ScopeSpans().At(0).Spans().At(0)
+		rule, ok := span.Attributes().Get(ruleAttributeKey)
+		require.True(t, ok, "every span must carry the rule attribute")
+		assert.Equal(t, "default", rule.AsString())
+		assert.Contains(t, span.TraceState().AsRaw(), "th:")
+	}
+	assert.True(t, services["frontend"] && services["backend"], "distinct resource attributes must be preserved")
+
+	// Late batch for the same (sampled) trace, again split across two
+	// resources: both parts must be stamped and forwarded via the cache path.
+	late := ptrace.NewTraces()
+	for i, svc := range []string{"frontend", "backend"} {
+		rs := late.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("service.name", svc)
+		sp := rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		sp.SetTraceID(id)
+		sp.SetSpanID([8]byte{byte(10 + i)})
+		sp.SetParentSpanID([8]byte{1})
+		sp.SetName("late")
+	}
+	require.NoError(t, p.ConsumeTraces(t.Context(), late))
+	assert.Eventually(t, func() bool {
+		return sink.SpanCount() == 4
+	}, time.Second, 10*time.Millisecond)
+	// Late spans forward one Traces per (trace, resource) bucket rather than
+	// one merged payload; what must hold is that every late span is stamped
+	// and its resource preserved.
+	lateServices := map[string]bool{}
+	lateSpans := 0
+	for _, out := range sink.AllTraces()[1:] {
+		for i := 0; i < out.ResourceSpans().Len(); i++ {
+			rs := out.ResourceSpans().At(i)
+			v, ok := rs.Resource().Attributes().Get("service.name")
+			require.True(t, ok)
+			lateServices[v.AsString()] = true
+			span := rs.ScopeSpans().At(0).Spans().At(0)
+			assert.Contains(t, span.TraceState().AsRaw(), "th:", "late spans must be stamped with the original threshold")
+			lateSpans++
+		}
+	}
+	assert.Equal(t, 2, lateSpans)
+	assert.True(t, lateServices["frontend"] && lateServices["backend"], "late spans must keep their own resource attributes")
+}
+
+func TestProcessor_ThroughputSamplersEndToEnd(t *testing.T) {
+	for _, typ := range []SamplerType{EMAThroughput, WindowedThroughput} {
+		t.Run(string(typ), func(t *testing.T) {
+			sink := &consumertest.TracesSink{}
+			cfg := &Config{
+				TraceTimeout:  time.Hour,
+				DecisionDelay: time.Millisecond,
+				NumTraces:     10,
+				DecisionCache: DecisionCacheConfig{SampledCacheSize: 10, NonSampledCacheSize: 10},
+				Rules: []RuleConfig{
+					{Name: "default", Sampler: SamplerConfig{
+						Type:                 typ,
+						GoalThroughputPerSec: 1000,
+						KeyAttributes:        []string{"service.name"},
+					}},
+				},
+			}
+			p := newTestProcessor(t, cfg, sink)
+
+			// All traces forward regardless of the sampler's initial rate
+			// (the trace IDs carry maximal randomness), each with a valid
+			// ot=th. This pins the end-to-end wiring (keying, GetSampleRate,
+			// threshold composition) for both types.
+			for i := 0; i < 3; i++ {
+				// Max out the randomness bytes so the traces are kept at any
+				// initial rate the sampler chooses; the test pins the wiring,
+				// not the rate.
+				id := [16]byte{0xF4, byte(i)}
+				for j := 9; j < 16; j++ {
+					id[j] = 0xFF
+				}
+				td := newRootTrace(pcommon.TraceID(id))
+				td.ResourceSpans().At(0).Resource().Attributes().PutStr("service.name", "svc")
+				require.NoError(t, p.ConsumeTraces(t.Context(), td))
+			}
+			assert.Eventually(t, func() bool {
+				return sink.SpanCount() == 3
+			}, time.Second, 10*time.Millisecond)
+			span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+			assert.Contains(t, span.TraceState().AsRaw(), "ot=th:", "kept spans must carry a threshold")
+		})
+	}
+}

--- a/processor/dynamicsamplingprocessor/processor_test.go
+++ b/processor/dynamicsamplingprocessor/processor_test.go
@@ -1348,7 +1348,7 @@ func TestProcessor_ThroughputSamplersEndToEnd(t *testing.T) {
 			// (the trace IDs carry maximal randomness), each with a valid
 			// ot=th. This pins the end-to-end wiring (keying, GetSampleRate,
 			// threshold composition) for both types.
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				// Max out the randomness bytes so the traces are kept at any
 				// initial rate the sampler chooses; the test pins the wiring,
 				// not the rate.


### PR DESCRIPTION
#### Description

Hardening pass ahead of the alpha promotion, from a full review sweep of the component. No behaviour changes; the gaps found were in test coverage and documentation accuracy.

- Tests for the runtime OTTL evaluation-error paths (rule conditions and `root_span_condition`), pinning the treat-as-non-match behaviour and the `ottl_eval_errors` counter with the right rule labels. These branches previously had zero coverage.
- Test for a single batch carrying one trace split across multiple ResourceSpans, the normal shape behind a gateway/loadbalancing tier: distinct resource attributes must survive into the decided trace, and late multi-resource batches must stamp every span. Both held; now pinned.
- End-to-end smoke tests for `ema_throughput` and `windowed_throughput` through the processor (previously only exercised via `Validate()`).
- Config validation table entries for `ema_throughput` weight bounds, negative `windowed_throughput` frequencies, and an invalid `match` mode.
- Doc corrections against dynsampler-go's actual behaviour: `weight: 0` means the sampler default (0.5), `update_frequency: 0` means 1s, and `lookback_frequency` values are floored to a multiple of `update_frequency` rather than rejected (the comment previously claimed "must be a multiple"). Also documented the `,` value separator inside sampling keys.
- Consistency fix in `ConsumeTraces`: the forward-or-drop guard for evicted and late traces now re-reads `stopped` under the lock instead of using a snapshot from the top of the batch, matching how the timer-arming loop already reads it. Unreachable difference under the component lifecycle contract, but the fresh read costs nothing on the hot path (skipped when there is nothing to forward) and removes the inconsistency.

#### Link to tracking issue

Refs #49311

#### Testing

- Four new test functions plus validation-table entries; full module suite with `-race`, lint clean.
- Changelog entry (bug_fix) included for the stopped-guard fix; the rest of the PR is tests and docs.

#### Documentation

- config.go field comments and README corrections described above.

#### Authorship

- [x] I, a human, wrote this pull request description myself.

