### PR TITLE
[fileconsumer] move `allowFileDeletion` and `windows.caseInsensitive` to beta

### DIFF
--- a/.chloggen/move-fg-beta.yaml
+++ b/.chloggen/move-fg-beta.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/fileconsumer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move filelog.allowFileDeletion and filelog.windows.caseInsensitive filelog.featuregates to beta
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46635]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/fileconsumer/documentation.md
+++ b/pkg/stanza/fileconsumer/documentation.md
@@ -28,10 +28,10 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `filelog.allowFileDeletion` | alpha | When enabled, allows usage of the `delete_after_read` setting. | v0.70.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16314) |
+| `filelog.allowFileDeletion` | beta | When enabled, allows usage of the `delete_after_read` setting. | v0.70.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16314) |
 | `filelog.allowHeaderMetadataParsing` | beta | When enabled, allows usage of the `header` setting. | v0.73.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18198) |
 | `filelog.mtimeSortType` | alpha | When enabled, allows usage of `ordering_criteria.mode` = `mtime`. | v0.89.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27812) |
 | `filelog.protobufCheckpointEncoding` | beta | Use protobuf encoding for checkpoint storage instead of JSON. | v0.148.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43266) |
-| `filelog.windows.caseInsensitive` | alpha | On Windows, make matching patterns in include/exclude case insensitive. | v0.142.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43777) |
+| `filelog.windows.caseInsensitive` | beta | On Windows, make matching patterns in include/exclude case insensitive. | v0.142.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43777) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/pkg/stanza/fileconsumer/internal/metadata/generated_feature_gates.go
+++ b/pkg/stanza/fileconsumer/internal/metadata/generated_feature_gates.go
@@ -8,7 +8,7 @@ import (
 
 var FilelogAllowFileDeletionFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"filelog.allowFileDeletion",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, allows usage of the `delete_after_read` setting."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16314"),
 	featuregate.WithRegisterFromVersion("v0.70.0"),
@@ -40,7 +40,7 @@ var FilelogProtobufCheckpointEncodingFeatureGate = featuregate.GlobalRegistry().
 
 var FilelogWindowsCaseInsensitiveFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"filelog.windows.caseInsensitive",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("On Windows, make matching patterns in include/exclude case insensitive."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43777"),
 	featuregate.WithRegisterFromVersion("v0.142.0"),

--- a/pkg/stanza/fileconsumer/metadata.yaml
+++ b/pkg/stanza/fileconsumer/metadata.yaml
@@ -11,7 +11,7 @@ status:
 
 feature_gates:
   - id: filelog.allowFileDeletion
-    stage: alpha
+    stage: beta
     description: >-
       When enabled, allows usage of the `delete_after_read` setting.
     from_version: v0.70.0
@@ -39,7 +39,7 @@ feature_gates:
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43266
     skip_strict_validation: true
   - id: filelog.windows.caseInsensitive
-    stage: alpha
+    stage: beta
     description: >-
       On Windows, make matching patterns in include/exclude case insensitive.
     from_version: v0.142.0


### PR DESCRIPTION
#### Description

This PR promotes `allowFileDeletion` and `windows.caseInsensitive` to beta. They have been around since `v0.70.0` and `v0.148.0` respectively and are stable i.e. no issues have been reported for those two gates

#### Link to tracking issue
Relates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46635

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.
