### PR TITLE
[receiver/elasticsearch] Add elasticsearch.cluster.uuid resource attribute

### DIFF
--- a/.chloggen/elasticsearch-cluster-uuid.yaml
+++ b/.chloggen/elasticsearch-cluster-uuid.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an opt-in `elasticsearch.cluster.uuid` resource attribute that uniquely identifies the cluster.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50263]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The attribute is disabled by default to preserve backward compatibility. Unlike `elasticsearch.cluster.name`,
+  the cluster UUID is stable across restarts and unique across clusters, so it can be enabled to disambiguate
+  clusters that share a name.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/elasticsearch-cluster-uuid.yaml
+++ b/.chloggen/elasticsearch-cluster-uuid.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: elasticsearchreceiver
+component: receiver/elasticsearch
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add an opt-in `elasticsearch.cluster.uuid` resource attribute that uniquely identifies the cluster.

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -1066,6 +1066,7 @@ Fraction of heap memory usage
 | Name | Description | Values | Enabled | Semantic Convention | Stability |
 | ---- | ----------- | ------ | ------- | ------------------- | --------- |
 | elasticsearch.cluster.name | The name of the elasticsearch cluster. | Any Str | true | - | - |
+| elasticsearch.cluster.uuid | The unique identifier (UUID) of the elasticsearch cluster, as reported by the cluster itself. | Any Str | false | - | - |
 | elasticsearch.index.name | The name of the elasticsearch index. | Any Str | true | - | - |
 | elasticsearch.node.name | The name of the elasticsearch node. | Any Str | true | - | - |
 | elasticsearch.node.version | The version of the elasticsearch node. | Any Str | true | - | - |

--- a/receiver/elasticsearchreceiver/generated_package_test.go
+++ b/receiver/elasticsearchreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package elasticsearchreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/elasticsearchreceiver/generated_package_test.go
+++ b/receiver/elasticsearchreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package elasticsearchreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_config.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_config.go
@@ -3704,6 +3704,7 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 // ResourceAttributesConfig provides config for elasticsearch resource attributes.
 type ResourceAttributesConfig struct {
 	ElasticsearchClusterName ResourceAttributeConfig `mapstructure:"elasticsearch.cluster.name"`
+	ElasticsearchClusterUUID ResourceAttributeConfig `mapstructure:"elasticsearch.cluster.uuid"`
 	ElasticsearchIndexName   ResourceAttributeConfig `mapstructure:"elasticsearch.index.name"`
 	ElasticsearchNodeName    ResourceAttributeConfig `mapstructure:"elasticsearch.node.name"`
 	ElasticsearchNodeVersion ResourceAttributeConfig `mapstructure:"elasticsearch.node.version"`
@@ -3713,6 +3714,9 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 	return ResourceAttributesConfig{
 		ElasticsearchClusterName: ResourceAttributeConfig{
 			Enabled: true,
+		},
+		ElasticsearchClusterUUID: ResourceAttributeConfig{
+			Enabled: false,
 		},
 		ElasticsearchIndexName: ResourceAttributeConfig{
 			Enabled: true,

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_config_test.go
@@ -401,6 +401,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					ElasticsearchClusterName: ResourceAttributeConfig{Enabled: true},
+					ElasticsearchClusterUUID: ResourceAttributeConfig{Enabled: true},
 					ElasticsearchIndexName:   ResourceAttributeConfig{Enabled: true},
 					ElasticsearchNodeName:    ResourceAttributeConfig{Enabled: true},
 					ElasticsearchNodeVersion: ResourceAttributeConfig{Enabled: true},
@@ -786,6 +787,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					ElasticsearchClusterName: ResourceAttributeConfig{Enabled: false},
+					ElasticsearchClusterUUID: ResourceAttributeConfig{Enabled: false},
 					ElasticsearchIndexName:   ResourceAttributeConfig{Enabled: false},
 					ElasticsearchNodeName:    ResourceAttributeConfig{Enabled: false},
 					ElasticsearchNodeVersion: ResourceAttributeConfig{Enabled: false},
@@ -1400,6 +1402,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 			name: "all_set",
 			want: ResourceAttributesConfig{
 				ElasticsearchClusterName: ResourceAttributeConfig{Enabled: true},
+				ElasticsearchClusterUUID: ResourceAttributeConfig{Enabled: true},
 				ElasticsearchIndexName:   ResourceAttributeConfig{Enabled: true},
 				ElasticsearchNodeName:    ResourceAttributeConfig{Enabled: true},
 				ElasticsearchNodeVersion: ResourceAttributeConfig{Enabled: true},
@@ -1409,6 +1412,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 			name: "none_set",
 			want: ResourceAttributesConfig{
 				ElasticsearchClusterName: ResourceAttributeConfig{Enabled: false},
+				ElasticsearchClusterUUID: ResourceAttributeConfig{Enabled: false},
 				ElasticsearchIndexName:   ResourceAttributeConfig{Enabled: false},
 				ElasticsearchNodeName:    ResourceAttributeConfig{Enabled: false},
 				ElasticsearchNodeVersion: ResourceAttributeConfig{Enabled: false},

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -3,13 +3,14 @@
 package metadata
 
 import (
+	"slices"
+	"time"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	"slices"
-	"time"
 )
 
 const (

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -3,14 +3,13 @@
 package metadata
 
 import (
-	"slices"
-	"time"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+	"slices"
+	"time"
 )
 
 const (
@@ -7843,6 +7842,12 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 	}
 	if mbc.ResourceAttributes.ElasticsearchClusterName.MetricsExclude != nil {
 		mb.resourceAttributeExcludeFilter["elasticsearch.cluster.name"] = filter.CreateFilter(mbc.ResourceAttributes.ElasticsearchClusterName.MetricsExclude)
+	}
+	if mbc.ResourceAttributes.ElasticsearchClusterUUID.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["elasticsearch.cluster.uuid"] = filter.CreateFilter(mbc.ResourceAttributes.ElasticsearchClusterUUID.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.ElasticsearchClusterUUID.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["elasticsearch.cluster.uuid"] = filter.CreateFilter(mbc.ResourceAttributes.ElasticsearchClusterUUID.MetricsExclude)
 	}
 	if mbc.ResourceAttributes.ElasticsearchIndexName.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["elasticsearch.index.name"] = filter.CreateFilter(mbc.ResourceAttributes.ElasticsearchIndexName.MetricsInclude)

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_test.go
@@ -546,6 +546,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			rb := mb.NewResourceBuilder()
 			rb.SetElasticsearchClusterName("elasticsearch.cluster.name-val")
+			rb.SetElasticsearchClusterUUID("elasticsearch.cluster.uuid-val")
 			rb.SetElasticsearchIndexName("elasticsearch.index.name-val")
 			rb.SetElasticsearchNodeName("elasticsearch.node.name-val")
 			rb.SetElasticsearchNodeVersion("elasticsearch.node.version-val")

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_resource.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_resource.go
@@ -28,6 +28,13 @@ func (rb *ResourceBuilder) SetElasticsearchClusterName(val string) {
 	}
 }
 
+// SetElasticsearchClusterUUID sets provided value as "elasticsearch.cluster.uuid" attribute.
+func (rb *ResourceBuilder) SetElasticsearchClusterUUID(val string) {
+	if rb.config.ElasticsearchClusterUUID.Enabled {
+		rb.res.Attributes().PutStr("elasticsearch.cluster.uuid", val)
+	}
+}
+
 // SetElasticsearchIndexName sets provided value as "elasticsearch.index.name" attribute.
 func (rb *ResourceBuilder) SetElasticsearchIndexName(val string) {
 	if rb.config.ElasticsearchIndexName.Enabled {

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_resource_test.go
@@ -14,6 +14,7 @@ func TestResourceBuilder(t *testing.T) {
 			cfg := loadResourceAttributesConfig(t, tt)
 			rb := NewResourceBuilder(cfg)
 			rb.SetElasticsearchClusterName("elasticsearch.cluster.name-val")
+			rb.SetElasticsearchClusterUUID("elasticsearch.cluster.uuid-val")
 			rb.SetElasticsearchIndexName("elasticsearch.index.name-val")
 			rb.SetElasticsearchNodeName("elasticsearch.node.name-val")
 			rb.SetElasticsearchNodeVersion("elasticsearch.node.version-val")
@@ -25,7 +26,7 @@ func TestResourceBuilder(t *testing.T) {
 			case "default":
 				assert.Equal(t, 4, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 4, res.Attributes().Len())
+				assert.Equal(t, 5, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -36,6 +37,11 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.Equal(t, "elasticsearch.cluster.name-val", elasticsearchClusterNameAttrVal.Str())
+			}
+			elasticsearchClusterUUIDAttrVal, ok := res.Attributes().Get("elasticsearch.cluster.uuid")
+			assert.Equal(t, tt == "all_set", ok)
+			if ok {
+				assert.Equal(t, "elasticsearch.cluster.uuid-val", elasticsearchClusterUUIDAttrVal.Str())
 			}
 			elasticsearchIndexNameAttrVal, ok := res.Attributes().Get("elasticsearch.index.name")
 			assert.True(t, ok)

--- a/receiver/elasticsearchreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/elasticsearchreceiver/internal/metadata/testdata/config.yaml
@@ -236,6 +236,8 @@ all_set:
   resource_attributes:
     elasticsearch.cluster.name:
       enabled: true
+    elasticsearch.cluster.uuid:
+      enabled: true
     elasticsearch.index.name:
       enabled: true
     elasticsearch.node.name:
@@ -478,6 +480,8 @@ reaggregate_set:
       enabled: true
   resource_attributes:
     elasticsearch.cluster.name:
+      enabled: true
+    elasticsearch.cluster.uuid:
       enabled: true
     elasticsearch.index.name:
       enabled: true
@@ -722,6 +726,8 @@ none_set:
   resource_attributes:
     elasticsearch.cluster.name:
       enabled: false
+    elasticsearch.cluster.uuid:
+      enabled: false
     elasticsearch.index.name:
       enabled: false
     elasticsearch.node.name:
@@ -731,6 +737,10 @@ none_set:
 filter_set_include:
   resource_attributes:
     elasticsearch.cluster.name:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+    elasticsearch.cluster.uuid:
       enabled: true
       metrics_include:
         - regexp: ".*"
@@ -752,6 +762,10 @@ filter_set_exclude:
       enabled: true
       metrics_exclude:
         - strict: "elasticsearch.cluster.name-val"
+    elasticsearch.cluster.uuid:
+      enabled: true
+      metrics_exclude:
+        - strict: "elasticsearch.cluster.uuid-val"
     elasticsearch.index.name:
       enabled: true
       metrics_exclude:

--- a/receiver/elasticsearchreceiver/internal/model/clustermetadata.go
+++ b/receiver/elasticsearchreceiver/internal/model/clustermetadata.go
@@ -5,6 +5,7 @@ package model // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 type ClusterMetadataResponse struct {
 	ClusterName string `json:"cluster_name"`
+	ClusterUUID string `json:"cluster_uuid"`
 	Version     struct {
 		Number string `json:"number"`
 	} `json:"version"`

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -22,6 +22,10 @@ resource_attributes:
     description: The name of the elasticsearch cluster.
     type: string
     enabled: true
+  elasticsearch.cluster.uuid:
+    description: The unique identifier (UUID) of the elasticsearch cluster, as reported by the cluster itself.
+    type: string
+    enabled: false
   elasticsearch.index.name:
     description: The name of the elasticsearch index.
     type: string

--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -40,6 +40,7 @@ type elasticsearchScraper struct {
 	mb          *metadata.MetricsBuilder
 	version     *version.Version
 	clusterName string
+	clusterUUID string
 }
 
 func newElasticSearchScraper(
@@ -80,6 +81,7 @@ func (r *elasticsearchScraper) getClusterMetadata(ctx context.Context, errs *scr
 	}
 
 	r.clusterName = response.ClusterName
+	r.clusterUUID = response.ClusterUUID
 
 	esVersion, err := version.NewVersion(response.Version.Number)
 	if err != nil {
@@ -316,6 +318,7 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pcommo
 
 		rb := r.mb.NewResourceBuilder()
 		rb.SetElasticsearchClusterName(nodeStats.ClusterName)
+		rb.SetElasticsearchClusterUUID(r.clusterUUID)
 		rb.SetElasticsearchNodeName(info.Name)
 
 		if node, ok := nodesInfo.Nodes[id]; ok {
@@ -336,6 +339,7 @@ func (r *elasticsearchScraper) scrapeClusterMetrics(ctx context.Context, now pco
 
 	rb := r.mb.NewResourceBuilder()
 	rb.SetElasticsearchClusterName(r.clusterName)
+	rb.SetElasticsearchClusterUUID(r.clusterUUID)
 	r.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 }
 
@@ -683,5 +687,6 @@ func (r *elasticsearchScraper) scrapeOneIndexMetrics(now pcommon.Timestamp, name
 	rb := r.mb.NewResourceBuilder()
 	rb.SetElasticsearchIndexName(name)
 	rb.SetElasticsearchClusterName(r.clusterName)
+	rb.SetElasticsearchClusterUUID(r.clusterUUID)
 	r.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 }

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -88,6 +88,41 @@ func TestScraper(t *testing.T) {
 		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 
+// TestScraperClusterUUID verifies that when the opt-in elasticsearch.cluster.uuid resource
+// attribute is enabled, every emitted resource carries the cluster UUID from the metadata endpoint.
+func TestScraperClusterUUID(t *testing.T) {
+	t.Parallel()
+
+	config := createDefaultConfig().(*Config)
+	config.MetricsBuilderConfig.ResourceAttributes.ElasticsearchClusterUUID.Enabled = true
+
+	sc := newElasticSearchScraper(receivertest.NewNopSettings(metadata.Type), config)
+	require.NoError(t, sc.start(t.Context(), componenttest.NewNopHost()))
+
+	mockClient := mocks.MockElasticsearchClient{}
+	mockClient.On("ClusterMetadata", mock.Anything).Return(clusterMetadata(t), nil)
+	mockClient.On("ClusterHealth", mock.Anything).Return(clusterHealth(t), nil)
+	mockClient.On("ClusterStats", mock.Anything, []string{"_all"}).Return(clusterStats(t), nil)
+	mockClient.On("Nodes", mock.Anything, []string{"_all"}).Return(nodes(t), nil)
+	mockClient.On("NodeStats", mock.Anything, []string{"_all"}).Return(nodeStatsLinux(t), nil)
+	mockClient.On("IndexStats", mock.Anything, []string{"_all"}).Return(indexStats(t), nil)
+	sc.client = &mockClient
+
+	expectedUUID := clusterMetadata(t).ClusterUUID
+	require.NotEmpty(t, expectedUUID)
+
+	actualMetrics, err := sc.scrape(t.Context())
+	require.NoError(t, err)
+
+	resourceMetrics := actualMetrics.ResourceMetrics()
+	require.Positive(t, resourceMetrics.Len())
+	for i := 0; i < resourceMetrics.Len(); i++ {
+		uuid, ok := resourceMetrics.At(i).Resource().Attributes().Get("elasticsearch.cluster.uuid")
+		require.True(t, ok, "elasticsearch.cluster.uuid attribute missing on resource %d", i)
+		require.Equal(t, expectedUUID, uuid.Str())
+	}
+}
+
 func TestScraperNoIOStats(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### Description
This PR adds an opt-in `elasticsearch.cluster.uuid` resource attribute that uniquely identifies the cluster. The value is surfaced from the `cluster_uuid` field already returned by the root endpoint via `ClusterMetadata()`. The attribute is disabled by default to preserve backward compatibility.

#### Link to tracking issue
Fixes #50263


#### Testing
Tuned.

#### Documentation
Tuned.

#### Authorship

- [x] I, a human, wrote this pull request description myself.

