### PR TITLE
[chore] [internal/core] Use math/rand/v2.ChaCha8 in goldendataset trace generator

### DIFF
--- a/internal/coreinternal/goldendataset/traces_generator.go
+++ b/internal/coreinternal/goldendataset/traces_generator.go
@@ -4,7 +4,6 @@
 package goldendataset // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/goldendataset"
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -36,7 +35,8 @@ func GenerateTraces(tracePairsFile, spanPairsFile string) ([]ptrace.Traces, erro
 	if metadata.InternalCoreinternalGoldendatasetDontEmitV0MessagingConventionsFeatureGate.IsEnabled() && !metadata.InternalCoreinternalGoldendatasetEmitV1MessagingConventionsFeatureGate.IsEnabled() {
 		return nil, errors.New("internal.coreinternal.goldendataset.DontEmitV0MessagingConventions cannot be enabled without enabling internal.coreinternal.goldendataset.EmitV1MessagingConventions")
 	}
-	random := (*randReader)(rand.New(rand.NewPCG(42, 0)))
+	// Use a fixed seed so that the generated IDs are reproducible across runs.
+	random := rand.NewChaCha8([32]byte{42})
 	pairsData, err := loadPictOutputFile(tracePairsFile)
 	if err != nil {
 		return nil, err
@@ -59,23 +59,6 @@ func GenerateTraces(tracePairsFile, spanPairsFile string) ([]ptrace.Traces, erro
 		}
 	}
 	return traces, err
-}
-
-// TODO: use math/rand/v2.ChaCha8.Read when we upgrade to go1.23.
-type randReader rand.Rand
-
-func (r *randReader) Read(p []byte) (n int, err error) {
-	for len(p) >= 8 {
-		binary.BigEndian.PutUint64(p[:8], (*rand.Rand)(r).Uint64())
-		p = p[8:]
-		n += 8
-	}
-	if len(p) > 0 {
-		var buf [8]byte
-		binary.BigEndian.PutUint64(buf[:], (*rand.Rand)(r).Uint64())
-		n += copy(p, buf[:])
-	}
-	return n, err
 }
 
 // generateResourceSpan generates a single PData ResourceSpans populated based on the provided inputs. They are:

--- a/internal/coreinternal/goldendataset/traces_generator_test.go
+++ b/internal/coreinternal/goldendataset/traces_generator_test.go
@@ -20,6 +20,41 @@ func TestGenerateTraces(t *testing.T) {
 	assert.Len(t, rscSpans, 32)
 }
 
+// TestGenerateTracesIsReproducible verifies that the seeded random number generator produces the
+// same trace, span, parent and link IDs on every call, which is what makes the golden dataset
+// usable for reproducible tests.
+func TestGenerateTracesIsReproducible(t *testing.T) {
+	collectIDs := func(t *testing.T) []string {
+		t.Helper()
+		tds, err := GenerateTraces("testdata/generated_pict_pairs_traces.txt",
+			"testdata/generated_pict_pairs_spans.txt")
+		require.NoError(t, err)
+
+		var ids []string
+		for _, td := range tds {
+			for i := 0; i < td.ResourceSpans().Len(); i++ {
+				scopeSpans := td.ResourceSpans().At(i).ScopeSpans()
+				for j := 0; j < scopeSpans.Len(); j++ {
+					spans := scopeSpans.At(j).Spans()
+					for k := 0; k < spans.Len(); k++ {
+						span := spans.At(k)
+						ids = append(ids, span.TraceID().String(), span.SpanID().String(), span.ParentSpanID().String())
+						for l := 0; l < span.Links().Len(); l++ {
+							link := span.Links().At(l)
+							ids = append(ids, link.TraceID().String(), link.SpanID().String())
+						}
+					}
+				}
+			}
+		}
+		return ids
+	}
+
+	first := collectIDs(t)
+	require.NotEmpty(t, first)
+	assert.Equal(t, first, collectIDs(t))
+}
+
 func TestGenerateTracesInvalidRPCFeatureGateCombination(t *testing.T) {
 	prevDontEmit := metadata.InternalCoreinternalGoldendatasetDontEmitV0RPCConventionsFeatureGate.IsEnabled()
 	prevEmitV1 := metadata.InternalCoreinternalGoldendatasetEmitV1RPCConventionsFeatureGate.IsEnabled()


### PR DESCRIPTION
#### Description
The `randReader` shim existed only to provide an `io.Reader` over `math/rand/v2.Rand` because `ChaCha8.Read` was not available before go1.23. Both the **repo** and the **internal/coreinternal** module now require go1.25, so the shim can be replaced with `rand.NewChaCha8`, which implements `io.Reader` directly

#### Link to tracking issue
N/A


#### Testing
Added a test asserting that the generated trace, span, parent and link IDs are identical across calls, which is the reproducibility property the seeded generator exists to provide

#### Documentation
N/A

#### Authorship

- [x] I, a human, wrote this pull request description myself.