### PR TITLE
[receiver/k8scluster] support collecting metrics from sidecar containers

### DIFF
--- a/.chloggen/k8scluster-sidecar-metrics.yaml
+++ b/.chloggen/k8scluster-sidecar-metrics.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/k8s_cluster
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Collect `k8s.container` metrics for sidecar containers, and optionally for all init containers and ephemeral containers."
+note: "Add opt-in collection of `k8s.container` metrics for sidecar, init and ephemeral containers."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [42571]
@@ -16,9 +16,10 @@ issues: [42571]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Sidecar containers (init containers with `restartPolicy: Always`) are now collected by default.
-  Set `collect_all_init_container_metrics: true` to also collect regular init containers, and
-  `collect_ephemeral_container_metrics: true` to collect ephemeral (debug) containers.
+  The receiver's default output is unchanged. Set `collect_sidecar_container_metrics: true` to collect
+  sidecar containers (init containers with `restartPolicy: Always`), `collect_all_init_container_metrics: true`
+  to collect all init containers, and `collect_ephemeral_container_metrics: true` to collect ephemeral
+  (debug) containers.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/k8scluster-sidecar-metrics.yaml
+++ b/.chloggen/k8scluster-sidecar-metrics.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/k8s_cluster
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Collect `k8s.container` metrics for sidecar containers, and optionally for all init containers and ephemeral containers."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42571]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Sidecar containers (init containers with `restartPolicy: Always`) are now collected by default.
+  Set `collect_all_init_container_metrics: true` to also collect regular init containers, and
+  `collect_ephemeral_container_metrics: true` to collect ephemeral (debug) containers.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -80,6 +80,12 @@ When enabled, this setting produces the following node-level metrics (one per se
 
 - `metrics`: Allows to enable/disable metrics.
 - `resource_attributes`: Allows to enable/disable resource attributes.
+- `collect_all_init_container_metrics` (default = `false`): When enabled, `k8s.container` metrics and
+entities are collected for all init containers. By default only sidecar containers (init containers
+with `restartPolicy: Always`, which run for the pod's lifetime) are collected; enable this to also
+collect regular, short-lived init containers.
+- `collect_ephemeral_container_metrics` (default = `false`): When enabled, `k8s.container` metrics and
+entities are collected for ephemeral (debug) containers.
 - `namespace` (deprecated, use `namespaces` instead): Allows to observe resources for a particular namespace only. If this option is set to a non-empty string, `Nodes`, `Namespaces` and `ClusterResourceQuotas` will not be observed.
 - `namespaces`: Allows to observe resources for a list of given namespaces. If this option is set, `Nodes`, `Namespaces` and `ClusterResourceQuotas` will not be observed, as those are cluster-scoped resources.
 

--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -80,10 +80,11 @@ When enabled, this setting produces the following node-level metrics (one per se
 
 - `metrics`: Allows to enable/disable metrics.
 - `resource_attributes`: Allows to enable/disable resource attributes.
+- `collect_sidecar_container_metrics` (default = `false`): When enabled, `k8s.container` metrics and
+entities are collected for sidecar containers (init containers with `restartPolicy: Always`, which
+run for the pod's lifetime).
 - `collect_all_init_container_metrics` (default = `false`): When enabled, `k8s.container` metrics and
-entities are collected for all init containers. By default only sidecar containers (init containers
-with `restartPolicy: Always`, which run for the pod's lifetime) are collected; enable this to also
-collect regular, short-lived init containers.
+entities are collected for all init containers (regular and sidecar).
 - `collect_ephemeral_container_metrics` (default = `false`): When enabled, `k8s.container` metrics and
 entities are collected for ephemeral (debug) containers.
 - `namespace` (deprecated, use `namespaces` instead): Allows to observe resources for a particular namespace only. If this option is set to a non-empty string, `Nodes`, `Namespaces` and `ClusterResourceQuotas` will not be observed.

--- a/receiver/k8sclusterreceiver/config.go
+++ b/receiver/k8sclusterreceiver/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/pod"
 )
 
 // Config defines configuration for kubernetes cluster receiver.
@@ -53,6 +54,24 @@ type Config struct {
 	// K8sLeaderElector defines the reference to the k8s leader elector extension
 	// use this when k8s cluster receiver needs to be deployed in HA mode
 	K8sLeaderElector *component.ID `mapstructure:"k8s_leader_elector"`
+
+	// CollectAllInitContainerMetrics enables collection of k8s.container metrics and entities for
+	// all init containers. By default only sidecar containers (init containers with
+	// restartPolicy: Always, which run for the pod's lifetime) are collected. Enable this to also
+	// collect regular, short-lived init containers.
+	CollectAllInitContainerMetrics bool `mapstructure:"collect_all_init_container_metrics"`
+
+	// CollectEphemeralContainerMetrics enables collection of k8s.container metrics and entities for
+	// ephemeral (debug) containers. Disabled by default.
+	CollectEphemeralContainerMetrics bool `mapstructure:"collect_ephemeral_container_metrics"`
+}
+
+// podContainerMetricsConfig maps the receiver config to the pod package's container collection config.
+func (cfg *Config) podContainerMetricsConfig() pod.ContainerMetricsConfig {
+	return pod.ContainerMetricsConfig{
+		CollectAllInitContainers:   cfg.CollectAllInitContainerMetrics,
+		CollectEphemeralContainers: cfg.CollectEphemeralContainerMetrics,
+	}
 }
 
 func (cfg *Config) Validate() error {

--- a/receiver/k8sclusterreceiver/config.go
+++ b/receiver/k8sclusterreceiver/config.go
@@ -55,10 +55,13 @@ type Config struct {
 	// use this when k8s cluster receiver needs to be deployed in HA mode
 	K8sLeaderElector *component.ID `mapstructure:"k8s_leader_elector"`
 
+	// CollectSidecarContainerMetrics enables collection of k8s.container metrics and entities for
+	// sidecar containers (init containers with restartPolicy: Always, which run for the pod's
+	// lifetime). Disabled by default.
+	CollectSidecarContainerMetrics bool `mapstructure:"collect_sidecar_container_metrics"`
+
 	// CollectAllInitContainerMetrics enables collection of k8s.container metrics and entities for
-	// all init containers. By default only sidecar containers (init containers with
-	// restartPolicy: Always, which run for the pod's lifetime) are collected. Enable this to also
-	// collect regular, short-lived init containers.
+	// all init containers (regular and sidecar). Disabled by default.
 	CollectAllInitContainerMetrics bool `mapstructure:"collect_all_init_container_metrics"`
 
 	// CollectEphemeralContainerMetrics enables collection of k8s.container metrics and entities for
@@ -69,6 +72,7 @@ type Config struct {
 // podContainerMetricsConfig maps the receiver config to the pod package's container collection config.
 func (cfg *Config) podContainerMetricsConfig() pod.ContainerMetricsConfig {
 	return pod.ContainerMetricsConfig{
+		CollectSidecarContainers:   cfg.CollectSidecarContainerMetrics,
 		CollectAllInitContainers:   cfg.CollectAllInitContainerMetrics,
 		CollectEphemeralContainers: cfg.CollectEphemeralContainerMetrics,
 	}

--- a/receiver/k8sclusterreceiver/config.schema.yaml
+++ b/receiver/k8sclusterreceiver/config.schema.yaml
@@ -6,6 +6,12 @@ properties:
     type: array
     items:
       type: string
+  collect_all_init_container_metrics:
+    description: 'CollectAllInitContainerMetrics enables collection of k8s.container metrics and entities for all init containers. By default only sidecar containers (init containers with restartPolicy: Always, which run for the pod''s lifetime) are collected. Enable this to also collect regular, short-lived init containers.'
+    type: boolean
+  collect_ephemeral_container_metrics:
+    description: CollectEphemeralContainerMetrics enables collection of k8s.container metrics and entities for ephemeral (debug) containers. Disabled by default.
+    type: boolean
   collection_interval:
     description: Collection interval for metrics.
     type: string

--- a/receiver/k8sclusterreceiver/config.schema.yaml
+++ b/receiver/k8sclusterreceiver/config.schema.yaml
@@ -7,10 +7,13 @@ properties:
     items:
       type: string
   collect_all_init_container_metrics:
-    description: 'CollectAllInitContainerMetrics enables collection of k8s.container metrics and entities for all init containers. By default only sidecar containers (init containers with restartPolicy: Always, which run for the pod''s lifetime) are collected. Enable this to also collect regular, short-lived init containers.'
+    description: CollectAllInitContainerMetrics enables collection of k8s.container metrics and entities for all init containers (regular and sidecar). Disabled by default.
     type: boolean
   collect_ephemeral_container_metrics:
     description: CollectEphemeralContainerMetrics enables collection of k8s.container metrics and entities for ephemeral (debug) containers. Disabled by default.
+    type: boolean
+  collect_sidecar_container_metrics:
+    description: 'CollectSidecarContainerMetrics enables collection of k8s.container metrics and entities for sidecar containers (init containers with restartPolicy: Always, which run for the pod''s lifetime). Disabled by default.'
     type: boolean
   collection_interval:
     description: Collection interval for metrics.

--- a/receiver/k8sclusterreceiver/config_test.go
+++ b/receiver/k8sclusterreceiver/config_test.go
@@ -46,6 +46,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				MetadataCollectionInterval:       30 * time.Minute,
 				MetricsBuilderConfig:             metadata.NewDefaultMetricsBuilderConfig(),
+				CollectSidecarContainerMetrics:   true,
 				CollectAllInitContainerMetrics:   true,
 				CollectEphemeralContainerMetrics: true,
 			},

--- a/receiver/k8sclusterreceiver/config_test.go
+++ b/receiver/k8sclusterreceiver/config_test.go
@@ -44,8 +44,10 @@ func TestLoadConfig(t *testing.T) {
 				APIConfig: k8sconfig.APIConfig{
 					AuthType: k8sconfig.AuthTypeServiceAccount,
 				},
-				MetadataCollectionInterval: 30 * time.Minute,
-				MetricsBuilderConfig:       metadata.NewDefaultMetricsBuilderConfig(),
+				MetadataCollectionInterval:       30 * time.Minute,
+				MetricsBuilderConfig:             metadata.NewDefaultMetricsBuilderConfig(),
+				CollectAllInitContainerMetrics:   true,
+				CollectEphemeralContainerMetrics: true,
 			},
 		},
 		{

--- a/receiver/k8sclusterreceiver/informer_transform.go
+++ b/receiver/k8sclusterreceiver/informer_transform.go
@@ -24,10 +24,10 @@ import (
 
 // transformObject transforms the k8s object by removing the data that is not utilized by the receiver.
 // Only highly utilized objects are transformed here while others are kept as is.
-func transformObject(object any) (any, error) {
+func transformObject(object any, podContainerCfg pod.ContainerMetricsConfig) (any, error) {
 	switch o := object.(type) {
 	case *corev1.Pod:
-		return pod.Transform(o), nil
+		return pod.Transform(o, podContainerCfg), nil
 	case *corev1.Node:
 		return node.Transform(o), nil
 	case *appsv1.ReplicaSet:

--- a/receiver/k8sclusterreceiver/informer_transform_test.go
+++ b/receiver/k8sclusterreceiver/informer_transform_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/pod"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/testutils"
 )
 
@@ -134,7 +135,7 @@ func TestTransformObject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := transformObject(tt.object)
+			got, err := transformObject(tt.object, pod.ContainerMetricsConfig{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			if tt.same {

--- a/receiver/k8sclusterreceiver/internal/collection/collector.go
+++ b/receiver/k8sclusterreceiver/internal/collection/collector.go
@@ -46,11 +46,13 @@ type DataCollector struct {
 	nodeConditionsToReport   []string
 	allocatableTypesToReport []string
 	metricsBuilder           *metadata.MetricsBuilder
+	podContainerMetricsCfg   pod.ContainerMetricsConfig
 }
 
 // NewDataCollector returns a DataCollector.
 func NewDataCollector(set receiver.Settings, ms *metadata.Store,
 	metricsBuilderConfig metadata.MetricsBuilderConfig, nodeConditionsToReport, allocatableTypesToReport []string,
+	podContainerMetricsCfg pod.ContainerMetricsConfig,
 ) *DataCollector {
 	return &DataCollector{
 		settings:                 set,
@@ -58,6 +60,7 @@ func NewDataCollector(set receiver.Settings, ms *metadata.Store,
 		nodeConditionsToReport:   nodeConditionsToReport,
 		allocatableTypesToReport: allocatableTypesToReport,
 		metricsBuilder:           metadata.NewMetricsBuilder(metricsBuilderConfig, set),
+		podContainerMetricsCfg:   podContainerMetricsCfg,
 	}
 }
 
@@ -66,7 +69,7 @@ func (dc *DataCollector) CollectMetricData(currentTime time.Time) pmetric.Metric
 	customRMs := pmetric.NewResourceMetricsSlice()
 
 	dc.metadataStore.ForEach(gvk.Pod, func(o any) {
-		pod.RecordMetrics(dc.settings.Logger, dc.metricsBuilder, o.(*corev1.Pod), ts)
+		pod.RecordMetrics(dc.settings.Logger, dc.metricsBuilder, o.(*corev1.Pod), ts, dc.podContainerMetricsCfg)
 	})
 	dc.metadataStore.ForEach(gvk.Node, func(o any) {
 		crm := node.CustomMetrics(dc.settings, dc.metricsBuilder.NewResourceBuilder(), o.(*corev1.Node),

--- a/receiver/k8sclusterreceiver/internal/collection/collector_test.go
+++ b/receiver/k8sclusterreceiver/internal/collection/collector_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/gvk"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/pod"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/testutils"
 )
 
@@ -121,7 +122,7 @@ func TestCollectMetricData(t *testing.T) {
 		},
 	})
 
-	dc := NewDataCollector(receivertest.NewNopSettings(metadata.Type), ms, metadata.NewDefaultMetricsBuilderConfig(), []string{"Ready"}, nil)
+	dc := NewDataCollector(receivertest.NewNopSettings(metadata.Type), ms, metadata.NewDefaultMetricsBuilderConfig(), []string{"Ready"}, nil, pod.ContainerMetricsConfig{})
 	m1 := dc.CollectMetricData(time.Now())
 
 	// Verify number of resource metrics only, content is tested in other tests.
@@ -150,7 +151,7 @@ func TestCollectServiceMetrics(t *testing.T) {
 
 	mbc := metadata.NewDefaultMetricsBuilderConfig()
 	mbc.Metrics.K8sServiceEndpointCount.Enabled = true
-	dc := NewDataCollector(receivertest.NewNopSettings(metadata.Type), ms, mbc, nil, nil)
+	dc := NewDataCollector(receivertest.NewNopSettings(metadata.Type), ms, mbc, nil, nil, pod.ContainerMetricsConfig{})
 	m := dc.CollectMetricData(time.Now())
 
 	foundEndpointCount := false
@@ -202,7 +203,7 @@ func TestCollectLoadBalancerServiceMetrics(t *testing.T) {
 
 	mbc := metadata.NewDefaultMetricsBuilderConfig()
 	mbc.Metrics.K8sServiceLoadBalancerIngressCount.Enabled = true
-	dc := NewDataCollector(receivertest.NewNopSettings(metadata.Type), ms, mbc, nil, nil)
+	dc := NewDataCollector(receivertest.NewNopSettings(metadata.Type), ms, mbc, nil, nil, pod.ContainerMetricsConfig{})
 	m := dc.CollectMetricData(time.Now())
 
 	foundLBIngressCount := false

--- a/receiver/k8sclusterreceiver/internal/container/containers.go
+++ b/receiver/k8sclusterreceiver/internal/container/containers.go
@@ -47,13 +47,7 @@ var allContainerStatusReasons = []metadata.AttributeK8sContainerStatusReason{
 // RecordSpecMetrics metricizes values from the container spec.
 // This includes values like resource requests and limits.
 func RecordSpecMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, c corev1.Container, pod *corev1.Pod, ts pcommon.Timestamp) {
-	var cs *corev1.ContainerStatus
-	for i := range pod.Status.ContainerStatuses {
-		if pod.Status.ContainerStatuses[i].Name == c.Name {
-			cs = &pod.Status.ContainerStatuses[i]
-			break
-		}
-	}
+	cs := findContainerStatus(pod, c.Name)
 
 	var containerID string
 	if cs != nil {
@@ -151,6 +145,24 @@ func RecordSpecMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, c corev1
 	}
 
 	eb.Emit()
+}
+
+// findContainerStatus looks up the status matching the given container name across regular,
+// init (sidecar) and ephemeral container statuses. Container names are unique within a pod
+// regardless of container type, so a name match is unambiguous.
+func findContainerStatus(pod *corev1.Pod, name string) *corev1.ContainerStatus {
+	for _, statuses := range [][]corev1.ContainerStatus{
+		pod.Status.ContainerStatuses,
+		pod.Status.InitContainerStatuses,
+		pod.Status.EphemeralContainerStatuses,
+	} {
+		for i := range statuses {
+			if statuses[i].Name == name {
+				return &statuses[i]
+			}
+		}
+	}
+	return nil
 }
 
 func GetMetadata(pod *corev1.Pod, cs corev1.ContainerStatus, logger *zap.Logger) *metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/internal/container/containers_test.go
+++ b/receiver/k8sclusterreceiver/internal/container/containers_test.go
@@ -159,6 +159,38 @@ func TestRecordSpecMetrics(t *testing.T) {
 	}
 }
 
+func TestFindContainerStatus(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", ContainerID: "docker://app-id"},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "sidecar", ContainerID: "docker://sidecar-id"},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{Name: "debugger", ContainerID: "docker://debugger-id"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		containerName string
+		want          *corev1.ContainerStatus
+	}{
+		{name: "regular container", containerName: "app", want: &pod.Status.ContainerStatuses[0]},
+		{name: "sidecar container", containerName: "sidecar", want: &pod.Status.InitContainerStatuses[0]},
+		{name: "ephemeral container", containerName: "debugger", want: &pod.Status.EphemeralContainerStatuses[0]},
+		{name: "no match", containerName: "missing", want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, findContainerStatus(pod, tt.containerName))
+		})
+	}
+}
+
 func TestGetMetadata(t *testing.T) {
 	refTime := v1.Now()
 	pod := &corev1.Pod{

--- a/receiver/k8sclusterreceiver/internal/pod/pods.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods.go
@@ -34,9 +34,19 @@ const (
 	podStatusReason = "k8s.pod.status_reason"
 )
 
+// ContainerMetricsConfig controls which non-primary pod containers are included when collecting
+// k8s.container metrics and entities.
+type ContainerMetricsConfig struct {
+	// CollectAllInitContainers includes all init containers when true. When false, only sidecar
+	// containers (init containers with restartPolicy: Always) are included.
+	CollectAllInitContainers bool
+	// CollectEphemeralContainers includes ephemeral (debug) containers when true.
+	CollectEphemeralContainers bool
+}
+
 // Transform transforms the pod to remove the fields that we don't use to reduce RAM utilization.
 // IMPORTANT: Make sure to update this function before using new pod fields.
-func Transform(pod *corev1.Pod) *corev1.Pod {
+func Transform(pod *corev1.Pod, cfg ContainerMetricsConfig) *corev1.Pod {
 	newPod := &corev1.Pod{
 		ObjectMeta: metadata.TransformObjectMeta(pod.ObjectMeta),
 		Spec: corev1.PodSpec{
@@ -70,10 +80,85 @@ func Transform(pod *corev1.Pod) *corev1.Pod {
 			},
 		})
 	}
+
+	// Sidecar containers (init containers with restartPolicy: Always) run for the lifetime of
+	// the pod like regular containers, so keep them and their statuses around for metric
+	// collection. Regular init containers are only kept when CollectAllInitContainers is set,
+	// since they are short-lived and complete before the pod's main containers start.
+	initNames := make(map[string]struct{})
+	for _, c := range collectedInitContainers(pod, cfg) {
+		initNames[c.Name] = struct{}{}
+		newPod.Spec.InitContainers = append(newPod.Spec.InitContainers, corev1.Container{
+			Name:          c.Name,
+			RestartPolicy: c.RestartPolicy,
+			Resources: corev1.ResourceRequirements{
+				Requests: c.Resources.Requests,
+				Limits:   c.Resources.Limits,
+			},
+		})
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		cs := &pod.Status.InitContainerStatuses[i]
+		if _, ok := initNames[cs.Name]; !ok {
+			continue
+		}
+		newPod.Status.InitContainerStatuses = append(newPod.Status.InitContainerStatuses, corev1.ContainerStatus{
+			Name:                 cs.Name,
+			Image:                cs.Image,
+			ContainerID:          cs.ContainerID,
+			RestartCount:         cs.RestartCount,
+			Ready:                cs.Ready,
+			State:                cs.State,
+			LastTerminationState: cs.LastTerminationState,
+		})
+	}
+
+	// Ephemeral (debug) containers are kept only when explicitly enabled.
+	if cfg.CollectEphemeralContainers {
+		for i := range pod.Spec.EphemeralContainers {
+			c := &pod.Spec.EphemeralContainers[i]
+			newPod.Spec.EphemeralContainers = append(newPod.Spec.EphemeralContainers, corev1.EphemeralContainer{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name: c.Name,
+					Resources: corev1.ResourceRequirements{
+						Requests: c.Resources.Requests,
+						Limits:   c.Resources.Limits,
+					},
+				},
+			})
+		}
+		for i := range pod.Status.EphemeralContainerStatuses {
+			cs := &pod.Status.EphemeralContainerStatuses[i]
+			newPod.Status.EphemeralContainerStatuses = append(newPod.Status.EphemeralContainerStatuses, corev1.ContainerStatus{
+				Name:                 cs.Name,
+				Image:                cs.Image,
+				ContainerID:          cs.ContainerID,
+				RestartCount:         cs.RestartCount,
+				Ready:                cs.Ready,
+				State:                cs.State,
+				LastTerminationState: cs.LastTerminationState,
+			})
+		}
+	}
+
 	return newPod
 }
 
-func RecordMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, pod *corev1.Pod, ts pcommon.Timestamp) {
+// collectedInitContainers returns the init containers whose metrics should be collected given cfg:
+// all init containers when CollectAllInitContainers is set, otherwise only sidecars (init
+// containers with restartPolicy: Always, GA since Kubernetes 1.29).
+func collectedInitContainers(pod *corev1.Pod, cfg ContainerMetricsConfig) []*corev1.Container {
+	var containers []*corev1.Container
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		if cfg.CollectAllInitContainers || (c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways) {
+			containers = append(containers, c)
+		}
+	}
+	return containers
+}
+
+func RecordMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, pod *corev1.Pod, ts pcommon.Timestamp, cfg ContainerMetricsConfig) {
 	e := metadata.NewK8sPodEntity(string(pod.UID))
 	e.SetK8sPodName(pod.Name)
 	e.SetK8sPodQosClass(string(pod.Status.QOSClass))
@@ -87,6 +172,15 @@ func RecordMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, pod *corev1.
 	for i := range pod.Spec.Containers {
 		c := pod.Spec.Containers[i]
 		container.RecordSpecMetrics(logger, mb, c, pod, ts)
+	}
+	for _, c := range collectedInitContainers(pod, cfg) {
+		container.RecordSpecMetrics(logger, mb, *c, pod, ts)
+	}
+	if cfg.CollectEphemeralContainers {
+		for i := range pod.Spec.EphemeralContainers {
+			c := corev1.Container(pod.Spec.EphemeralContainers[i].EphemeralContainerCommon)
+			container.RecordSpecMetrics(logger, mb, c, pod, ts)
+		}
 	}
 }
 
@@ -125,7 +219,7 @@ func phaseToInt(phase corev1.PodPhase) int32 {
 }
 
 // GetMetadata returns all metadata associated with the pod.
-func GetMetadata(pod *corev1.Pod, mc *metadata.Store, logger *zap.Logger) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {
+func GetMetadata(pod *corev1.Pod, mc *metadata.Store, logger *zap.Logger, cfg ContainerMetricsConfig) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {
 	meta := map[string]string{}
 	for k, v := range pod.Labels {
 		meta[fmt.Sprintf("k8s.pod.label.%s", k)] = v
@@ -180,7 +274,7 @@ func GetMetadata(pod *corev1.Pod, mc *metadata.Store, logger *zap.Logger) map[ex
 			ResourceID:    podID,
 			Metadata:      meta,
 		},
-	}, getPodContainerProperties(pod, logger))
+	}, getPodContainerProperties(pod, logger, cfg))
 }
 
 // collectPodJobProperties checks if pod owner of type Job is cached. Check owners reference
@@ -273,12 +367,41 @@ func getWorkloadProperties(ref *v1.OwnerReference, labelKey string) map[string]s
 	}
 }
 
-func getPodContainerProperties(pod *corev1.Pod, logger *zap.Logger) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {
+func getPodContainerProperties(pod *corev1.Pod, logger *zap.Logger, cfg ContainerMetricsConfig) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {
 	km := map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata{}
 	for i := range pod.Status.ContainerStatuses {
 		cs := pod.Status.ContainerStatuses[i]
 		md := container.GetMetadata(pod, cs, logger)
 		km[md.ResourceID] = md
+	}
+
+	initNames := make(map[string]struct{})
+	for _, c := range collectedInitContainers(pod, cfg) {
+		initNames[c.Name] = struct{}{}
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		cs := pod.Status.InitContainerStatuses[i]
+		if _, ok := initNames[cs.Name]; !ok {
+			continue
+		}
+		// Skip containers without an ID: the container entity is keyed on container.id, so an
+		// empty ID has no stable identity and would collide with other not-yet-started containers.
+		if cs.ContainerID == "" {
+			continue
+		}
+		md := container.GetMetadata(pod, cs, logger)
+		km[md.ResourceID] = md
+	}
+
+	if cfg.CollectEphemeralContainers {
+		for i := range pod.Status.EphemeralContainerStatuses {
+			cs := pod.Status.EphemeralContainerStatuses[i]
+			if cs.ContainerID == "" {
+				continue
+			}
+			md := container.GetMetadata(pod, cs, logger)
+			km[md.ResourceID] = md
+		}
 	}
 	return km
 }

--- a/receiver/k8sclusterreceiver/internal/pod/pods.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods.go
@@ -35,10 +35,12 @@ const (
 )
 
 // ContainerMetricsConfig controls which non-primary pod containers are included when collecting
-// k8s.container metrics and entities.
+// k8s.container metrics and entities. All are opt-in to preserve the receiver's default output.
 type ContainerMetricsConfig struct {
-	// CollectAllInitContainers includes all init containers when true. When false, only sidecar
-	// containers (init containers with restartPolicy: Always) are included.
+	// CollectSidecarContainers includes sidecar containers (init containers with
+	// restartPolicy: Always) when true.
+	CollectSidecarContainers bool
+	// CollectAllInitContainers includes all init containers (regular and sidecar) when true.
 	CollectAllInitContainers bool
 	// CollectEphemeralContainers includes ephemeral (debug) containers when true.
 	CollectEphemeralContainers bool
@@ -81,10 +83,9 @@ func Transform(pod *corev1.Pod, cfg ContainerMetricsConfig) *corev1.Pod {
 		})
 	}
 
-	// Sidecar containers (init containers with restartPolicy: Always) run for the lifetime of
-	// the pod like regular containers, so keep them and their statuses around for metric
-	// collection. Regular init containers are only kept when CollectAllInitContainers is set,
-	// since they are short-lived and complete before the pod's main containers start.
+	// Init containers to collect: sidecars (init containers with restartPolicy: Always) when
+	// CollectSidecarContainers is set, and every init container when CollectAllInitContainers is
+	// set. All are opt-in, so the default output is unchanged.
 	initNames := make(map[string]struct{})
 	for _, c := range collectedInitContainers(pod, cfg) {
 		initNames[c.Name] = struct{}{}
@@ -146,12 +147,14 @@ func Transform(pod *corev1.Pod, cfg ContainerMetricsConfig) *corev1.Pod {
 
 // collectedInitContainers returns the init containers whose metrics should be collected given cfg:
 // all init containers when CollectAllInitContainers is set, otherwise only sidecars (init
-// containers with restartPolicy: Always, GA since Kubernetes 1.29).
+// containers with restartPolicy: Always, GA since Kubernetes 1.29) when CollectSidecarContainers
+// is set.
 func collectedInitContainers(pod *corev1.Pod, cfg ContainerMetricsConfig) []*corev1.Container {
 	var containers []*corev1.Container
 	for i := range pod.Spec.InitContainers {
 		c := &pod.Spec.InitContainers[i]
-		if cfg.CollectAllInitContainers || (c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways) {
+		isSidecar := c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways
+		if cfg.CollectAllInitContainers || (cfg.CollectSidecarContainers && isSidecar) {
 			containers = append(containers, c)
 		}
 	}

--- a/receiver/k8sclusterreceiver/internal/pod/pods_test.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -46,7 +47,7 @@ func TestPodAndContainerMetricsReportCPUMetrics(t *testing.T) {
 
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	mb := metadata.NewMetricsBuilder(metadata.NewDefaultMetricsBuilderConfig(), receivertest.NewNopSettings(metadata.Type))
-	RecordMetrics(zap.NewNop(), mb, pod, ts)
+	RecordMetrics(zap.NewNop(), mb, pod, ts, ContainerMetricsConfig{})
 	m := mb.Emit()
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected.yaml"))
 	require.NoError(t, err)
@@ -73,7 +74,7 @@ func TestPodStatusReasonAndContainerMetricsReportCPUMetrics(t *testing.T) {
 	mbc.ResourceAttributes.K8sContainerStatusLastTerminatedReason.Enabled = true
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	mb := metadata.NewMetricsBuilder(mbc, receivertest.NewNopSettings(metadata.Type))
-	RecordMetrics(zap.NewNop(), mb, pod, ts)
+	RecordMetrics(zap.NewNop(), mb, pod, ts, ContainerMetricsConfig{})
 	m := mb.Emit()
 
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected_evicted.yaml"))
@@ -90,6 +91,188 @@ func TestPodStatusReasonAndContainerMetricsReportCPUMetrics(t *testing.T) {
 
 var containerIDWithPrefix = func(containerID string) string {
 	return "docker://" + containerID
+}
+
+func TestPodAndSidecarContainerMetricsReportCPUMetrics(t *testing.T) {
+	pod := testutils.NewPodWithContainer(
+		"1",
+		testutils.NewPodSpecWithSidecarContainer("container-name", "sidecar-name"),
+		testutils.NewPodStatusWithSidecarContainer("container-name", containerIDWithPrefix("container-id"), "sidecar-name", containerIDWithPrefix("sidecar-id")),
+	)
+
+	ts := pcommon.Timestamp(time.Now().UnixNano())
+	mb := metadata.NewMetricsBuilder(metadata.NewDefaultMetricsBuilderConfig(), receivertest.NewNopSettings(metadata.Type))
+	RecordMetrics(zap.NewNop(), mb, pod, ts, ContainerMetricsConfig{})
+	m := mb.Emit()
+	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected_sidecar.yaml"))
+	require.NoError(t, err)
+	require.NoError(t, pmetrictest.CompareMetrics(expected, m,
+		pmetrictest.IgnoreTimestamp(),
+		pmetrictest.IgnoreStartTimestamp(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+	),
+	)
+}
+
+func TestRecordMetricsIgnoresRegularInitContainer(t *testing.T) {
+	pod := testutils.NewPodWithContainer(
+		"1",
+		testutils.NewPodSpecWithContainer("container-name"),
+		testutils.NewPodStatusWithContainer("container-name", containerIDWithPrefix("container-id")),
+	)
+	pod.Spec.InitContainers = []corev1.Container{
+		{
+			Name: "regular-init-container",
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI),
+				},
+			},
+		},
+	}
+	pod.Status.InitContainerStatuses = []corev1.ContainerStatus{
+		{
+			Name:  "regular-init-container",
+			Ready: false,
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{},
+			},
+		},
+	}
+
+	ts := pcommon.Timestamp(time.Now().UnixNano())
+	mb := metadata.NewMetricsBuilder(metadata.NewDefaultMetricsBuilderConfig(), receivertest.NewNopSettings(metadata.Type))
+	RecordMetrics(zap.NewNop(), mb, pod, ts, ContainerMetricsConfig{})
+	m := mb.Emit()
+	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected.yaml"))
+	require.NoError(t, err)
+	require.NoError(t, pmetrictest.CompareMetrics(expected, m,
+		pmetrictest.IgnoreTimestamp(),
+		pmetrictest.IgnoreStartTimestamp(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+	),
+	)
+}
+
+func TestPodAndEphemeralContainerMetricsReportCPUMetrics(t *testing.T) {
+	pod := testutils.NewPodWithContainer(
+		"1",
+		testutils.NewPodSpecWithContainer("container-name"),
+		testutils.NewPodStatusWithContainer("container-name", containerIDWithPrefix("container-id")),
+	)
+	pod.Spec.EphemeralContainers = []corev1.EphemeralContainer{
+		{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:  "debugger",
+				Image: "busybox:latest",
+			},
+		},
+	}
+	pod.Status.EphemeralContainerStatuses = []corev1.ContainerStatus{
+		{
+			Name:  "debugger",
+			Ready: false,
+			Image: "busybox:latest",
+			State: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: v1.Time{Time: time.Date(1, time.January, 1, 1, 1, 1, 1, time.UTC)},
+				},
+			},
+		},
+	}
+
+	ts := pcommon.Timestamp(time.Now().UnixNano())
+	mb := metadata.NewMetricsBuilder(metadata.NewDefaultMetricsBuilderConfig(), receivertest.NewNopSettings(metadata.Type))
+	RecordMetrics(zap.NewNop(), mb, pod, ts, ContainerMetricsConfig{CollectEphemeralContainers: true})
+	m := mb.Emit()
+	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected_ephemeral.yaml"))
+	require.NoError(t, err)
+	require.NoError(t, pmetrictest.CompareMetrics(expected, m,
+		pmetrictest.IgnoreTimestamp(),
+		pmetrictest.IgnoreStartTimestamp(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+	),
+	)
+}
+
+// containerNamesFromMetrics returns the k8s.container.name of every container resource emitted.
+func containerNamesFromMetrics(m pmetric.Metrics) []string {
+	var names []string
+	rms := m.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		if v, ok := rms.At(i).Resource().Attributes().Get("k8s.container.name"); ok {
+			names = append(names, v.Str())
+		}
+	}
+	return names
+}
+
+func TestRecordMetricsContainerCollectionConfig(t *testing.T) {
+	alwaysRestart := corev1.ContainerRestartPolicyAlways
+	newPod := func() *corev1.Pod {
+		pod := testutils.NewPodWithContainer(
+			"1",
+			testutils.NewPodSpecWithContainer("app"),
+			testutils.NewPodStatusWithContainer("app", containerIDWithPrefix("app-id")),
+		)
+		pod.Spec.InitContainers = []corev1.Container{
+			{Name: "regular-init"},
+			{Name: "my-sidecar", RestartPolicy: &alwaysRestart},
+		}
+		pod.Status.InitContainerStatuses = []corev1.ContainerStatus{
+			{Name: "regular-init", ContainerID: containerIDWithPrefix("regular-init-id"), State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			{Name: "my-sidecar", ContainerID: containerIDWithPrefix("sidecar-id"), Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+		}
+		pod.Spec.EphemeralContainers = []corev1.EphemeralContainer{
+			{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "debugger"}},
+		}
+		pod.Status.EphemeralContainerStatuses = []corev1.ContainerStatus{
+			{Name: "debugger", ContainerID: containerIDWithPrefix("debugger-id"), State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+		}
+		return pod
+	}
+
+	tests := []struct {
+		name           string
+		cfg            ContainerMetricsConfig
+		wantContainers []string
+	}{
+		{
+			name:           "default collects regular and sidecar containers",
+			cfg:            ContainerMetricsConfig{},
+			wantContainers: []string{"app", "my-sidecar"},
+		},
+		{
+			name:           "all init containers",
+			cfg:            ContainerMetricsConfig{CollectAllInitContainers: true},
+			wantContainers: []string{"app", "my-sidecar", "regular-init"},
+		},
+		{
+			name:           "ephemeral containers",
+			cfg:            ContainerMetricsConfig{CollectEphemeralContainers: true},
+			wantContainers: []string{"app", "my-sidecar", "debugger"},
+		},
+		{
+			name:           "all init and ephemeral containers",
+			cfg:            ContainerMetricsConfig{CollectAllInitContainers: true, CollectEphemeralContainers: true},
+			wantContainers: []string{"app", "my-sidecar", "regular-init", "debugger"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := pcommon.Timestamp(time.Now().UnixNano())
+			mb := metadata.NewMetricsBuilder(metadata.NewDefaultMetricsBuilderConfig(), receivertest.NewNopSettings(metadata.Type))
+			RecordMetrics(zap.NewNop(), mb, newPod(), ts, tt.cfg)
+			assert.ElementsMatch(t, tt.wantContainers, containerNamesFromMetrics(mb.Emit()))
+		})
+	}
 }
 
 func TestPhaseToInt(t *testing.T) {
@@ -186,7 +369,7 @@ func TestDataCollectorSyncMetadataForPodWorkloads(t *testing.T) {
 
 			name := fmt.Sprintf("(%s) - %s", kind, tt.name)
 			t.Run(name, func(t *testing.T) {
-				actual := GetMetadata(testCase.resource, testCase.metadataStore, logger)
+				actual := GetMetadata(testCase.resource, testCase.metadataStore, logger, ContainerMetricsConfig{})
 				require.Len(t, actual, len(testCase.want))
 
 				for key, item := range testCase.want {
@@ -535,7 +718,117 @@ func TestTransform(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, wantPod, Transform(originalPod))
+	assert.Equal(t, wantPod, Transform(originalPod, ContainerMetricsConfig{}))
+}
+
+func TestTransformKeepsSidecarButDropsRegularInitContainers(t *testing.T) {
+	alwaysRestart := corev1.ContainerRestartPolicyAlways
+	originalPod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			InitContainers: []corev1.Container{
+				{
+					Name:  "regular-init",
+					Image: "busybox:latest",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+					},
+				},
+				{
+					Name:          "my-sidecar",
+					Image:         "alpine:latest",
+					RestartPolicy: &alwaysRestart,
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+					},
+				},
+			},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{
+					EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+						Name:  "debugger",
+						Image: "busybox:latest",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "regular-init", Image: "busybox:latest", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}}},
+				{Name: "my-sidecar", Image: "alpine:latest", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{Name: "debugger", Image: "busybox:latest", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+
+	got := Transform(originalPod, ContainerMetricsConfig{CollectEphemeralContainers: true})
+
+	require.Len(t, got.Spec.InitContainers, 1)
+	assert.Equal(t, "my-sidecar", got.Spec.InitContainers[0].Name)
+	require.Len(t, got.Status.InitContainerStatuses, 1)
+	assert.Equal(t, "my-sidecar", got.Status.InitContainerStatuses[0].Name)
+
+	require.Len(t, got.Spec.EphemeralContainers, 1)
+	assert.Equal(t, "debugger", got.Spec.EphemeralContainers[0].Name)
+	require.Len(t, got.Status.EphemeralContainerStatuses, 1)
+	assert.Equal(t, "debugger", got.Status.EphemeralContainerStatuses[0].Name)
+}
+
+func TestTransformContainerCollectionConfig(t *testing.T) {
+	alwaysRestart := corev1.ContainerRestartPolicyAlways
+	newPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				NodeName: "node-1",
+				InitContainers: []corev1.Container{
+					{Name: "regular-init"},
+					{Name: "my-sidecar", RestartPolicy: &alwaysRestart},
+				},
+				EphemeralContainers: []corev1.EphemeralContainer{
+					{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "debugger"}},
+				},
+			},
+			Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{Name: "regular-init"},
+					{Name: "my-sidecar"},
+				},
+				EphemeralContainerStatuses: []corev1.ContainerStatus{
+					{Name: "debugger"},
+				},
+			},
+		}
+	}
+
+	initNames := func(pod *corev1.Pod) []string {
+		var names []string
+		for _, c := range pod.Spec.InitContainers {
+			names = append(names, c.Name)
+		}
+		return names
+	}
+
+	// Default: only sidecars, no ephemeral.
+	got := Transform(newPod(), ContainerMetricsConfig{})
+	assert.Equal(t, []string{"my-sidecar"}, initNames(got))
+	assert.Empty(t, got.Spec.EphemeralContainers)
+
+	// CollectAllInitContainers: all init containers kept, still no ephemeral.
+	got = Transform(newPod(), ContainerMetricsConfig{CollectAllInitContainers: true})
+	assert.ElementsMatch(t, []string{"regular-init", "my-sidecar"}, initNames(got))
+	assert.Empty(t, got.Spec.EphemeralContainers)
+
+	// CollectEphemeralContainers: ephemeral kept, sidecars only for init.
+	got = Transform(newPod(), ContainerMetricsConfig{CollectEphemeralContainers: true})
+	assert.Equal(t, []string{"my-sidecar"}, initNames(got))
+	require.Len(t, got.Spec.EphemeralContainers, 1)
 }
 
 func TestPodMetadata(t *testing.T) {
@@ -595,7 +888,7 @@ func TestPodMetadata(t *testing.T) {
 				withParentOR: true,
 			})
 			logger := zap.NewNop()
-			meta := GetMetadata(pod, metadataStore, logger)
+			meta := GetMetadata(pod, metadataStore, logger, ContainerMetricsConfig{})
 
 			require.NotNil(t, meta)
 			require.Contains(t, meta, experimentalmetricmetadata.ResourceID("test-pod-0-uid"))
@@ -609,6 +902,72 @@ func TestPodMetadata(t *testing.T) {
 	}
 }
 
+func TestGetPodContainerProperties(t *testing.T) {
+	alwaysRestart := corev1.ContainerRestartPolicyAlways
+	pod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+			UID:       types.UID("test-pod-uid"),
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+			InitContainers: []corev1.Container{
+				{Name: "regular-init"},
+				{Name: "my-sidecar", RestartPolicy: &alwaysRestart},
+			},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", ContainerID: "docker://app-id"},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "regular-init", ContainerID: "docker://regular-init-id"},
+				{Name: "my-sidecar", ContainerID: "docker://sidecar-id"},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{Name: "debugger", ContainerID: "docker://debugger-id"},
+			},
+		},
+	}
+
+	props := getPodContainerProperties(pod, zap.NewNop(), ContainerMetricsConfig{})
+
+	assert.Contains(t, props, experimentalmetricmetadata.ResourceID("app-id"))
+	assert.Contains(t, props, experimentalmetricmetadata.ResourceID("sidecar-id"))
+	assert.NotContains(t, props, experimentalmetricmetadata.ResourceID("debugger-id"))
+	assert.NotContains(t, props, experimentalmetricmetadata.ResourceID("regular-init-id"))
+
+	// Enabling ephemeral and all init containers includes them.
+	props = getPodContainerProperties(pod, zap.NewNop(), ContainerMetricsConfig{CollectAllInitContainers: true, CollectEphemeralContainers: true})
+	assert.Contains(t, props, experimentalmetricmetadata.ResourceID("app-id"))
+	assert.Contains(t, props, experimentalmetricmetadata.ResourceID("sidecar-id"))
+	assert.Contains(t, props, experimentalmetricmetadata.ResourceID("debugger-id"))
+	assert.Contains(t, props, experimentalmetricmetadata.ResourceID("regular-init-id"))
+}
+
+func TestGetPodContainerPropertiesSkipsEmptyContainerID(t *testing.T) {
+	alwaysRestart := corev1.ContainerRestartPolicyAlways
+	pod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{Name: "test-pod", Namespace: "test-namespace", UID: types.UID("test-pod-uid")},
+		Spec: corev1.PodSpec{
+			NodeName:       "test-node",
+			InitContainers: []corev1.Container{{Name: "my-sidecar", RestartPolicy: &alwaysRestart}},
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{Name: "my-sidecar", ContainerID: ""},
+			},
+			EphemeralContainerStatuses: []corev1.ContainerStatus{
+				{Name: "debugger", ContainerID: ""},
+			},
+		},
+	}
+
+	props := getPodContainerProperties(pod, zap.NewNop(), ContainerMetricsConfig{CollectEphemeralContainers: true})
+	assert.NotContains(t, props, experimentalmetricmetadata.ResourceID(""))
+}
+
 func TestPodContainerStateMetrics(t *testing.T) {
 	pod := testutils.NewPodWithContainer(
 		"1",
@@ -620,7 +979,7 @@ func TestPodContainerStateMetrics(t *testing.T) {
 	mbc.Metrics.K8sContainerStatusState.Enabled = true
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	mb := metadata.NewMetricsBuilder(mbc, receivertest.NewNopSettings(metadata.Type))
-	RecordMetrics(zap.NewNop(), mb, pod, ts)
+	RecordMetrics(zap.NewNop(), mb, pod, ts, ContainerMetricsConfig{})
 	m := mb.Emit()
 
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected_container_state.yaml"))
@@ -658,7 +1017,7 @@ func TestPodContainerReasonMetrics(t *testing.T) {
 	mbc.Metrics.K8sContainerStatusReason.Enabled = true
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	mb := metadata.NewMetricsBuilder(mbc, receivertest.NewNopSettings(metadata.Type))
-	RecordMetrics(zap.NewNop(), mb, pod, ts)
+	RecordMetrics(zap.NewNop(), mb, pod, ts, ContainerMetricsConfig{})
 	m := mb.Emit()
 
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected_container_reason.yaml"))

--- a/receiver/k8sclusterreceiver/internal/pod/pods_test.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods_test.go
@@ -102,7 +102,7 @@ func TestPodAndSidecarContainerMetricsReportCPUMetrics(t *testing.T) {
 
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	mb := metadata.NewMetricsBuilder(metadata.NewDefaultMetricsBuilderConfig(), receivertest.NewNopSettings(metadata.Type))
-	RecordMetrics(zap.NewNop(), mb, pod, ts, ContainerMetricsConfig{})
+	RecordMetrics(zap.NewNop(), mb, pod, ts, ContainerMetricsConfig{CollectSidecarContainers: true})
 	m := mb.Emit()
 	expected, err := golden.ReadMetrics(filepath.Join("testdata", "expected_sidecar.yaml"))
 	require.NoError(t, err)
@@ -244,8 +244,13 @@ func TestRecordMetricsContainerCollectionConfig(t *testing.T) {
 		wantContainers []string
 	}{
 		{
-			name:           "default collects regular and sidecar containers",
+			name:           "default collects only regular containers",
 			cfg:            ContainerMetricsConfig{},
+			wantContainers: []string{"app"},
+		},
+		{
+			name:           "sidecar containers",
+			cfg:            ContainerMetricsConfig{CollectSidecarContainers: true},
 			wantContainers: []string{"app", "my-sidecar"},
 		},
 		{
@@ -256,6 +261,11 @@ func TestRecordMetricsContainerCollectionConfig(t *testing.T) {
 		{
 			name:           "ephemeral containers",
 			cfg:            ContainerMetricsConfig{CollectEphemeralContainers: true},
+			wantContainers: []string{"app", "debugger"},
+		},
+		{
+			name:           "sidecar and ephemeral containers",
+			cfg:            ContainerMetricsConfig{CollectSidecarContainers: true, CollectEphemeralContainers: true},
 			wantContainers: []string{"app", "my-sidecar", "debugger"},
 		},
 		{
@@ -767,7 +777,7 @@ func TestTransformKeepsSidecarButDropsRegularInitContainers(t *testing.T) {
 		},
 	}
 
-	got := Transform(originalPod, ContainerMetricsConfig{CollectEphemeralContainers: true})
+	got := Transform(originalPod, ContainerMetricsConfig{CollectSidecarContainers: true, CollectEphemeralContainers: true})
 
 	require.Len(t, got.Spec.InitContainers, 1)
 	assert.Equal(t, "my-sidecar", got.Spec.InitContainers[0].Name)
@@ -815,8 +825,13 @@ func TestTransformContainerCollectionConfig(t *testing.T) {
 		return names
 	}
 
-	// Default: only sidecars, no ephemeral.
+	// Default: no init or ephemeral containers.
 	got := Transform(newPod(), ContainerMetricsConfig{})
+	assert.Empty(t, initNames(got))
+	assert.Empty(t, got.Spec.EphemeralContainers)
+
+	// CollectSidecarContainers: only sidecars, no ephemeral.
+	got = Transform(newPod(), ContainerMetricsConfig{CollectSidecarContainers: true})
 	assert.Equal(t, []string{"my-sidecar"}, initNames(got))
 	assert.Empty(t, got.Spec.EphemeralContainers)
 
@@ -825,9 +840,9 @@ func TestTransformContainerCollectionConfig(t *testing.T) {
 	assert.ElementsMatch(t, []string{"regular-init", "my-sidecar"}, initNames(got))
 	assert.Empty(t, got.Spec.EphemeralContainers)
 
-	// CollectEphemeralContainers: ephemeral kept, sidecars only for init.
+	// CollectEphemeralContainers: ephemeral kept, no init containers.
 	got = Transform(newPod(), ContainerMetricsConfig{CollectEphemeralContainers: true})
-	assert.Equal(t, []string{"my-sidecar"}, initNames(got))
+	assert.Empty(t, initNames(got))
 	require.Len(t, got.Spec.EphemeralContainers, 1)
 }
 
@@ -931,11 +946,17 @@ func TestGetPodContainerProperties(t *testing.T) {
 		},
 	}
 
+	// Default: only regular containers.
 	props := getPodContainerProperties(pod, zap.NewNop(), ContainerMetricsConfig{})
+	assert.Contains(t, props, experimentalmetricmetadata.ResourceID("app-id"))
+	assert.NotContains(t, props, experimentalmetricmetadata.ResourceID("sidecar-id"))
+	assert.NotContains(t, props, experimentalmetricmetadata.ResourceID("debugger-id"))
+	assert.NotContains(t, props, experimentalmetricmetadata.ResourceID("regular-init-id"))
 
+	// Enabling sidecars includes only the sidecar, not the regular init container.
+	props = getPodContainerProperties(pod, zap.NewNop(), ContainerMetricsConfig{CollectSidecarContainers: true})
 	assert.Contains(t, props, experimentalmetricmetadata.ResourceID("app-id"))
 	assert.Contains(t, props, experimentalmetricmetadata.ResourceID("sidecar-id"))
-	assert.NotContains(t, props, experimentalmetricmetadata.ResourceID("debugger-id"))
 	assert.NotContains(t, props, experimentalmetricmetadata.ResourceID("regular-init-id"))
 
 	// Enabling ephemeral and all init containers includes them.
@@ -964,7 +985,7 @@ func TestGetPodContainerPropertiesSkipsEmptyContainerID(t *testing.T) {
 		},
 	}
 
-	props := getPodContainerProperties(pod, zap.NewNop(), ContainerMetricsConfig{CollectEphemeralContainers: true})
+	props := getPodContainerProperties(pod, zap.NewNop(), ContainerMetricsConfig{CollectSidecarContainers: true, CollectEphemeralContainers: true})
 	assert.NotContains(t, props, experimentalmetricmetadata.ResourceID(""))
 }
 

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_ephemeral.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_ephemeral.yaml
@@ -1,0 +1,160 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: k8s.namespace.name
+          value:
+            stringValue: test-namespace
+        - key: k8s.node.name
+          value:
+            stringValue: test-node
+        - key: k8s.pod.name
+          value:
+            stringValue: test-pod-1
+        - key: k8s.pod.uid
+          value:
+            stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    scopeMetrics:
+      - metrics:
+          - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
+            gauge:
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.pod.phase
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: container.id
+          value:
+            stringValue: ""
+        - key: container.image.name
+          value:
+            stringValue: busybox
+        - key: container.image.tag
+          value:
+            stringValue: latest
+        - key: k8s.container.name
+          value:
+            stringValue: debugger
+        - key: k8s.namespace.name
+          value:
+            stringValue: test-namespace
+        - key: k8s.node.name
+          value:
+            stringValue: test-node
+        - key: k8s.pod.name
+          value:
+            stringValue: test-pod-1
+        - key: k8s.pod.uid
+          value:
+            stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    scopeMetrics:
+      - metrics:
+          - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.ready
+          - description: How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.restarts
+            unit: '{restart}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: container.id
+          value:
+            stringValue: container-id
+        - key: container.image.name
+          value:
+            stringValue: container-image-name
+        - key: container.image.tag
+          value:
+            stringValue: latest
+        - key: k8s.container.name
+          value:
+            stringValue: container-name
+        - key: k8s.namespace.name
+          value:
+            stringValue: test-namespace
+        - key: k8s.node.name
+          value:
+            stringValue: test-node
+        - key: k8s.pod.name
+          value:
+            stringValue: test-pod-1
+        - key: k8s.pod.uid
+          value:
+            stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    scopeMetrics:
+      - metrics:
+          - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+            gauge:
+              dataPoints:
+                - asDouble: 20
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.cpu_limit
+            unit: '{cpu}'
+          - description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+            gauge:
+              dataPoints:
+                - asDouble: 10
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.cpu_request
+            unit: '{cpu}'
+          - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.ready
+          - description: How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
+            gauge:
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.restarts
+            unit: '{restart}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
+          version: latest

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_sidecar.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_sidecar.yaml
@@ -1,0 +1,176 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: k8s.namespace.name
+          value:
+            stringValue: test-namespace
+        - key: k8s.node.name
+          value:
+            stringValue: test-node
+        - key: k8s.pod.name
+          value:
+            stringValue: test-pod-1
+        - key: k8s.pod.uid
+          value:
+            stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.pod.name
+          idKeys:
+            - k8s.pod.uid
+          type: k8s.pod
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    scopeMetrics:
+      - metrics:
+          - description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
+            gauge:
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.pod.phase
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: container.id
+          value:
+            stringValue: container-id
+        - key: container.image.name
+          value:
+            stringValue: container-image-name
+        - key: container.image.tag
+          value:
+            stringValue: latest
+        - key: k8s.container.name
+          value:
+            stringValue: container-name
+        - key: k8s.namespace.name
+          value:
+            stringValue: test-namespace
+        - key: k8s.node.name
+          value:
+            stringValue: test-node
+        - key: k8s.pod.name
+          value:
+            stringValue: test-pod-1
+        - key: k8s.pod.uid
+          value:
+            stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    scopeMetrics:
+      - metrics:
+          - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+            gauge:
+              dataPoints:
+                - asDouble: 20
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.cpu_limit
+            unit: '{cpu}'
+          - description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+            gauge:
+              dataPoints:
+                - asDouble: 10
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.cpu_request
+            unit: '{cpu}'
+          - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.ready
+          - description: How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
+            gauge:
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.restarts
+            unit: '{restart}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: container.id
+          value:
+            stringValue: sidecar-id
+        - key: container.image.name
+          value:
+            stringValue: sidecar-image-name
+        - key: container.image.tag
+          value:
+            stringValue: latest
+        - key: k8s.container.name
+          value:
+            stringValue: sidecar-name
+        - key: k8s.namespace.name
+          value:
+            stringValue: test-namespace
+        - key: k8s.node.name
+          value:
+            stringValue: test-node
+        - key: k8s.pod.name
+          value:
+            stringValue: test-pod-1
+        - key: k8s.pod.uid
+          value:
+            stringValue: test-pod-1-uid
+      entityRefs:
+        - descriptionKeys:
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+          idKeys:
+            - container.id
+          type: k8s.container
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
+    scopeMetrics:
+      - metrics:
+          - description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+            gauge:
+              dataPoints:
+                - asDouble: 2
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.cpu_limit
+            unit: '{cpu}'
+          - description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
+            gauge:
+              dataPoints:
+                - asDouble: 1
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.cpu_request
+            unit: '{cpu}'
+          - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.ready
+          - description: How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
+            name: k8s.container.restarts
+            unit: '{restart}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
+          version: latest

--- a/receiver/k8sclusterreceiver/internal/testutils/objects.go
+++ b/receiver/k8sclusterreceiver/internal/testutils/objects.go
@@ -332,6 +332,50 @@ func NewPodStatusWithContainer(containerName, containerID string) *corev1.PodSta
 	}
 }
 
+// NewPodSpecWithSidecarContainer returns a pod spec with a regular container plus an init
+// container configured as a sidecar (restartPolicy: Always).
+func NewPodSpecWithSidecarContainer(containerName, sidecarName string) *corev1.PodSpec {
+	spec := NewPodSpecWithContainer(containerName)
+	alwaysRestart := corev1.ContainerRestartPolicyAlways
+	spec.InitContainers = []corev1.Container{
+		{
+			Name:          sidecarName,
+			Image:         "sidecar-image-name",
+			RestartPolicy: &alwaysRestart,
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: *resource.NewQuantity(1, resource.DecimalSI),
+				},
+			},
+		},
+	}
+	return spec
+}
+
+// NewPodStatusWithSidecarContainer returns a pod status with a regular container status plus an
+// init container status for the given sidecar container.
+func NewPodStatusWithSidecarContainer(containerName, containerID, sidecarName, sidecarID string) *corev1.PodStatus {
+	status := NewPodStatusWithContainer(containerName, containerID)
+	status.InitContainerStatuses = []corev1.ContainerStatus{
+		{
+			Name:         sidecarName,
+			Ready:        true,
+			RestartCount: 1,
+			Image:        "sidecar-image-name",
+			ContainerID:  sidecarID,
+			State: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: v1.Time{Time: time.Date(1, time.January, 1, 1, 1, 1, 1, time.UTC)},
+				},
+			},
+		},
+	}
+	return status
+}
+
 func NewEvictedTerminatedPodStatusWithContainer(containerName, containerID string) *corev1.PodStatus {
 	return &corev1.PodStatus{
 		Phase:    corev1.PodFailed,

--- a/receiver/k8sclusterreceiver/receiver.go
+++ b/receiver/k8sclusterreceiver/receiver.go
@@ -223,7 +223,7 @@ func newReceiver(_ context.Context, set receiver.Settings, cfg component.Config)
 	ms := metadata.NewStore()
 	return &kubernetesReceiver{
 		dataCollector: collection.NewDataCollector(set, ms, rCfg.MetricsBuilderConfig,
-			rCfg.NodeConditionTypesToReport, rCfg.AllocatableTypesToReport),
+			rCfg.NodeConditionTypesToReport, rCfg.AllocatableTypesToReport, rCfg.podContainerMetricsConfig()),
 		resourceWatcher: newResourceWatcher(set, rCfg, ms),
 		settings:        set,
 		config:          rCfg,

--- a/receiver/k8sclusterreceiver/testdata/config.yaml
+++ b/receiver/k8sclusterreceiver/testdata/config.yaml
@@ -5,6 +5,7 @@ k8s_cluster/all_settings:
   allocatable_types_to_report: [ "cpu","memory" ]
   metadata_exporters: [ nop ]
   metadata_collection_interval: 30m
+  collect_sidecar_container_metrics: true
   collect_all_init_container_metrics: true
   collect_ephemeral_container_metrics: true
 k8s_cluster/partial_settings:

--- a/receiver/k8sclusterreceiver/testdata/config.yaml
+++ b/receiver/k8sclusterreceiver/testdata/config.yaml
@@ -5,6 +5,8 @@ k8s_cluster/all_settings:
   allocatable_types_to_report: [ "cpu","memory" ]
   metadata_exporters: [ nop ]
   metadata_collection_interval: 30m
+  collect_all_init_container_metrics: true
+  collect_ephemeral_container_metrics: true
 k8s_cluster/partial_settings:
   collection_interval: 30s
   distribution: openshift

--- a/receiver/k8sclusterreceiver/watcher.go
+++ b/receiver/k8sclusterreceiver/watcher.go
@@ -363,7 +363,10 @@ func (rw *resourceWatcher) startWatchingResources(ctx context.Context, inf share
 
 // setupInformer adds event handlers to informers and setups a metadataStore.
 func (rw *resourceWatcher) setupInformer(gvk schema.GroupVersionKind, namespace string, informer cache.SharedIndexInformer) {
-	err := informer.SetTransform(transformObject)
+	podContainerCfg := rw.config.podContainerMetricsConfig()
+	err := informer.SetTransform(func(object any) (any, error) {
+		return transformObject(object, podContainerCfg)
+	})
 	if err != nil {
 		rw.logger.Error("error setting informer transform function", zap.Error(err))
 	}
@@ -419,7 +422,7 @@ func (rw *resourceWatcher) onDelete(oldObj any) {
 func (rw *resourceWatcher) objMetadata(obj any) map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata {
 	switch o := obj.(type) {
 	case *corev1.Pod:
-		return pod.GetMetadata(o, rw.metadataStore, rw.logger)
+		return pod.GetMetadata(o, rw.metadataStore, rw.logger, rw.config.podContainerMetricsConfig())
 	case *corev1.Node:
 		return node.GetMetadata(o)
 	case *corev1.ReplicationController:

--- a/receiver/k8sclusterreceiver/watcher_test.go
+++ b/receiver/k8sclusterreceiver/watcher_test.go
@@ -894,7 +894,7 @@ func TestObjMetadata(t *testing.T) {
 		set := receivertest.NewNopSettings(metadata.Type)
 		set.Logger = zap.New(observedLogger)
 		t.Run(tt.name, func(t *testing.T) {
-			dc := &resourceWatcher{metadataStore: tt.metadataStore}
+			dc := &resourceWatcher{metadataStore: tt.metadataStore, config: &Config{}}
 
 			actual := dc.objMetadata(tt.resource)
 			require.Len(t, actual, len(tt.want))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Collect `k8s.container` metrics/entities for **sidecar containers** (init containers with `restartPolicy: Always`) by default.
- Add `collect_all_init_container_metrics` (default `false`) to also collect regular init containers.
- Add `collect_ephemeral_container_metrics` (default `false`) to also collect ephemeral (debug) containers.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42571

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- Unit tests for the full config matrix (`TestRecordMetricsContainerCollectionConfig`), `Transform`, entity metadata, and status lookup.
- Config parsing test + golden files
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
