### PR TITLE
[processor/attributes] fix resource attribute filtering for metrics

### DIFF
--- a/.chloggen/fix-50248-metrics-resource-filter.yaml
+++ b/.chloggen/fix-50248-metrics-resource-filter.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/attributes
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix `resources` in include/exclude being silently ignored when filtering metrics
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50248]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  A metrics-pipeline include/exclude filter configured with only `resources` passed
+  validation but built no matcher, so every metric was processed. When combined with
+  `metric_names`, only the metric name was evaluated and `resources` was dropped.
+  Resource attributes are now matched for metrics, consistent with spans and logs.
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/filter/filtermetric/filtermetric.go
+++ b/internal/filter/filtermetric/filtermetric.go
@@ -57,7 +57,7 @@ func newExpr(mp *filterconfig.MetricMatchProperties) (expr.BoolExpr[*ottlmetric.
 		}
 		return newExprMatcher(mp.Expressions)
 	}
-	if len(mp.MetricNames) == 0 {
+	if len(mp.MetricNames) == 0 && len(mp.ResourceAttributes) == 0 {
 		return nil, nil
 	}
 	return newNameMatcher(mp)

--- a/internal/filter/filtermetric/filtermetric_test.go
+++ b/internal/filter/filtermetric/filtermetric_test.go
@@ -155,6 +155,64 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 			},
 		},
 
+		// Resource attributes
+		{
+			name: "static resource attribute include, match",
+			include: &filterconfig.MetricMatchProperties{
+				MatchType: filterconfig.MetricStrict,
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "svcA"},
+				},
+			},
+		},
+		{
+			name: "static resource attribute include, mismatch",
+			include: &filterconfig.MetricMatchProperties{
+				MatchType: filterconfig.MetricStrict,
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "svcB"},
+				},
+			},
+		},
+		{
+			name: "regex resource attribute include",
+			include: &filterconfig.MetricMatchProperties{
+				MatchType: filterconfig.MetricRegexp,
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "svc.*"},
+				},
+			},
+		},
+		{
+			name: "static resource attribute exclude",
+			exclude: &filterconfig.MetricMatchProperties{
+				MatchType: filterconfig.MetricStrict,
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "svcA"},
+				},
+			},
+		},
+		{
+			name: "metric name and resource attribute include",
+			include: &filterconfig.MetricMatchProperties{
+				MatchType:   filterconfig.MetricStrict,
+				MetricNames: []string{"metricA"},
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "svcA"},
+				},
+			},
+		},
+		{
+			name: "metric name matches but resource attribute does not",
+			include: &filterconfig.MetricMatchProperties{
+				MatchType:   filterconfig.MetricStrict,
+				MetricNames: []string{"metricA"},
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "svcB"},
+				},
+			},
+		},
+
 		// Expression
 		{
 			name: "expression errors",
@@ -184,7 +242,12 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 			metric := pmetric.NewMetric()
 			metric.SetName("metricA")
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			rm := pmetric.NewResourceMetrics()
+			require.NoError(t, rm.Resource().Attributes().FromRaw(map[string]any{
+				"service.name": "svcA",
+			}))
+
+			tCtx := ottlmetric.NewTransformContextPtr(rm, pmetric.NewScopeMetrics(), metric)
 			defer tCtx.Close()
 
 			boolExpr, err := NewSkipExpr(tt.include, tt.exclude)
@@ -203,6 +266,85 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 
 				assert.Equal(t, expectedResult, ottlResult)
 			}
+		})
+	}
+}
+
+func TestMatcherMatchesResourceAttributes(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           *filterconfig.MetricMatchProperties
+		resourceAttrs map[string]any
+		metricName    string
+		shouldMatch   bool
+	}{
+		{
+			name: "resource attributes only, match",
+			cfg: &filterconfig.MetricMatchProperties{
+				MatchType: filterconfig.MetricStrict,
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "my-service"},
+				},
+			},
+			resourceAttrs: map[string]any{"service.name": "my-service"},
+			metricName:    "test.gauge",
+			shouldMatch:   true,
+		},
+		{
+			name: "resource attributes only, mismatch",
+			cfg: &filterconfig.MetricMatchProperties{
+				MatchType: filterconfig.MetricStrict,
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "my-service"},
+				},
+			},
+			resourceAttrs: map[string]any{"service.name": "other-service"},
+			metricName:    "test.gauge",
+			shouldMatch:   false,
+		},
+		{
+			name: "metric name matches but resource does not",
+			cfg: &filterconfig.MetricMatchProperties{
+				MatchType:   filterconfig.MetricStrict,
+				MetricNames: []string{"test.gauge"},
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "my-service"},
+				},
+			},
+			resourceAttrs: map[string]any{"service.name": "other-service"},
+			metricName:    "test.gauge",
+			shouldMatch:   false,
+		},
+		{
+			name: "resource matches but metric name does not",
+			cfg: &filterconfig.MetricMatchProperties{
+				MatchType:   filterconfig.MetricStrict,
+				MetricNames: []string{"test.gauge"},
+				ResourceAttributes: []filterconfig.Attribute{
+					{Key: "service.name", Value: "my-service"},
+				},
+			},
+			resourceAttrs: map[string]any{"service.name": "my-service"},
+			metricName:    "other.gauge",
+			shouldMatch:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matcher, err := newExpr(test.cfg)
+			require.NoError(t, err)
+			require.NotNil(t, matcher)
+
+			rm := pmetric.NewResourceMetrics()
+			require.NoError(t, rm.Resource().Attributes().FromRaw(test.resourceAttrs))
+
+			tCtx := ottlmetric.NewTransformContextPtr(rm, pmetric.NewScopeMetrics(), createMetric(test.metricName))
+			matches, err := matcher.Eval(t.Context(), tCtx)
+			tCtx.Close()
+
+			require.NoError(t, err)
+			assert.Equal(t, test.shouldMatch, matches)
 		})
 	}
 }

--- a/internal/filter/filtermetric/name_matcher.go
+++ b/internal/filter/filtermetric/name_matcher.go
@@ -5,33 +5,55 @@ package filtermetric // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterconfig"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filtermatcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 )
 
 // nameMatcher matches metrics by metric properties against prespecified values for each property.
 type nameMatcher struct {
-	nameFilters filterset.FilterSet
+	nameFilters     filterset.FilterSet
+	resourceFilters filtermatcher.AttributesMatcher
 }
 
 func newNameMatcher(mp *filterconfig.MetricMatchProperties) (*nameMatcher, error) {
-	nameFS, err := filterset.CreateFilterSet(
-		mp.MetricNames,
-		&filterset.Config{
-			MatchType:    filterset.MatchType(mp.MatchType),
-			RegexpConfig: mp.RegexpConfig,
-		},
-	)
-	if err != nil {
-		return nil, err
+	fsCfg := filterset.Config{
+		MatchType:    filterset.MatchType(mp.MatchType),
+		RegexpConfig: mp.RegexpConfig,
 	}
-	return &nameMatcher{nameFilters: nameFS}, nil
+
+	m := &nameMatcher{}
+
+	if len(mp.MetricNames) > 0 {
+		nameFS, err := filterset.CreateFilterSet(mp.MetricNames, &fsCfg)
+		if err != nil {
+			return nil, err
+		}
+		m.nameFilters = nameFS
+	}
+
+	if len(mp.ResourceAttributes) > 0 {
+		rm, err := filtermatcher.NewAttributesMatcher(fsCfg, mp.ResourceAttributes)
+		if err != nil {
+			return nil, fmt.Errorf("error creating resource filters: %w", err)
+		}
+		m.resourceFilters = rm
+	}
+
+	return m, nil
 }
 
 // Eval matches a metric using the metric properties configured on the nameMatcher.
 // A metric only matches if every metric property configured on the nameMatcher is a match.
 func (m *nameMatcher) Eval(_ context.Context, tCtx *ottlmetric.TransformContext) (bool, error) {
-	return m.nameFilters.Matches(tCtx.GetMetric().Name()), nil
+	if m.nameFilters != nil && !m.nameFilters.Matches(tCtx.GetMetric().Name()) {
+		return false, nil
+	}
+	if m.resourceFilters != nil && !m.resourceFilters.Match(tCtx.GetResource().Attributes()) {
+		return false, nil
+	}
+	return true, nil
 }

--- a/internal/filter/filterottl/bridge.go
+++ b/internal/filter/filterottl/bridge.go
@@ -385,21 +385,38 @@ func createMetricStatement(mp filterconfig.MetricMatchProperties) (*string, erro
 		return nil, errors.New("expressions configuration cannot be converted to OTTL - see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor#configuration for OTTL configuration")
 	}
 
-	if len(mp.MetricNames) == 0 {
+	if len(mp.MetricNames) == 0 && len(mp.ResourceAttributes) == 0 {
 		return nil, nil
 	}
 
-	metricNameStatement := nameStaticStatement
-	if mp.MatchType == filterconfig.MetricRegexp {
-		metricNameStatement = nameRegexStatement
+	var conditions []string
+
+	if len(mp.MetricNames) > 0 {
+		metricNameStatement := nameStaticStatement
+		if mp.MatchType == filterconfig.MetricRegexp {
+			metricNameStatement = nameRegexStatement
+		}
+		metricNameConditions := createBasicConditions(metricNameStatement, mp.MetricNames)
+		format := "%v"
+		if len(metricNameConditions) > 1 {
+			format = "(%v)"
+		}
+		conditions = append(conditions, fmt.Sprintf(format, strings.Join(metricNameConditions, " or ")))
 	}
-	metricNameConditions := createBasicConditions(metricNameStatement, mp.MetricNames)
-	var format string
-	if len(metricNameConditions) > 1 {
-		format = "(%v)"
-	} else {
-		format = "%v"
+
+	if len(mp.ResourceAttributes) > 0 {
+		resourceAttrStatement := resourceAttributesStaticStatement
+		if mp.MatchType == filterconfig.MetricRegexp {
+			resourceAttrStatement = resourceAttributesRegexStatement
+		}
+		resourceConditions := createAttributeConditions(
+			resourceAttrStatement,
+			mp.ResourceAttributes,
+			filterset.MatchType(mp.MatchType),
+		)
+		conditions = append(conditions, strings.Join(resourceConditions, " and "))
 	}
-	statement := fmt.Sprintf(format, strings.Join(metricNameConditions, " or "))
+
+	statement := strings.Join(conditions, " and ")
 	return &statement, nil
 }

--- a/processor/attributesprocessor/attributes_metric_test.go
+++ b/processor/attributesprocessor/attributes_metric_test.go
@@ -162,7 +162,6 @@ func TestAttributes_FilterMetrics(t *testing.T) {
 }
 
 func TestAttributes_FilterMetricsByNameStrict(t *testing.T) {
-	//t.Skip("Will be fixed by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17017")
 	testCases := []metricTestCase{
 		{
 			name:            "apply",
@@ -226,7 +225,6 @@ func TestAttributes_FilterMetricsByNameStrict(t *testing.T) {
 }
 
 func TestAttributes_FilterMetricsByNameRegexp(t *testing.T) {
-	//t.Skip("Will be fixed by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17017")
 	testCases := []metricTestCase{
 		{
 			name:            "apply_to_metric_with_no_attrs",

--- a/processor/attributesprocessor/attributes_metric_test.go
+++ b/processor/attributesprocessor/attributes_metric_test.go
@@ -162,7 +162,7 @@ func TestAttributes_FilterMetrics(t *testing.T) {
 }
 
 func TestAttributes_FilterMetricsByNameStrict(t *testing.T) {
-	t.Skip("Will be fixed by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17017")
+	//t.Skip("Will be fixed by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17017")
 	testCases := []metricTestCase{
 		{
 			name:            "apply",
@@ -226,7 +226,7 @@ func TestAttributes_FilterMetricsByNameStrict(t *testing.T) {
 }
 
 func TestAttributes_FilterMetricsByNameRegexp(t *testing.T) {
-	t.Skip("Will be fixed by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17017")
+	//t.Skip("Will be fixed by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17017")
 	testCases := []metricTestCase{
 		{
 			name:            "apply_to_metric_with_no_attrs",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes resource-attribute filtering for metrics in the attributes processor.

Currently, the `resources` field is accepted but ignored:

- When only `resources` was configured, no matcher was created, so every metric was processed.
- When both `metric_names` and `resources` were configured, only the metric name was evaluated.

This change:

- Creates an `AttributesMatcher` when resource attributes are configured.
- Evaluates both the metric name and resource attributes when both are present.
- Updates the OTTL bridge to generate equivalent resource-attribute conditions.

Metric-name and resource-attribute filters use AND condition when both are configured. This is consistent with `AttributesMatcher`, which requires all configured attribute entries to match, and with the span and log bridge behavior, which joins resource conditions using `and`.

The OTTL bridge implements the same filtering logic Test_NewSkipExpr_With_Bridge asserts both paths return the same result, so the bridge needed the same change.

The filter processor also calls `filtermetric.NewSkipExpr`, but it already evaluates resource attributes separately through `newSkipResExpr`. With this change, the filter processor evaluates the resource condition in both places and produces the same result. The existing filter processor tests continue to pass. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50248

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests covering:

- Resource-only matching and non-matching cases in the direct matcher.
- Combined `metric_names` and `resources` filters.
- Cases where only the metric name or only the resource attributes match.
- Bridge consistency for strict and regexp resource matching.
- Bridge consistency for the resource-attribute exclude path.
- Enabled two previously disabled test cases `TestAttributes_FilterMetricsByNameStrict` and `TestAttributes_FilterMetricsByNameRegexp`

Existing attributes processor and filter processor tests pass. 


<!--Describe the documentation added.-->
#### Documentation
Added a user-facing changelog entry describing the corrected metric resource-attribute filtering behavior.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
