### PR TITLE
[exporter/otelarrow] Retry stream reconnect failures after Arrow support is proven

### DIFF
--- a/.chloggen/50254-otelarrow-reconnect-after-transient-connect-error.yaml
+++ b/.chloggen/50254-otelarrow-reconnect-after-transient-connect-error.yaml
@@ -1,0 +1,36 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/otelarrow
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Retry a stream whose reconnect attempt fails after it has already proven the endpoint supports Arrow, instead of abandoning its work state.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50254]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, once any stream had connected successfully, a later transient failure to
+  re-establish that stream (e.g. an auth handshake timeout) was treated the same as an
+  endpoint that does not support Arrow: unless `disable_downgrade` was set, the stream's work
+  state was left orphaned instead of being restarted. The orphaned state stayed registered
+  with the prioritizer and could still be selected, permanently consuming one of the
+  `num_streams` worker goroutines and blocking export until the collector was restarted. Such
+  reconnect failures are now always retried once a stream's work state has proven the endpoint
+  supports Arrow; only a work state that has never connected is treated as an unsupported-endpoint
+  signal.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/otelarrowexporter/internal/arrow/exporter.go
+++ b/exporter/otelarrowexporter/internal/arrow/exporter.go
@@ -214,9 +214,11 @@ func (e *Exporter) startArrowStream(ctx context.Context, ws *streamWorkState) {
 }
 
 // runStreamController starts the initial set of streams, then waits for streams to
-// terminate one at a time and restarts them.  If streams come back with a nil
-// client (meaning that OTel-Arrow was not supported by the endpoint), it will
-// not be restarted.
+// terminate one at a time and restarts them.  If a stream comes back with a nil
+// client and its work state has never previously connected (meaning that
+// OTel-Arrow was not supported by the endpoint), it will not be restarted.
+// Once a work state has proven the endpoint supports Arrow, later connection
+// failures for it are treated as transient and always restarted.
 func (e *Exporter) runStreamController(exportCtx, downCtx context.Context, downDc doneCancel) {
 	defer e.cancel()
 	defer e.wg.Done()
@@ -226,13 +228,18 @@ func (e *Exporter) runStreamController(exportCtx, downCtx context.Context, downD
 	for {
 		select {
 		case stream := <-e.returning:
-			if stream.client != nil || e.disableDowngrade {
-				// The stream closed or broken.  Restart it.
+			if stream.client != nil || e.disableDowngrade || stream.workState.everConnected.Load() {
+				// The stream closed or broken, or this work
+				// state previously proved that the endpoint
+				// supports Arrow, so this failure is known to
+				// be transient.  Restart it.
 				e.startArrowStream(downCtx, stream.workState)
 				continue
 			}
-			// Otherwise, the stream never got started.  It was
-			// downgraded and senders will use the standard OTLP path.
+			// Otherwise, the stream never got started and this
+			// endpoint's support for Arrow has not been
+			// established.  It was downgraded and senders will
+			// use the standard OTLP path.
 			running--
 
 			// None of the streams were able to connect to

--- a/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -327,6 +327,47 @@ func TestArrowExporterStreamConnectError(t *testing.T) {
 	}
 }
 
+// TestArrowExporterReconnectAfterTransientConnectError tests that once a
+// stream's work state has successfully connected, a later transient
+// connect error (e.g., an auth handshake timeout) is retried rather than
+// treated as a downgrade signal and the work state abandoned.
+func TestArrowExporterReconnectAfterTransientConnectError(t *testing.T) {
+	for _, pname := range AllPrioritizers {
+		t.Run(string(pname), func(t *testing.T) {
+			tc := newSingleStreamTestCase(t, pname)
+			initial := newUnresponsiveTestChannel()
+			connErr := newConnectErrorTestChannel()
+			healthy := newHealthyTestChannel()
+
+			tc.traceCall.AnyTimes().DoAndReturn(tc.returnNewStream(initial, connErr, healthy))
+
+			var wg sync.WaitGroup
+			wg.Go(func() {
+				outputData := <-healthy.sendChannel()
+				healthy.recv <- statusOKFor(outputData.BatchId)
+			})
+
+			bg := t.Context()
+			require.NoError(t, tc.exporter.Start(bg))
+
+			// Close the first stream once it has connected (proving the
+			// endpoint supports Arrow), forcing a reconnect that hits a
+			// transient connect error.  A work state that had never
+			// connected would be abandoned on that error (see
+			// TestArrowExporterStreamConnectError); this one already
+			// proved Arrow support and must be retried instead.
+			initial.unblock()
+
+			sent, err := tc.exporter.SendAndWait(bg, twoTraces)
+			require.True(t, sent, "exporter should recover from the transient connect error instead of downgrading")
+			require.NoError(t, err)
+
+			wg.Wait()
+			require.NoError(t, tc.exporter.Shutdown(bg))
+		})
+	}
+}
+
 // TestArrowExporterDowngrade tests that if the Recv() returns an
 // Unimplemented code (as gRPC does) that the connection is downgraded
 // without error.

--- a/exporter/otelarrowexporter/internal/arrow/stream.go
+++ b/exporter/otelarrowexporter/internal/arrow/stream.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	arrowpb "github.com/open-telemetry/otel-arrow/go/api/experimental/arrow/v1"
@@ -80,6 +81,14 @@ type streamWorkState struct {
 
 	// waiters is the response channel for each active batch.
 	waiters map[int64]chan<- error
+
+	// everConnected is set once a stream using this work state has
+	// successfully connected and was not rejected as unsupported
+	// (i.e., it proved the endpoint accepts Arrow streams).  Once
+	// set, later connection failures for this work state are known
+	// to be transient and are always retried instead of being
+	// counted toward a downgrade decision.
+	everConnected atomic.Bool
 }
 
 // writeItem is passed from the sender (a pipeline consumer) to the
@@ -223,6 +232,13 @@ func (s *Stream) run(ctx context.Context, dc doneCancel, streamClient StreamClie
 	}
 	if writeErr != nil {
 		s.logStreamError("writer", writeErr)
+	}
+
+	if s.client != nil {
+		// Reaching here with a non-nil client means the stream
+		// connected and was not rejected as Unimplemented, proving
+		// the endpoint supports Arrow streams.
+		s.workState.everConnected.Store(true)
 	}
 
 	s.workState.lock.Lock()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When a stream's reconnect attempt fails (`client == nil`, logged as `cannot start arrow stream`) and
`disable_downgrade` is `false` (the default), `runStreamController` used to treat that failure the
same as "this endpoint does not support Arrow": unless every other stream had also failed, the
stream's `streamWorkState` was abandoned instead of restarted, while remaining registered with the
prioritizer. Because the prioritizer keeps selecting the idle/orphaned work state as "least
loaded", each dispatch to it permanently consumes one of the `num_streams` prioritizer worker
goroutines with nothing ever draining it. If enough streams hit a transient reconnect failure
(e.g. an auth handshake timeout) this way, the exporter can wedge permanently and never recover
without restarting the collector.

This adds an `everConnected` flag to `streamWorkState`, set once a stream using that work state has
connected and was not rejected as unsupported (i.e., it proved the endpoint accepts Arrow
streams). Once set, later connection failures for that work state are known to be transient and
are always retried instead of being counted toward the downgrade decision. A work state that has
never connected is still treated as evidence the endpoint may not support Arrow, preserving the
existing full-failure downgrade behavior.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50254

#### Testing

Added `TestArrowExporterReconnectAfterTransientConnectError` in
`exporter/otelarrowexporter/internal/arrow/exporter_test.go`: a single-stream exporter first
connects successfully, is closed to force a reconnect, hits a transient connect error on the
second attempt, and is expected to recover (not downgrade) on the third. Verified this test fails
on the pre-fix code (`sent` is false, logs show "could not establish arrow streams, downgrading to
standard OTLP export") and passes after the fix, including with `-race -count=10`.

Commands run and their results:
- `go build ./exporter/otelarrowexporter/...` — passes
- `go test ./exporter/otelarrowexporter/... -race -timeout 180s` — all tests pass, including
  `TestArrowExporterStreamConnectError`, `TestArrowExporterDowngrade`, and
  `TestArrowExporterDisableDowngrade`, which cover the pre-existing full-failure downgrade
  semantics and are unaffected by this change.
- `golangci-lint run ./exporter/otelarrowexporter/...` — no findings.
- `make chlog-validate` — passes.

This was validated with the package's existing unit test harness (mocked gRPC streams), not a live
cluster or the collector binary; no other validation was available or required for a change of this
size.

#### Documentation

No user-facing configuration or behavior contract changed; only the exporter's internal
stream-recovery behavior in a previously-buggy case. No documentation updates needed.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->

---
AI assistance: this change was drafted with Claude Code.

Fixes #50254