### PR TITLE
[receiver/awsfirehosereceiver] Bound per-request gzip decompression to prevent DoS

### DIFF
--- a/.chloggen/awsfirehosereceiver-decompression-limit.yaml
+++ b/.chloggen/awsfirehosereceiver-decompression-limit.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awsfirehose
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bound per-request gzip decompression to `max_request_body_size` to prevent unbounded memory growth from a decompression bomb in a Firehose record.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49230]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The same `max_request_body_size` value (default 20 MiB) now also bounds the total decompressed
+  size of gzip-encoded records in a request. Deployments sending highly-compressible Firehose
+  payloads may need to raise this value if they start seeing 413 responses.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awsfirehosereceiver/logs_receiver.go
+++ b/receiver/awsfirehosereceiver/logs_receiver.go
@@ -91,6 +91,12 @@ func (c *logsConsumer) Consume(ctx context.Context, nextRecord nextRecordFunc, c
 		if errors.Is(err, io.EOF) {
 			break
 		}
+		if err != nil {
+			if errors.Is(err, errDecompressedRecordTooLarge) {
+				return http.StatusRequestEntityTooLarge, err
+			}
+			return http.StatusBadRequest, err
+		}
 		logs, err := c.unmarshaler.UnmarshalLogs(record)
 		if err != nil {
 			return http.StatusBadRequest, err

--- a/receiver/awsfirehosereceiver/logs_receiver_test.go
+++ b/receiver/awsfirehosereceiver/logs_receiver_test.go
@@ -155,6 +155,26 @@ func TestLogsConsumer_Errors(t *testing.T) {
 	}
 }
 
+func TestLogsConsumer_NextRecordError(t *testing.T) {
+	lc := &logsConsumer{
+		unmarshaler: unmarshalertest.NewNopLogs(),
+		consumer:    consumertest.NewNop(),
+	}
+	t.Run("WithDecompressionLimitExceeded", func(t *testing.T) {
+		nextRecord := func() ([]byte, error) { return nil, errDecompressedRecordTooLarge }
+		gotStatus, gotErr := lc.Consume(t.Context(), nextRecord, nil)
+		require.Equal(t, http.StatusRequestEntityTooLarge, gotStatus)
+		require.ErrorIs(t, gotErr, errDecompressedRecordTooLarge)
+	})
+	t.Run("WithOtherError", func(t *testing.T) {
+		testErr := errors.New("test error")
+		nextRecord := func() ([]byte, error) { return nil, testErr }
+		gotStatus, gotErr := lc.Consume(t.Context(), nextRecord, nil)
+		require.Equal(t, http.StatusBadRequest, gotStatus)
+		require.Equal(t, testErr, gotErr)
+	})
+}
+
 func TestLogsConsumer(t *testing.T) {
 	t.Run("WithCommonAttributes", func(t *testing.T) {
 		base := plog.NewLogs()

--- a/receiver/awsfirehosereceiver/metrics_receiver.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver.go
@@ -126,6 +126,12 @@ func (c *metricsConsumer) Consume(ctx context.Context, nextRecord nextRecordFunc
 		if errors.Is(err, io.EOF) {
 			break
 		}
+		if err != nil {
+			if errors.Is(err, errDecompressedRecordTooLarge) {
+				return http.StatusRequestEntityTooLarge, err
+			}
+			return http.StatusBadRequest, err
+		}
 		metrics, err := c.unmarshaler.UnmarshalMetrics(record)
 		if err != nil {
 			return http.StatusBadRequest, err

--- a/receiver/awsfirehosereceiver/metrics_receiver_test.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver_test.go
@@ -166,6 +166,26 @@ func TestMetricsConsumer_Errors(t *testing.T) {
 	}
 }
 
+func TestMetricsConsumer_NextRecordError(t *testing.T) {
+	mc := &metricsConsumer{
+		unmarshaler: unmarshalertest.NewNopMetrics(),
+		consumer:    consumertest.NewNop(),
+	}
+	t.Run("WithDecompressionLimitExceeded", func(t *testing.T) {
+		nextRecord := func() ([]byte, error) { return nil, errDecompressedRecordTooLarge }
+		gotStatus, gotErr := mc.Consume(t.Context(), nextRecord, nil)
+		require.Equal(t, http.StatusRequestEntityTooLarge, gotStatus)
+		require.ErrorIs(t, gotErr, errDecompressedRecordTooLarge)
+	})
+	t.Run("WithOtherError", func(t *testing.T) {
+		testErr := errors.New("test error")
+		nextRecord := func() ([]byte, error) { return nil, testErr }
+		gotStatus, gotErr := mc.Consume(t.Context(), nextRecord, nil)
+		require.Equal(t, http.StatusBadRequest, gotStatus)
+		require.Equal(t, testErr, gotErr)
+	})
+}
+
 func TestMetricsConsumer(t *testing.T) {
 	t.Run("WithCommonAttributes", func(t *testing.T) {
 		base := pmetric.NewMetrics()

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -34,11 +34,16 @@ const (
 )
 
 var (
-	errInvalidAccessKey         = errors.New("invalid firehose access key")
-	errInHeaderMissingRequestID = errors.New("missing request id in header")
-	errInBodyMissingRequestID   = errors.New("missing request id in body")
-	errInBodyDiffRequestID      = errors.New("different request id in body")
+	errInvalidAccessKey           = errors.New("invalid firehose access key")
+	errInHeaderMissingRequestID   = errors.New("missing request id in header")
+	errInBodyMissingRequestID     = errors.New("missing request id in body")
+	errInBodyDiffRequestID        = errors.New("different request id in body")
+	errDecompressedRecordTooLarge = errors.New("decompressed record size exceeds the configured limit")
 )
+
+// defaultMaxRequestBodySize mirrors confighttp's own default, and is used as the
+// upper bound on cumulative decompressed record size when MaxRequestBodySize is unset.
+const defaultMaxRequestBodySize = 20 * 1024 * 1024 // 20 MiB
 
 // The firehoseConsumer is responsible for using the unmarshaler and the consumer.
 type firehoseConsumer interface {
@@ -202,6 +207,12 @@ func (fmr *firehoseReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
+	decompressionLimit := fmr.config.ServerConfig.MaxRequestBodySize
+	if decompressionLimit <= 0 {
+		decompressionLimit = defaultMaxRequestBodySize
+	}
+	var decompressedSize int64
+
 	var recordIndex int
 	var recordBuf []byte
 	nextRecord := func() ([]byte, error) {
@@ -217,7 +228,7 @@ func (fmr *firehoseReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return nil, fmt.Errorf("unable to base64 decode the record at index %d: %w", recordIndex-1, decodeErr)
 		}
 
-		recordBuf, decodeErr = gunzipRecordIfNeeded(recordBuf)
+		recordBuf, decodeErr = gunzipRecordIfNeeded(recordBuf, decompressionLimit, &decompressedSize)
 		if decodeErr != nil {
 			return nil, fmt.Errorf("unable to decompress the record at index %d: %w", recordIndex-1, decodeErr)
 		}
@@ -282,7 +293,11 @@ func (fmr *firehoseReceiver) sendResponse(w http.ResponseWriter, requestID strin
 	}
 }
 
-func gunzipRecordIfNeeded(record []byte) ([]byte, error) {
+// gunzipRecordIfNeeded decompresses record if it is gzip-encoded, bounding the
+// decompressed size to protect against decompression bomb attacks. limit is the
+// maximum number of decompressed bytes allowed across all records in the request,
+// and decompressedSize accumulates the total decompressed so far.
+func gunzipRecordIfNeeded(record []byte, limit int64, decompressedSize *int64) ([]byte, error) {
 	if len(record) < 2 || record[0] != 0x1f || record[1] != 0x8b {
 		return record, nil
 	}
@@ -293,10 +308,15 @@ func gunzipRecordIfNeeded(record []byte) ([]byte, error) {
 	}
 	defer reader.Close()
 
-	decompressed, err := io.ReadAll(reader)
+	remaining := max(limit-*decompressedSize, 0)
+	decompressed, err := io.ReadAll(io.LimitReader(reader, remaining+1))
 	if err != nil {
 		return nil, err
 	}
+	if int64(len(decompressed)) > remaining {
+		return nil, errDecompressedRecordTooLarge
+	}
+	*decompressedSize += int64(len(decompressed))
 
 	return decompressed, nil
 }

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -134,6 +134,7 @@ func TestFirehoseRequest(t *testing.T) {
 	}
 	var noRecords []firehoseRecord
 	testCases := map[string]struct {
+		config           *Config
 		headers          map[string]string
 		commonAttributes map[string]string
 		body             any
@@ -224,6 +225,25 @@ func TestFirehoseRequest(t *testing.T) {
 			}),
 			wantStatusCode: http.StatusOK,
 		},
+		"WithGzipRecordExceedingDecompressionLimit": {
+			config: &Config{
+				AccessKey: testFirehoseAccessKey,
+				ServerConfig: confighttp.ServerConfig{
+					MaxRequestBodySize: 4,
+				},
+			},
+			body: testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{
+				testFirehoseRecordFromBytes(newGzipRecord(t, []byte("this decompresses to more than four bytes"))),
+			}),
+			consumer: firehoseConsumerFunc(func(_ context.Context, next nextRecordFunc, _ map[string]string) (int, error) {
+				if _, err := next(); err != nil {
+					return http.StatusRequestEntityTooLarge, err
+				}
+				return http.StatusOK, nil
+			}),
+			wantStatusCode: http.StatusRequestEntityTooLarge,
+			wantErr:        fmt.Errorf("unable to decompress the record at index 0: %w", errDecompressedRecordTooLarge),
+		},
 		"WithValidRecords": {
 			body: testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{
 				testFirehoseRecord("test"),
@@ -263,7 +283,11 @@ func TestFirehoseRequest(t *testing.T) {
 			if consumer == nil {
 				consumer = defaultConsumer
 			}
-			r := testFirehoseReceiver(cfg, consumer)
+			config := testCase.config
+			if config == nil {
+				config = cfg
+			}
+			r := testFirehoseReceiver(config, consumer)
 
 			got := httptest.NewRecorder()
 			r.ServeHTTP(got, request)
@@ -296,6 +320,41 @@ func TestFirehoseRequestInvalidJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(got.Body.Bytes(), &gotResponse))
 	require.Equal(t, testFirehoseRequestID, gotResponse.RequestID)
 	require.Regexp(t, gotResponse.ErrorMessage, `awsfirehosereceiver\.firehoseRequest\.ReadStringAsSlice: expects .*`)
+}
+
+func TestGunzipRecordIfNeeded(t *testing.T) {
+	t.Run("NonGzipPassesThroughUnbounded", func(t *testing.T) {
+		var decompressedSize int64
+		got, err := gunzipRecordIfNeeded([]byte("plain text"), 1, &decompressedSize)
+		require.NoError(t, err)
+		require.Equal(t, []byte("plain text"), got)
+		require.Zero(t, decompressedSize)
+	})
+
+	t.Run("GzipWithinLimit", func(t *testing.T) {
+		var decompressedSize int64
+		got, err := gunzipRecordIfNeeded(newGzipRecord(t, []byte("hello")), 5, &decompressedSize)
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello"), got)
+		require.EqualValues(t, 5, decompressedSize)
+	})
+
+	t.Run("GzipExceedingLimit", func(t *testing.T) {
+		var decompressedSize int64
+		_, err := gunzipRecordIfNeeded(newGzipRecord(t, []byte("hello")), 4, &decompressedSize)
+		require.ErrorIs(t, err, errDecompressedRecordTooLarge)
+	})
+
+	t.Run("GzipExceedingCumulativeLimit", func(t *testing.T) {
+		var decompressedSize int64
+		got, err := gunzipRecordIfNeeded(newGzipRecord(t, []byte("hello")), 8, &decompressedSize)
+		require.NoError(t, err)
+		require.Equal(t, []byte("hello"), got)
+		require.EqualValues(t, 5, decompressedSize)
+
+		_, err = gunzipRecordIfNeeded(newGzipRecord(t, []byte("world")), 8, &decompressedSize)
+		require.ErrorIs(t, err, errDecompressedRecordTooLarge)
+	})
 }
 
 // testFirehoseReceiver is a convenience function for creating a test firehoseReceiver


### PR DESCRIPTION
#### Description

`receiver/awsfirehosereceiver` base64-decodes each Firehose record and, when the decoded bytes
have a gzip magic header, inflates the record entirely into memory with
`io.ReadAll(gzip.NewReader(...))`. There is no cap on the per-record decompressed size and no cap
on the cumulative decompressed size across records in a single request, so a small request body
(well under the 20 MiB compressed-body cap inherited from `confighttp`) can be crafted to inflate
to gigabytes of resident memory, either via a single highly compressed record or by packing many
smaller gzip records into one request. When the receiver has no `access_key` configured, this path
is reachable by an unauthenticated remote client.

This bounds decompression using the existing `confighttp.ServerConfig.MaxRequestBodySize` field
(default 20 MiB) rather than introducing new configuration. `gunzipRecordIfNeeded` now decompresses
through an `io.LimitReader` capped by the remaining per-request budget and rejects the record if the
decompressed size would exceed it, tracking a running total across all records in the request so
that many small compressed records cannot collectively bypass the limit. Records that exceed the
limit are mapped to HTTP 413 in `logsConsumer.Consume` and `metricsConsumer.Consume`, which also
required explicitly checking `nextRecord()`'s error there -- previously that error was silently
discarded and unmarshaling proceeded on a stale/nil buffer, producing a misleading error instead of
the real one.

Note: this does change behavior for legitimate traffic -- a highly compressible payload that
decompresses past `MaxRequestBodySize`, which previously succeeded, will now be rejected with 413.
Deployments sending such payloads may need to raise `max_request_body_size`.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49230

#### Testing

`go build ./...` and `go vet ./...` are clean in `receiver/awsfirehosereceiver`. `go test ./...`
passes, including new tests: `TestGunzipRecordIfNeeded` (unit tests for the per-record and
cumulative decompression caps), a new `WithGzipRecordExceedingDecompressionLimit` case in
`TestFirehoseRequest` (end-to-end 413 mapping), and `TestLogsConsumer_NextRecordError` /
`TestMetricsConsumer_NextRecordError` (verifying the new 413/400 error mapping from `nextRecord()`).
`golangci-lint run ./...` and `make chlog-validate` also pass.

To confirm the new tests actually exercise the fix rather than being vacuously true, I stashed only
the three modified non-test source files (`receiver.go`, `logs_receiver.go`, `metrics_receiver.go`)
and reran `go vet`: it failed with `undefined: errDecompressedRecordTooLarge` against the new test
files, i.e. the tests do not even compile without the fix. Restoring the source changes made the
build and all tests pass again.

I did not reproduce the full multi-GiB memory-growth proof of concept from the report; the fix is a
boundable cap whose enforcement is demonstrated with small, deterministic byte limits (e.g. a
4-byte and an 8-byte cumulative budget) in the tests above, which is sufficient to prove the cap
triggers correctly.

#### Documentation

N/A -- no user-facing configuration was added. The existing `max_request_body_size` option
(inherited from the squashed `confighttp.ServerConfig`) now also bounds cumulative decompressed
record size; this is called out in the changelog entry's subtext.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

---
AI assistance: this change was drafted with Claude Code.

Fixes #49230