### PR TITLE
[exporter/loadbalancing] Fix duplicate delivery on partial export of signals

### DIFF
--- a/.chloggen/44191-loadbalancing-partial-failure-consumererror.yaml
+++ b/.chloggen/44191-loadbalancing-partial-failure-consumererror.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/load_balancing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix duplicate span/log/metric delivery when a batch is partially exported across multiple backends and retry is enabled.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44191]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When a batch was split across multiple backends and some succeeded while others failed, the
+  exporter reported the whole batch as failed, so `retry_on_failure` re-sent everything --
+  including the data healthy backends had already accepted. Only the subset that actually
+  failed is retried now.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -32,7 +32,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.46.0
 	go.opentelemetry.io/otel/trace v1.46.0
 	go.uber.org/goleak v1.3.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.28.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.4
@@ -183,6 +182,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.46.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.55.0 // indirect

--- a/exporter/loadbalancingexporter/helpers.go
+++ b/exporter/loadbalancingexporter/helpers.go
@@ -4,7 +4,11 @@
 package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 
 import (
+	"errors"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -18,4 +22,28 @@ func mergeTraces(t1, t2 ptrace.Traces) ptrace.Traces {
 func mergeLogs(l1, l2 plog.Logs) plog.Logs {
 	l2.ResourceLogs().MoveAndAppendTo(l1.ResourceLogs())
 	return l1
+}
+
+// The failed*FromError helpers return the narrower failure payload a sub-exporter reported,
+// falling back to the full batch that was sent to that backend when it reported none.
+
+func failedTracesFromError(err error, fallback ptrace.Traces) ptrace.Traces {
+	if tracesErr, ok := errors.AsType[consumererror.Traces](err); ok {
+		return tracesErr.Data()
+	}
+	return fallback
+}
+
+func failedLogsFromError(err error, fallback plog.Logs) plog.Logs {
+	if logsErr, ok := errors.AsType[consumererror.Logs](err); ok {
+		return logsErr.Data()
+	}
+	return fallback
+}
+
+func failedMetricsFromError(err error, fallback pmetric.Metrics) pmetric.Metrics {
+	if metricsErr, ok := errors.AsType[consumererror.Metrics](err); ok {
+		return metricsErr.Data()
+	}
+	return fallback
 }

--- a/exporter/loadbalancingexporter/helpers_test.go
+++ b/exporter/loadbalancingexporter/helpers_test.go
@@ -4,12 +4,26 @@
 package loadbalancingexporter
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
+
+// serviceNameForEndpoint brute-forces a service name that the ring routes to wantEndpoint.
+func serviceNameForEndpoint(t *testing.T, ring *hashRing, wantEndpoint string) string {
+	t.Helper()
+	for i := range 1_000_000 {
+		name := fmt.Sprintf("svc-%d", i)
+		if ring.endpointFor([]byte(name)) == wantEndpoint {
+			return name
+		}
+	}
+	t.Fatalf("no service name routed to %q", wantEndpoint)
+	return ""
+}
 
 func TestMergeTracesTwoEmpty(t *testing.T) {
 	expectedEmpty := ptrace.NewTraces()

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -5,6 +5,7 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"strings"
@@ -13,13 +14,13 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/otel/metric"
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
@@ -32,6 +33,8 @@ const (
 )
 
 var _ exporter.Logs = (*logExporterImp)(nil)
+
+type exporterLogs map[*wrappedExporter]plog.Logs
 
 type logExporterImp struct {
 	loadBalancer *loadBalancer
@@ -120,11 +123,10 @@ func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		batches = splitLogsByAttributes(ld, e.routingAttrs)
 	}
 
-	logsByExporter := make(map[*wrappedExporter]plog.Logs, len(batches))
-	exporterEndpoints := make(map[*wrappedExporter]string, len(batches))
+	logsByExporter := make(exporterLogs, len(batches))
 
 	for routingID, lds := range batches {
-		exp, endpoint, err := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
+		exp, _, err := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
 		if err != nil {
 			return err
 		}
@@ -133,30 +135,50 @@ func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		if !ok {
 			exp.consumeWG.Add(1)
 			logsByExporter[exp] = lds
-			exporterEndpoints[exp] = endpoint
 		} else {
 			mergeLogs(logsByExporter[exp], lds)
 		}
 	}
 
-	var errs error
-	for exp, lds := range logsByExporter {
-		start := time.Now()
-		err := exp.ConsumeLogs(ctx, lds)
-		duration := time.Since(start)
+	return e.exportBatches(ctx, logsByExporter)
+}
 
-		exp.consumeWG.Done()
-		errs = multierr.Append(errs, err)
-		e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(exp.endpointAttr))
-		if err == nil {
-			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.successAttr))
-		} else {
-			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.failureAttr))
-			e.logger.Debug("failed to export logs", zap.Error(err))
+// exportToBackend sends ld to one backend, records per-backend telemetry, and signals the
+// exporter's consume wait group.
+func (e *logExporterImp) exportToBackend(ctx context.Context, exp *wrappedExporter, ld plog.Logs) error {
+	start := time.Now()
+	err := exp.ConsumeLogs(ctx, ld)
+	duration := time.Since(start)
+	exp.consumeWG.Done()
+	e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(exp.endpointAttr))
+	if err == nil {
+		e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.successAttr))
+	} else {
+		e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.failureAttr))
+		e.logger.Debug("failed to export logs", zap.Error(err))
+	}
+	return err
+}
+
+// exportBatches sends each pre-routed batch to its backend, returning a consumererror.Logs
+// carrying only the subset that failed so retries do not re-send already-delivered data.
+func (e *logExporterImp) exportBatches(ctx context.Context, batches exporterLogs) error {
+	var errs error
+	var failed []plog.Logs
+	for exp, lds := range batches {
+		if err := e.exportToBackend(ctx, exp, lds); err != nil {
+			errs = errors.Join(errs, err)
+			failed = append(failed, failedLogsFromError(err, lds))
 		}
 	}
-
-	return errs
+	if len(failed) == 0 {
+		return nil
+	}
+	// Merging into the first failed batch leaves the common single-failure case a no-op.
+	for _, lds := range failed[1:] {
+		mergeLogs(failed[0], lds)
+	}
+	return consumererror.NewLogs(errs, failed[0])
 }
 
 func splitLogsByServiceName(ld plog.Logs) map[string]plog.Logs {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -2642,4 +2643,76 @@ func newMockLogsExporter(consumelogsfn func(ctx context.Context, ld plog.Logs) e
 
 func newNopMockLogsExporter() exporter.Logs {
 	return &mockLogsExporter{Component: mockComponent{}}
+}
+
+// TestExportBatches_PropagatesSubExporterPartialFailureLogs checks that a sub-exporter's own
+// consumererror.Logs subset is propagated, not the whole batch it was sent.
+func TestExportBatches_PropagatesSubExporterPartialFailureLogs(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	// 2 records in; the sub-exporter will claim only the first failed.
+	ld := plog.NewLogs()
+	sl := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty()
+	sl.LogRecords().AppendEmpty().Body().SetStr("log-failed")
+	sl.LogRecords().AppendEmpty().Body().SetStr("log-succeeded")
+
+	subFailed := plog.NewLogs()
+	subFailed.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log-failed")
+
+	backendErr := errors.New("partial backend failure")
+	badEndpoint := endpointWithPort("bad")
+	bad := newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		return consumererror.NewLogs(backendErr, subFailed)
+	}), badEndpoint)
+
+	// exportBatches works off pre-routed batches, so no load balancer is needed here.
+	e := &logExporterImp{logger: ts.Logger, telemetry: tb}
+
+	bad.consumeWG.Add(1)
+	err := e.exportBatches(t.Context(), exporterLogs{bad: ld})
+
+	var logsErr consumererror.Logs
+	require.ErrorAs(t, err, &logsErr)
+	assert.Equal(t, 1, logsErr.Data().LogRecordCount(),
+		"should propagate sub-exporter's reported failed subset, not the full batch")
+	assert.Equal(t, "log-failed", logsErr.Data().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Str())
+}
+
+func TestConsumeLogs_PartialFailureOnlyRetriesFailedBackend(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	backendErr := errors.New("backend unavailable")
+	goodCalls := 0
+
+	endpoints := []string{"endpoint-1", "endpoint-2"}
+	ring := newHashRing(endpoints)
+	svcGood := serviceNameForEndpoint(t, ring, "endpoint-1")
+	svcBad := serviceNameForEndpoint(t, ring, "endpoint-2")
+
+	goodEndpoint := endpointWithPort("endpoint-1")
+	badEndpoint := endpointWithPort("endpoint-2")
+
+	good := newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		goodCalls++
+		return nil
+	}), goodEndpoint)
+	bad := newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		return backendErr
+	}), badEndpoint)
+
+	lb := &loadBalancer{
+		ring:      ring,
+		exporters: map[string]*wrappedExporter{goodEndpoint: good, badEndpoint: bad},
+	}
+	e := &logExporterImp{loadBalancer: lb, routingKey: svcRouting, logger: ts.Logger, telemetry: tb}
+
+	ld := mergeLogs(simpleLogWithServiceName(svcGood), simpleLogWithServiceName(svcBad))
+
+	err := e.ConsumeLogs(t.Context(), ld)
+
+	// Must be a typed error, otherwise the retry machinery re-sends the whole batch.
+	var logsErr consumererror.Logs
+	require.ErrorAs(t, err, &logsErr, "expected consumererror.Logs, got %T: %v", err, err)
+	assert.Equal(t, 1, logsErr.Data().LogRecordCount(), "failed payload should contain only the bad backend's log")
+	assert.Equal(t, 1, goodCalls, "good backend must not be re-sent")
 }

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -20,7 +20,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/metric"
 	conventions "go.opentelemetry.io/otel/semconv/v1.40.0"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
@@ -29,6 +28,8 @@ import (
 )
 
 var _ exporter.Metrics = (*metricExporterImp)(nil)
+
+type exporterMetrics map[*wrappedExporter]pmetric.Metrics
 
 type metricExporterImp struct {
 	loadBalancer *loadBalancer
@@ -130,45 +131,68 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 	// accumulated data, so merging N batches costs O(N) identity computations
 	// instead of O(N^2) — with per-stream routing keys N can easily be in the
 	// thousands per ConsumeMetrics call.
-	metricsByExporter := map[*wrappedExporter]*metrics.Merger{}
-	exporterEndpoints := map[*wrappedExporter]string{}
+	mergersByExporter := map[*wrappedExporter]*metrics.Merger{}
 
 	for routingID, mds := range batches {
-		exp, endpoint, err := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
+		exp, _, err := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
 		if err != nil {
 			return err
 		}
 
-		merger, ok := metricsByExporter[exp]
+		merger, ok := mergersByExporter[exp]
 		if !ok {
 			exp.consumeWG.Add(1)
 			merger = metrics.NewMerger(pmetric.NewMetrics())
-			metricsByExporter[exp] = merger
-			exporterEndpoints[exp] = endpoint
+			mergersByExporter[exp] = merger
 		}
 
 		merger.Merge(mds)
 	}
 
-	var errs error
-	for exp, merger := range metricsByExporter {
-		mds := merger.Metrics()
-		start := time.Now()
-		err := exp.ConsumeMetrics(ctx, mds)
-		duration := time.Since(start)
-
-		exp.consumeWG.Done()
-		errs = multierr.Append(errs, err)
-		e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(exp.endpointAttr))
-		if err == nil {
-			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.successAttr))
-		} else {
-			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.failureAttr))
-			e.logger.Debug("failed to export metrics", zap.Error(err))
-		}
+	metricsByExporter := make(exporterMetrics, len(mergersByExporter))
+	for exp, merger := range mergersByExporter {
+		metricsByExporter[exp] = merger.Metrics()
 	}
 
-	return errs
+	return e.exportBatches(ctx, metricsByExporter)
+}
+
+// exportToBackend sends md to one backend, records per-backend telemetry, and signals the
+// exporter's consume wait group.
+func (e *metricExporterImp) exportToBackend(ctx context.Context, exp *wrappedExporter, md pmetric.Metrics) error {
+	start := time.Now()
+	err := exp.ConsumeMetrics(ctx, md)
+	duration := time.Since(start)
+	exp.consumeWG.Done()
+	e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(exp.endpointAttr))
+	if err == nil {
+		e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.successAttr))
+	} else {
+		e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.failureAttr))
+		e.logger.Debug("failed to export metrics", zap.Error(err))
+	}
+	return err
+}
+
+// exportBatches sends each pre-routed batch to its backend, returning a consumererror.Metrics
+// carrying only the subset that failed so retries do not re-send already-delivered data.
+func (e *metricExporterImp) exportBatches(ctx context.Context, batches exporterMetrics) error {
+	var errs error
+	var failed []pmetric.Metrics
+	for exp, mds := range batches {
+		if err := e.exportToBackend(ctx, exp, mds); err != nil {
+			errs = errors.Join(errs, err)
+			failed = append(failed, failedMetricsFromError(err, mds))
+		}
+	}
+	if len(failed) == 0 {
+		return nil
+	}
+	// Merging into the first failed batch avoids metrics.Merge's deep copy when only one failed.
+	for _, mds := range failed[1:] {
+		metrics.Merge(failed[0], mds)
+	}
+	return consumererror.NewMetrics(errs, failed[0])
 }
 
 func splitMetricsByResourceServiceName(md pmetric.Metrics) (map[string]pmetric.Metrics, []error) {

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -1319,4 +1320,90 @@ func (e *mockMetricsExporter) ConsumeMetrics(ctx context.Context, md pmetric.Met
 		return e.consumeErr
 	}
 	return e.ConsumeMetricsFn(ctx, md)
+}
+
+// TestExportBatches_PropagatesSubExporterPartialFailureMetrics checks that a sub-exporter's own
+// consumererror.Metrics subset is propagated, not the whole batch it was sent.
+func TestExportBatches_PropagatesSubExporterPartialFailureMetrics(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	// Distinct resources so metrics.Merge does not collapse them; the sub-exporter will
+	// claim only resource "one" failed.
+	md := pmetric.NewMetrics()
+	rm1 := md.ResourceMetrics().AppendEmpty()
+	rm1.Resource().Attributes().PutStr("resource", "one")
+	appendSimpleMetricWithID(rm1, "metric-failed")
+	rm2 := md.ResourceMetrics().AppendEmpty()
+	rm2.Resource().Attributes().PutStr("resource", "two")
+	appendSimpleMetricWithID(rm2, "metric-succeeded")
+
+	subFailed := pmetric.NewMetrics()
+	rmSub := subFailed.ResourceMetrics().AppendEmpty()
+	rmSub.Resource().Attributes().PutStr("resource", "one")
+	appendSimpleMetricWithID(rmSub, "metric-failed")
+
+	backendErr := errors.New("partial backend failure")
+	badEndpoint := endpointWithPort("bad")
+	bad := newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+		return consumererror.NewMetrics(backendErr, subFailed)
+	}), badEndpoint)
+
+	// exportBatches works off pre-routed batches, so no load balancer is needed here.
+	e := &metricExporterImp{logger: ts.Logger, telemetry: tb}
+
+	bad.consumeWG.Add(1)
+	err := e.exportBatches(t.Context(), exporterMetrics{bad: md})
+
+	var metricsErr consumererror.Metrics
+	require.ErrorAs(t, err, &metricsErr)
+	require.Equal(t, 1, metricsErr.Data().ResourceMetrics().Len(),
+		"should propagate sub-exporter's reported failed subset, not the full batch")
+	assert.Equal(t, "metric-failed",
+		metricsErr.Data().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name(),
+		"failed subset should be resource 'one', not 'two'")
+}
+
+func TestConsumeMetrics_PartialFailureOnlyRetriesFailedBackend(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	backendErr := errors.New("backend unavailable")
+	goodCalls := 0
+
+	endpoints := []string{"endpoint-1", "endpoint-2"}
+	ring := newHashRing(endpoints)
+	svcGood := serviceNameForEndpoint(t, ring, "endpoint-1")
+	svcBad := serviceNameForEndpoint(t, ring, "endpoint-2")
+
+	goodEndpoint := endpointWithPort("endpoint-1")
+	badEndpoint := endpointWithPort("endpoint-2")
+
+	good := newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+		goodCalls++
+		return nil
+	}), goodEndpoint)
+	bad := newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+		return backendErr
+	}), badEndpoint)
+
+	lb := &loadBalancer{
+		ring:      ring,
+		exporters: map[string]*wrappedExporter{goodEndpoint: good, badEndpoint: bad},
+	}
+	e := &metricExporterImp{loadBalancer: lb, routingKey: svcRouting, logger: ts.Logger, telemetry: tb}
+
+	md := pmetric.NewMetrics()
+	rm1 := md.ResourceMetrics().AppendEmpty()
+	rm1.Resource().Attributes().PutStr("service.name", svcGood)
+	appendSimpleMetricWithID(rm1, "good-metric")
+	rm2 := md.ResourceMetrics().AppendEmpty()
+	rm2.Resource().Attributes().PutStr("service.name", svcBad)
+	appendSimpleMetricWithID(rm2, "bad-metric")
+
+	err := e.ConsumeMetrics(t.Context(), md)
+
+	// Must be a typed error, otherwise the retry machinery re-sends the whole batch.
+	var metricsErr consumererror.Metrics
+	require.ErrorAs(t, err, &metricsErr, "expected consumererror.Metrics, got %T: %v", err, err)
+	assert.Equal(t, 1, metricsErr.Data().ResourceMetrics().Len(), "failed payload should contain only the bad backend's resource metric")
+	assert.Equal(t, 1, goodCalls, "good backend must not be re-sent")
 }

--- a/exporter/loadbalancingexporter/resolver_k8s_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_test.go
@@ -96,13 +96,14 @@ func TestK8sResolve(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expectInit, res.Endpoints())
 
-		return &suiteContext{
-				endpoint:  endpoint,
-				clientset: cl,
-				resolver:  res,
-			}, func(*testing.T) {
-				require.NoError(t, res.shutdown(t.Context()))
-			}
+		sc := &suiteContext{
+			endpoint:  endpoint,
+			clientset: cl,
+			resolver:  res,
+		}
+		return sc, func(*testing.T) {
+			require.NoError(t, res.shutdown(t.Context()))
+		}
 	}
 	tests := []struct {
 		name              string

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -13,12 +13,12 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/metric"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
@@ -141,11 +141,7 @@ func (e *traceExporterImp) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 		}
 	}
 
-	var errs error
-	for exp, td := range exporterSegregatedTraces {
-		errs = multierr.Append(errs, e.exportToBackend(ctx, exp, td))
-	}
-	return errs
+	return e.exportBatches(ctx, exporterSegregatedTraces)
 }
 
 // consumeTracesByID routes each span to the backend for its trace ID, accumulating spans
@@ -216,11 +212,11 @@ func (e *traceExporterImp) consumeTracesByID(ctx context.Context, td ptrace.Trac
 		}
 	}
 
-	var errs error
+	batches := make(exporterTraces, len(dests))
 	for exp, d := range dests {
-		errs = multierr.Append(errs, e.exportToBackend(ctx, exp, d.traces))
+		batches[exp] = d.traces
 	}
-	return errs
+	return e.exportBatches(ctx, batches)
 }
 
 // exportToBackend sends td to one backend, records per-backend telemetry, and signals the
@@ -228,8 +224,8 @@ func (e *traceExporterImp) consumeTracesByID(ctx context.Context, td ptrace.Trac
 func (e *traceExporterImp) exportToBackend(ctx context.Context, exp *wrappedExporter, td ptrace.Traces) error {
 	start := time.Now()
 	err := exp.ConsumeTraces(ctx, td)
-	exp.consumeWG.Done()
 	duration := time.Since(start)
+	exp.consumeWG.Done()
 	e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(exp.endpointAttr))
 	if err == nil {
 		e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.successAttr))
@@ -238,6 +234,27 @@ func (e *traceExporterImp) exportToBackend(ctx context.Context, exp *wrappedExpo
 		e.logger.Debug("failed to export traces", zap.Error(err))
 	}
 	return err
+}
+
+// exportBatches sends each pre-routed batch to its backend, returning a consumererror.Traces
+// carrying only the subset that failed so retries do not re-send already-delivered data.
+func (e *traceExporterImp) exportBatches(ctx context.Context, batches exporterTraces) error {
+	var errs error
+	var failed []ptrace.Traces
+	for exp, td := range batches {
+		if err := e.exportToBackend(ctx, exp, td); err != nil {
+			errs = errors.Join(errs, err)
+			failed = append(failed, failedTracesFromError(err, td))
+		}
+	}
+	if len(failed) == 0 {
+		return nil
+	}
+	// Merging into the first failed batch leaves the common single-failure case a no-op.
+	for _, td := range failed[1:] {
+		mergeTraces(failed[0], td)
+	}
+	return consumererror.NewTraces(errs, failed[0])
 }
 
 // routingIdentifiersFromTraces reads the traces and determines an identifier that can be used to define a position on the

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -1132,4 +1133,80 @@ func TestConsumeTracesByID_NoConsumeWGLeakOnResolveError(t *testing.T) {
 	require.Error(t, e.consumeTracesByID(t.Context(), td))
 	require.True(t, waitGroupReturns(&good.consumeWG, time.Second),
 		"consumeWG leaked on resolve error: Shutdown's Wait() would hang")
+}
+
+// TestExportBatches_PropagatesSubExporterPartialFailureTraces checks that a sub-exporter's own
+// consumererror.Traces subset is propagated, not the whole batch it was sent.
+func TestExportBatches_PropagatesSubExporterPartialFailureTraces(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	// 2 spans in; the sub-exporter will claim only "span-failed" failed.
+	td := ptrace.NewTraces()
+	ss := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty()
+	ss.Spans().AppendEmpty().SetName("span-failed")
+	ss.Spans().AppendEmpty().SetName("span-succeeded")
+
+	subFailed := ptrace.NewTraces()
+	subFailed.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("span-failed")
+
+	backendErr := errors.New("partial backend failure")
+	badEndpoint := endpointWithPort("bad")
+	bad := newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
+		return consumererror.NewTraces(backendErr, subFailed)
+	}), badEndpoint)
+
+	// exportBatches works off pre-routed batches, so no load balancer is needed here.
+	e := &traceExporterImp{logger: ts.Logger, telemetry: tb}
+
+	bad.consumeWG.Add(1)
+	err := e.exportBatches(t.Context(), exporterTraces{bad: td})
+
+	var tracesErr consumererror.Traces
+	require.ErrorAs(t, err, &tracesErr)
+	assert.Equal(t, 1, tracesErr.Data().SpanCount(),
+		"should propagate sub-exporter's reported failed subset, not the full batch")
+	assert.Equal(t, "span-failed", tracesErr.Data().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Name())
+}
+
+func TestConsumeTracesByID_PartialFailureOnlyRetriesFailedBackend(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	backendErr := errors.New("backend unavailable")
+	goodCalls := 0
+
+	endpoints := []string{"endpoint-1", "endpoint-2"}
+	ring := newHashRing(endpoints)
+	tidGood := traceIDForEndpoint(t, ring, "endpoint-1")
+	tidBad := traceIDForEndpoint(t, ring, "endpoint-2")
+
+	goodEndpoint := endpointWithPort("endpoint-1")
+	badEndpoint := endpointWithPort("endpoint-2")
+
+	good := newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
+		goodCalls++
+		return nil
+	}), goodEndpoint)
+	bad := newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
+		return backendErr
+	}), badEndpoint)
+
+	lb := &loadBalancer{
+		ring:      ring,
+		exporters: map[string]*wrappedExporter{goodEndpoint: good, badEndpoint: bad},
+	}
+	e := &traceExporterImp{loadBalancer: lb, routingKey: traceIDRouting, logger: ts.Logger, telemetry: tb}
+
+	td := ptrace.NewTraces()
+	spans := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans()
+	spans.AppendEmpty().SetTraceID(tidGood)
+	spans.AppendEmpty().SetTraceID(tidBad)
+
+	err := e.consumeTracesByID(t.Context(), td)
+
+	// Must be a typed error, otherwise the retry machinery re-sends the whole batch.
+	var tracesErr consumererror.Traces
+	require.ErrorAs(t, err, &tracesErr, "expected consumererror.Traces, got %T: %v", err, err)
+	assert.Equal(t, 1, tracesErr.Data().SpanCount(), "failed payload should contain only the bad backend's span")
+	assert.Equal(t, tidBad, tracesErr.Data().ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID())
+	assert.Equal(t, 1, goodCalls, "good backend must not be re-sent")
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When a batch is split across multiple backends and some succeed while
others fail, the old code returned a plain errors.Join error covering
all data. The upstream retry_on_failure/sending_queue machinery then
retried the entire original batch, including spans/logs/metrics already
delivered to healthy backends, causing the massive duplication reported
in issue #44191.

#### What is still not fixed
Top-level `otelcol_exporter_sent_*` / `send_failed_*` remain inaccurate. `obsReportSender`
sits outside the retry sender and counts items from the original request, so any non-nil
error still marks the whole batch failed regardless of the `consumererror` payload. That
is tracked in #45015 and needs a change in collector-core: see
open-telemetry/opentelemetry-collector#13423 (and the analysis in
open-telemetry/opentelemetry-collector#13423 (comment) by @jamesmoessis). This PR is
deliberately scoped to the retry/duplication half only.

##### Prior art
This approach is not new, credit where it is due:
- #45027 by @iblancasa introduced the `consumererror` wrapping and the `failed*FromError` helpers this PR reuses. It also bundled telemetry changes that depend on the unresolved collector-core work above, and was closed by the stale bot before a code owner reviewed it.
- #47743 by @jeevan6996 independently reached the same design for #47600.
- @jamesmoessis diagnosed the retry-vs-metrics split in #45015 and raised it upstream.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #44191

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added regressions test.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
