### PR TITLE
[exporter/loadbalancing] Avoid duplicate span delivery on partial export retry

### DIFF
--- a/.chloggen/44191-loadbalancing-partial-retry-duplication.yaml
+++ b/.chloggen/44191-loadbalancing-partial-retry-duplication.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/loadbalancing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix duplicate trace delivery when the exporter-level `retry_on_failure`/`sending_queue` ("resiliency option 1") retries a batch after only some backends failed. Previously the whole original batch was retried, re-sending data to backends that had already received it; now only the data that actually failed to export is retried.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44191]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -141,11 +142,7 @@ func (e *traceExporterImp) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 		}
 	}
 
-	var errs error
-	for exp, td := range exporterSegregatedTraces {
-		errs = multierr.Append(errs, e.exportToBackend(ctx, exp, td))
-	}
-	return errs
+	return e.exportBatches(ctx, exporterSegregatedTraces)
 }
 
 // consumeTracesByID routes each span to the backend for its trace ID, accumulating spans
@@ -216,11 +213,36 @@ func (e *traceExporterImp) consumeTracesByID(ctx context.Context, td ptrace.Trac
 		}
 	}
 
-	var errs error
+	batches := make(exporterTraces, len(dests))
 	for exp, d := range dests {
-		errs = multierr.Append(errs, e.exportToBackend(ctx, exp, d.traces))
+		batches[exp] = d.traces
 	}
-	return errs
+	return e.exportBatches(ctx, batches)
+}
+
+// exportBatches sends each backend's batch and, if any fail, returns a consumererror.Traces
+// wrapping only the batches that actually failed. This ensures a retry (via the exporter's own
+// retry_on_failure/sending_queue settings) resends just the failed data instead of the whole
+// original request - re-sending everything would duplicate data at backends that already
+// received their batch successfully.
+func (e *traceExporterImp) exportBatches(ctx context.Context, batches exporterTraces) error {
+	var errs error
+	var failed ptrace.Traces
+	hasFailed := false
+	for exp, td := range batches {
+		if err := e.exportToBackend(ctx, exp, td); err != nil {
+			errs = multierr.Append(errs, err)
+			if !hasFailed {
+				failed = ptrace.NewTraces()
+				hasFailed = true
+			}
+			failed = mergeTraces(failed, td)
+		}
+	}
+	if errs != nil {
+		return consumererror.NewTraces(errs, failed)
+	}
+	return nil
 }
 
 // exportToBackend sends td to one backend, records per-backend telemetry, and signals the

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -275,6 +276,103 @@ func TestConsumeTracesByID_MultipleTraceIDs(t *testing.T) {
 		{3}: 1,
 		{4}: 1,
 	}, spansPerTID)
+}
+
+// TestConsumeTracesByID_PartialFailureOnlyRetriesFailedBackend verifies that when one backend
+// out of several fails, the returned error carries only the batch destined for the failed
+// backend (via consumererror.Traces), not the whole original request. Without this, a caller
+// that retries on error (e.g. the exporter's own retry_on_failure/sending_queue settings) would
+// resend the entire original request, duplicating data at backends that already succeeded.
+func TestConsumeTracesByID_PartialFailureOnlyRetriesFailedBackend(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	endpoints := []string{"good-endpoint", "bad-endpoint"}
+	failWant := errors.New("backend unavailable")
+
+	var goodCalls, badCalls int
+	received := ptrace.NewTraces()
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		te := &mockTracesExporter{Component: mockComponent{}}
+		te.ConsumeTracesFn = func(_ context.Context, td ptrace.Traces) error {
+			if endpoint == endpointWithPort("bad-endpoint") {
+				badCalls++
+				return failWant
+			}
+			goodCalls++
+			td.ResourceSpans().MoveAndAppendTo(received.ResourceSpans())
+			return nil
+		}
+		return te, nil
+	}
+
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			Static: configoptional.Some(StaticResolver{Hostnames: endpoints}),
+		},
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+
+	p, err := newTracesExporter(ts, cfg)
+	require.NoError(t, err)
+	require.Equal(t, traceIDRouting, p.routingKey)
+	p.loadBalancer = lb
+
+	lb.addMissingExporters(t.Context(), endpoints)
+	lb.res = &mockResolver{
+		triggerCallbacks: true,
+		onResolve: func(context.Context) ([]string, error) {
+			return endpoints, nil
+		},
+	}
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	// Find one trace ID that hashes to each endpoint so the batch is split across both backends.
+	var goodTID, badTID pcommon.TraceID
+	for i := byte(0); ; i++ {
+		tid := pcommon.TraceID{i}
+		switch endpointWithPort(lb.ring.endpointFor(tid[:])) {
+		case endpointWithPort("good-endpoint"):
+			goodTID = tid
+		case endpointWithPort("bad-endpoint"):
+			badTID = tid
+		}
+		if goodTID != (pcommon.TraceID{}) && badTID != (pcommon.TraceID{}) {
+			break
+		}
+	}
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Spans().AppendEmpty().SetTraceID(goodTID)
+	ss.Spans().AppendEmpty().SetTraceID(badTID)
+
+	err = p.ConsumeTraces(t.Context(), td)
+	require.Error(t, err)
+
+	var partial consumererror.Traces
+	require.ErrorAs(t, err, &partial, "error must carry only the failed batch")
+	assert.ErrorIs(t, err, failWant)
+
+	failed := partial.Data()
+	var failedTIDs []pcommon.TraceID
+	rss := failed.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		spans := rss.At(i).ScopeSpans().At(0).Spans()
+		for j := 0; j < spans.Len(); j++ {
+			failedTIDs = append(failedTIDs, spans.At(j).TraceID())
+		}
+	}
+	assert.Equal(t, []pcommon.TraceID{badTID}, failedTIDs, "only the failed backend's batch should be retried")
+
+	assert.Equal(t, 1, goodCalls)
+	assert.Equal(t, 1, badCalls)
+	assert.Equal(t, 1, received.SpanCount(), "the good backend's already-delivered span must not be retried")
 }
 
 // This test validates that exporter is can concurrently change the endpoints while consuming traces.


### PR DESCRIPTION
#### Description

Fixes duplicate span delivery to already-successfully-delivered backends when the loadbalancing exporter's own `retry_on_failure`/`sending_queue` settings ("resiliency option 1") retry a batch that only partially failed to export. Previously, a partial failure (some backends succeeded, one or more failed) caused the WHOLE original batch to be retried, including the sub-batches already delivered to healthy backends, because the returned error was a plain combined error instead of a `consumererror.Traces` carrying only the failed subset. This matches the mechanism described in the linked issue, where a cluster reschedule event produced a massive duplicate-span explosion on some backends.

Note: this PR scopes the fix to traces only (matching the "Spans" duplication reported in the issue). `exporter/loadbalancingexporter/log_exporter.go` and `metrics_exporter.go` have the identical bare-multierr pattern in `ConsumeLogs`/`ConsumeMetrics` and are susceptible to the same duplicate-delivery bug for logs/metrics routing when resiliency option 1 is enabled for those signals. Happy to follow up with the same fix for those signals if maintainers want it in this PR or a separate one.

#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44191

#### Testing

Added `exporter/loadbalancingexporter/trace_exporter_test.go: TestConsumeTracesByID_PartialFailureOnlyRetriesFailedBackend`, which sends one batch containing spans destined for two different backends, one healthy and one failing, and asserts the error returned by `ConsumeTraces` (via `errors.As` into `consumererror.Traces`) carries only the failed backend's spans, and that the healthy backend received its span exactly once (not duplicated).

Confirmed the test fails without the code change (verified via `git stash` of just `trace_exporter.go`) and passes with it — a genuine red-to-green regression test for the reported duplication mechanism.

Ran in `exporter/loadbalancingexporter`:
- `go build ./...` — succeeds
- `go test ./... -race` — all packages pass
- `golangci-lint run ./...` — clean
- `gofmt -l .` — no files need formatting

This validates the fix at the unit level against the exact mechanism reported in the issue (partial-batch retry duplicating already-delivered data). It was not exercised against a live Kubernetes cluster reschedule event.

#### Documentation

No documentation changes. The exporter's existing resilience documentation (README.md, "Resilience and scaling considerations") already describes resiliency option 1 as re-routing/retrying data on failure; this change only ensures that retry no longer duplicates data that was already delivered successfully.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

---
AI assistance: this change was drafted with Claude Code.

Fixes #44191