### PR TITLE
[chore] Move skipping validation to a central .mdatagen.yaml

### DIFF
--- a/.mdatagen.yaml
+++ b/.mdatagen.yaml
@@ -1,0 +1,801 @@
+exclusions:
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor
+    feature_gates:
+      - name: opampsupervisor.Extensions
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
+    feature_gates:
+      - name: connector.servicegraph.legacyLatencyMetricNames
+        validation:
+          enabled: false
+      - name: connector.servicegraph.legacyLatencyUnitMs
+        validation:
+          enabled: false
+      - name: connector.servicegraph.virtualNode
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
+    feature_gates:
+      - name: connector.spanmetrics.excludeResourceMetrics
+        validation:
+          enabled: false
+      - name: connector.spanmetrics.includeCollectorInstanceID
+        validation:
+          enabled: false
+      - name: connector.spanmetrics.legacyMetricNames
+        validation:
+          enabled: false
+      - name: connector.spanmetrics.useSecondAsDefaultMetricsUnit
+        validation:
+          enabled: false
+      - name: spanmetrics.statusCodeConvention.useOtelPrefix
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
+    feature_gates:
+      - name: awsemf.nodimrollupdefault
+        validation:
+          enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter
+    lifecycle_test:
+      enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
+    feature_gates:
+      - name: exporter.datadogexporter.DisableAPMStats
+        validation:
+          enabled: false
+      - name: exporter.datadogexporter.TraceExportUseCustomHTTPClient
+        validation:
+          enabled: false
+      - name: exporter.datadogexporter.metricexportserializerclient
+        validation:
+          enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter
+    lifecycle_test:
+      enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
+    feature_gates:
+      - name: exporter.googlecloud.CustomMonitoredResources
+        validation:
+          enabled: false
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter
+    # we skip the generated tests since and implement our own, as we make requests to google
+    # API on new GCS exporter
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
+    feature_gates:
+      - name: exporter.prometheusexporter.DisableAddMetricSuffixes
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
+    feature_gates:
+      - name: exporter.prometheusremotewritexporter.EnableMultipleWorkers
+        validation:
+          enabled: false
+      - name: exporter.prometheusremotewritexporter.RetryOn429
+        validation:
+          enabled: false
+      - name: exporter.prometheusremotewritexporter.enableSendingRW2
+        validation:
+          enabled: false
+      - name: exporter.prometheusremotewritexporter.removeTopLevelHTTPSettings
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
+    # Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter
+    # Needed because the component intentionally fails during start-up if unable to connect to rabbitmq broker
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
+    feature_gates:
+      - name: exporter.signalfx.consumeEntityEvents
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
+    # TODO: Update the extension to make the tests pass
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
+    lifecycle_test:
+      enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
+    feature_gates:
+      - name: extension.awslogsencoding.cloudtrail.enable.user.identity.prefix
+        validation:
+          enabled: false
+      - name: extension.awslogsencoding.vpcflow.start.iso8601
+        validation:
+          enabled: false
+      - name: extension.encoding.awslogsencoding.DontEmitV0RPCConventions
+        validation:
+          enabled: false
+      - name: extension.encoding.awslogsencoding.EmitV1RPCConventions
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
+    feature_gates:
+      - name: extension.azureencoding.DontEmitV0LogConventions
+        validation:
+          enabled: false
+      - name: extension.azureencoding.EmitV1LogConventions
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
+    feature_gates:
+      - name: extension.encoding.googlecloudlogentryencoding.DontEmitV0RPCConventions
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
+    feature_gates:
+      - name: extension.healthcheck.useComponentStatus
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
+    # TODO: Update the extension to make the tests pass
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
+    # Skip life cycle tests as we need a real kubeconfig to run the lifecycle tests, as the test needs to generate a kubeconfig client. Enable them once we have a proper solution for this
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver
+    # We don't want to make actual connections to CloudFoundry api in our tests
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
+    # TODO: Update the extension to make the tests pass
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
+    # TODO: Update the extension to make the tests pass
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
+    feature_gates:
+      - name: extension.opampextension.RemoteRestarts
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
+    # TODO: Update the extension to make the tests pass
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension
+    # TODO: Update the extension to make the tests pass
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal
+    feature_gates:
+      - name: internal.coreinternal.goldendataset.DontEmitV0DatabaseConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.DontEmitV0FaaSConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.DontEmitV0HTTPConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.DontEmitV0MessagingConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.DontEmitV0NetworkConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.DontEmitV0RPCConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.EmitV1DatabaseConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.EmitV1FaaSConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.EmitV1HTTPConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.EmitV1MessagingConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.EmitV1NetworkConventions
+        validation:
+          enabled: false
+      - name: internal.coreinternal.goldendataset.EmitV1RPCConventions
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog
+    feature_gates:
+      - name: datadog.EnableOperationAndResourceNameV2
+        validation:
+          enabled: false
+      - name: datadog.EnableReceiveResourceSpansV2
+        validation:
+          enabled: false
+      - name: datadog.EnableScopeConvention
+        validation:
+          enabled: false
+      - name: exporter.datadogexporter.AddUnits
+        validation:
+          enabled: false
+      - name: exporter.datadogexporter.DisableAllMetricRemapping
+        validation:
+          enabled: false
+      - name: exporter.datadogexporter.EnableAttributeSliceMultiTagExporting
+        validation:
+          enabled: false
+      - name: exporter.datadogexporter.InferIntervalForDeltaMetrics
+        validation:
+          enabled: false
+      - name: exporter.datadogexporter.metricremappingdisabled
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata
+    feature_gates:
+      - name: pkg.experimentalmetricmetadata.useEntityEventsSpecification
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl
+    feature_gates:
+      - name: ottl.PanicDuplicateName
+        validation:
+          enabled: false
+      - name: ottl.contexts.enableOTelColContext
+        validation:
+          enabled: false
+      - name: ottl.functions.enableLambda
+        validation:
+          enabled: false
+      - name: ottl.set.allowNil
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza
+    feature_gates:
+      - name: logs.assignKeys
+        validation:
+          enabled: false
+      - name: logs.jsonParserArray
+        validation:
+          enabled: false
+      - name: parser.uri.ecscompliant
+        validation:
+          enabled: false
+      - name: stanza.synchronousLogEmitter
+        validation:
+          enabled: false
+      - name: stanza.udp.useStableNetworkAttributes
+        validation:
+          enabled: false
+      - name: stanza.windows.eventDrivenScraping
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer
+    feature_gates:
+      - name: filelog.allowFileDeletion
+        validation:
+          enabled: false
+      - name: filelog.allowHeaderMetadataParsing
+        validation:
+          enabled: false
+      - name: filelog.mtimeSortType
+        validation:
+          enabled: false
+      - name: filelog.protobufCheckpointEncoding
+        validation:
+          enabled: false
+      - name: filelog.requireExplicitTopN
+        validation:
+          enabled: false
+      - name: filelog.windows.caseInsensitive
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azurelogs
+    feature_gates:
+      - name: pkg.translator.azurelogs.DontEmitV0LogConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.azurelogs.EmitV1LogConventions
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/faro
+    feature_gates:
+      - name: pkg.translator.faro.DontEmitV0DeploymentEnvironmentConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.faro.EmitV1DeploymentEnvironmentConventions
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger
+    feature_gates:
+      - name: pkg.translator.jaeger.DontEmitV0HttpConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.jaeger.EmitV1HttpConventions
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus
+    feature_gates:
+      - name: pkg.translator.prometheus.PermissiveLabelSanitization
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/skywalking
+    feature_gates:
+      - name: translator.skywalking.useStableSemconv
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin
+    feature_gates:
+      - name: pkg.translator.zipkin.DontEmitV0CloudResourceConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.zipkin.DontEmitV0HttpConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.zipkin.DontEmitV0NetworkConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.zipkin.DontEmitV0ScopeConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.zipkin.EmitV1CloudResourceConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.zipkin.EmitV1HttpConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.zipkin.EmitV1NetworkConventions
+        validation:
+          enabled: false
+      - name: pkg.translator.zipkin.EmitV1ScopeConventions
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
+    feature_gates:
+      - name: processor.k8sattributes.DontEmitV0K8sConventions
+        validation:
+          enabled: false
+      - name: processor.k8sattributes.EmitV1K8sConventions
+        validation:
+          enabled: false
+      - name: processor.k8sattributes.ShareProcessorBetweenPipelines
+        validation:
+          enabled: false
+      - name: processor.k8sattributes.telemetry.disableOldFormatMetrics
+        validation:
+          enabled: false
+      - name: processor.k8sattributes.telemetry.enableNewFormatMetrics
+        validation:
+          enabled: false
+    lifecycle_test:
+      enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
+    feature_gates:
+      - name: metricsgeneration.MatchAttributes
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/akamai
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/alibaba/ecs
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ecs
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/eks
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/lambda
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/digitalocean
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/dynatrace
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/hetzner
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/classic
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/ibmcloud/vpc
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openstack/nova
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/oraclecloud
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/scaleway
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/tencent/cvm
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/upcloud
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/vultr
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
+    feature_gates:
+      - name: processor.tailsamplingprocessor.metricstatcountbytessampled
+        validation:
+          enabled: false
+      - name: processor.tailsamplingprocessor.metricstatcountspanssampled
+        validation:
+          enabled: false
+      - name: processor.tailsamplingprocessor.recordpolicy
+        validation:
+          enabled: false
+      - name: processor.tailsamplingprocessor.tailstorageextension
+        validation:
+          enabled: false
+      - name: processor.tailsamplingprocessor.usetracestate
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
+    feature_gates:
+      - name: transform.flatten.logs
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver
+    # TODO: Update the receiver to pass the tests
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectoryinvreceiver
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
+    feature_gates:
+      - name: receiver.apache.disableOldFormatMetrics
+        validation:
+          enabled: false
+      - name: receiver.apache.enableNewFormatMetrics
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
+    # TODO: Update the receiver to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
+    # TODO: Update the receiver to pass the tests
+    feature_gates:
+      - name: receiver.awsecscontainermetrics.DontEmitV0ContainerConventions
+        validation:
+          enabled: false
+      - name: receiver.awsecscontainermetrics.EmitV1ContainerConventions
+        validation:
+          enabled: false
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver
+    # TODO Fix this
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
+    # TODO: Update the receiver to make the tests pass
+    lifecycle_test:
+      enabled: false
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver
+    # TODO: Update the exporter to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver/internal/scraper/systemscraper
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
+    feature_gates:
+      - name: cloudfoundry.resourceAttributes.allow
+        validation:
+          enabled: false
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
+    feature_gates:
+      - name: receiver.datadogreceiver.DontEmitDeprecatedRPCServiceAttr
+        validation:
+          enabled: false
+      - name: receiver.datadogreceiver.Enable128BitTraceID
+        validation:
+          enabled: false
+      - name: receiver.datadogreceiver.EnableMultiTagParsing
+        validation:
+          enabled: false
+    # Skip lifecycle tests since there are multiple receivers that run on the same port
+    lifecycle_test:
+      enabled: false
+    # see https://github.com/cihub/seelog/issues/182
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver
+    feature_gates:
+      - name: receiver.githubreceiver.UseCheckRunID
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
+    # TODO: Update the receiver to pass the tests
+    lifecycle_test:
+      enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver
+    # start requires an encoding extension to exist
+    lifecycle_test:
+      enabled: false
+    # requires google credentials for the storage client
+    shutdown_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
+    feature_gates:
+      - name: hostmetrics.process.bootTimeCache
+        validation:
+          enabled: false
+      - name: receiver.hostmetricsreceiver.UseLinuxMemAvailable
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
+    lifecycle_test:
+      enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
+    # TODO: Update the receiver to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
+    lifecycle_test:
+      enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
+    feature_gates:
+      - name: receiver.kafkametricsreceiver.UseFranzGo
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
+    # TODO: Update the receiver to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
+    feature_gates:
+      - name: receiver.kubeletstats.cpuUsageScrapeBased
+        validation:
+          enabled: false
+    goleak:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
+    # TODO: Update the receiver to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+    feature_gates:
+      - name: postgresqlreceiver.preciselagmetrics
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
+    feature_gates:
+      - name: receiver.prometheusreceiver.EnableCreatedTimestampZeroIngestion
+        validation:
+          enabled: false
+      - name: receiver.prometheusreceiver.IgnoreScopeInfoMetric
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver
+    # TODO: Update the receiver to pass the tests
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver
+    lifecycle_test:
+      enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+    feature_gates:
+      - name: receiver.sqlserver.RemoveServerResourceAttribute
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
+    feature_gates:
+      - name: receiver.vcenter.resourcePoolMemoryUsageAttribute
+        validation:
+          enabled: false
+  - component: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
+    feature_gates:
+      - name: domainControllers.autodiscovery
+        validation:
+          enabled: false

--- a/cmd/opampsupervisor/metadata.yaml
+++ b/cmd/opampsupervisor/metadata.yaml
@@ -15,4 +15,3 @@ feature_gates:
       When enabled, the opampsupervisor can be configured with and use specific extensions from the collector ecosystem.
     from_version: v0.153.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47690
-    skip_strict_validation: true

--- a/connector/datadogconnector/metadata.yaml
+++ b/connector/datadogconnector/metadata.yaml
@@ -10,7 +10,3 @@ status:
   codeowners:
     active: [mx-psi, dineshg13, jade-guiton-dd, IbraheemA]
     emeritus: [gbbr, ankitpatel96]
-
-tests:
-  goleak:
-    skip: true

--- a/connector/failoverconnector/metadata.yaml
+++ b/connector/failoverconnector/metadata.yaml
@@ -9,7 +9,3 @@ status:
   codeowners:
     active: [akats7]
     emeritus: [fatsheep9146]
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/connector/routingconnector/metadata.yaml
+++ b/connector/routingconnector/metadata.yaml
@@ -17,7 +17,3 @@ feature_gates:
     stage: beta
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48418
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/connector/servicegraphconnector/metadata.yaml
+++ b/connector/servicegraphconnector/metadata.yaml
@@ -17,7 +17,6 @@ feature_gates:
     from_version: v0.80.0
     to_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18743
-    skip_strict_validation: true
 
   - id: "connector.servicegraph.legacyLatencyUnitMs"
     description: When enabled, connector reports latency in milliseconds, instead of seconds.
@@ -25,7 +24,6 @@ feature_gates:
     from_version: v0.89.0
     to_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27488
-    skip_strict_validation: true
   
   - id: "connector.servicegraph.virtualNode"
     description: When enabled and setting `virtual_node_peer_attributes` is not empty, the connector looks for the presence of these attributes in span to create virtual server nodes.
@@ -33,7 +31,6 @@ feature_gates:
     from_version: v0.73.0
     to_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17196
-    skip_strict_validation: true
     
 tests:
   config:

--- a/connector/spanmetricsconnector/metadata.yaml
+++ b/connector/spanmetricsconnector/metadata.yaml
@@ -18,14 +18,12 @@ feature_gates:
     stage: alpha
     from_version: v0.137.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42103
-    skip_strict_validation: true
 
   - id: connector.spanmetrics.includeCollectorInstanceID
     description: When enabled, connector add collector.instance.id to default dimensions.
     stage: beta
     from_version: v0.136.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40400
-    skip_strict_validation: true
     
   - id: connector.spanmetrics.legacyMetricNames
     description: When enabled, connector uses legacy metric names.
@@ -33,21 +31,18 @@ feature_gates:
     stage: alpha
     from_version: v0.109.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33227
-    skip_strict_validation: true
 
   - id: connector.spanmetrics.useSecondAsDefaultMetricsUnit
     description: When enabled, connector use second as default unit for duration metrics.
     stage: alpha
     from_version: v0.137.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42462
-    skip_strict_validation: true
 
   - id: spanmetrics.statusCodeConvention.useOtelPrefix
     description: When enabled, generated metrics will use `otel.status_code=ERROR` instead of `status.code=STATUS_CODE_ERROR`
     stage: alpha
     from_version: v0.141.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43000
-    skip_strict_validation: true
 
 tests:
   config:

--- a/exporter/alibabacloudlogserviceexporter/metadata.yaml
+++ b/exporter/alibabacloudlogserviceexporter/metadata.yaml
@@ -15,5 +15,3 @@ tests:
     endpoint: "http://localhost:0"
     project: "otel-testing"
     logstore: "otel-data"
-  goleak:
-    skip: true

--- a/exporter/awsemfexporter/metadata.yaml
+++ b/exporter/awsemfexporter/metadata.yaml
@@ -16,7 +16,6 @@ feature_gates:
     stage: alpha
     from_version: v0.83.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23997
-    skip_strict_validation: true
 
 tests:
   config:
@@ -24,5 +23,3 @@ tests:
     resource_to_telemetry_conversion:
       enabled: true
   expect_consumer_error: true
-  goleak:
-    skip: true

--- a/exporter/awskinesisexporter/metadata.yaml
+++ b/exporter/awskinesisexporter/metadata.yaml
@@ -8,8 +8,3 @@ status:
   distributions: [contrib]
   codeowners:
     active: [Aneurysm9, MovieStoreGuy]
-
-# TODO: Update the exporter to pass the tests
-tests:
-  skip_lifecycle: true
-

--- a/exporter/awsxrayexporter/metadata.yaml
+++ b/exporter/awsxrayexporter/metadata.yaml
@@ -20,5 +20,3 @@ tests:
   config:
     region: 'us-west-2'
   expect_consumer_error: true
-  goleak:
-    skip: true

--- a/exporter/azureblobexporter/metadata.yaml
+++ b/exporter/azureblobexporter/metadata.yaml
@@ -14,6 +14,3 @@ status:
 tests:
   config:
   expect_consumer_error: true
-  skip_lifecycle: true
-  goleak:
-    skip: true

--- a/exporter/azuredataexplorerexporter/metadata.yaml
+++ b/exporter/azuredataexplorerexporter/metadata.yaml
@@ -17,4 +17,3 @@ tests:
     application_id: "f80da32c-108c-415c-a19e-643f461a677a"
     application_key: "xx-xx-xx-xx"
     tenant_id: "21ff9e36-fbaa-43c8-98ba-00431ea10bc3"
-  skip_lifecycle: true

--- a/exporter/azuremonitorexporter/metadata.yaml
+++ b/exporter/azuremonitorexporter/metadata.yaml
@@ -15,5 +15,3 @@ tests:
     connection_string: "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/"
     instrumentation_key: b1cd0778-85fc-4677-a3fa-79d3c23e0efd
   expect_consumer_error: true
-  goleak:
-    skip: true

--- a/exporter/cassandraexporter/metadata.yaml
+++ b/exporter/cassandraexporter/metadata.yaml
@@ -8,7 +8,3 @@ status:
   distributions: [contrib]
   codeowners:
     active: [atoulme, emreyalvac]
-
-# TODO: Update the exporter to pass the tests
-tests:
-  skip_lifecycle: true

--- a/exporter/clickhouseexporter/metadata.yaml
+++ b/exporter/clickhouseexporter/metadata.yaml
@@ -15,4 +15,3 @@ status:
 tests:
   config:
     endpoint: clickhouse://localhost:9000
-  skip_lifecycle: true

--- a/exporter/datadogexporter/metadata.yaml
+++ b/exporter/datadogexporter/metadata.yaml
@@ -18,7 +18,6 @@ feature_gates:
       Datadog Exporter will not compute APM Stats
     from_version: v0.89.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28616
-    skip_strict_validation: true
 
   - id: exporter.datadogexporter.TraceExportUseCustomHTTPClient
     stage: alpha
@@ -26,7 +25,6 @@ feature_gates:
       When enabled, trace export uses the HTTP client from the exporter HTTP configs
     from_version: v0.105.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34025
-    skip_strict_validation: true
 
   - id: exporter.datadogexporter.metricexportserializerclient
     stage: beta
@@ -34,7 +32,6 @@ feature_gates:
       When enabled, metric export in datadogexporter uses the serializer exporter from the Datadog Agent.
     from_version: v0.122.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37930
-    skip_strict_validation: true
 
 tests:
   config:
@@ -49,4 +46,3 @@ tests:
   expect_consumer_error: true
   goleak:
     setup: "setupTestMain(m)"
-    skip: true

--- a/exporter/datasetexporter/metadata.yaml
+++ b/exporter/datasetexporter/metadata.yaml
@@ -14,6 +14,3 @@ tests:
   config:
     dataset_url: https://app.scalyr.com
     api_key: key-minimal
-  skip_lifecycle: true
-  goleak:
-    skip: true

--- a/exporter/dorisexporter/metadata.yaml
+++ b/exporter/dorisexporter/metadata.yaml
@@ -9,7 +9,3 @@ status:
   distributions: [contrib]
   codeowners:
     active: [atoulme, joker-star-l]
-
-# TODO: Update the exporter to pass the tests
-tests:
-  skip_lifecycle: true

--- a/exporter/googlecloudexporter/metadata.yaml
+++ b/exporter/googlecloudexporter/metadata.yaml
@@ -18,10 +18,8 @@ feature_gates:
     stage: alpha
     from_version: "v0.122.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38331
-    skip_strict_validation: true
 
 tests:
-  skip_lifecycle: true
   goleak:
     ignore:
       top:

--- a/exporter/googlecloudpubsubexporter/metadata.yaml
+++ b/exporter/googlecloudpubsubexporter/metadata.yaml
@@ -9,9 +9,7 @@ status:
   codeowners:
     active: [alexvanboxel]
 
-# TODO: Update the exporter to pass the tests
 tests:
-  skip_lifecycle: true
   goleak:
     ignore:
       top:

--- a/exporter/googlecloudstorageexporter/metadata.yaml
+++ b/exporter/googlecloudstorageexporter/metadata.yaml
@@ -11,11 +11,3 @@ status:
   codeowners:
     active: [constanca-m, braydonk]
     seeking_new: true
-
-tests:
-  # we skip the generated tests since and implement our own, as we make requests to google
-  # API on new GCS exporter
-  skip_shutdown: true
-  # we skip the generated tests since and implement our own, as we make requests to google
-  # API on new GCS exporter
-  skip_lifecycle: true

--- a/exporter/googlemanagedprometheusexporter/metadata.yaml
+++ b/exporter/googlemanagedprometheusexporter/metadata.yaml
@@ -10,7 +10,6 @@ status:
     active: [aabmass, dashpole, braydonk, jsuereth, psx95, ridwanmsharif]
 
 tests:
-  skip_lifecycle: true
   goleak:
     ignore:
       top:

--- a/exporter/kafkaexporter/metadata.yaml
+++ b/exporter/kafkaexporter/metadata.yaml
@@ -23,8 +23,6 @@ feature_gates:
 
 tests:
   config: {}
-  skip_lifecycle: true
-  skip_shutdown: true
   goleak:
     ignore:
       top:

--- a/exporter/prometheusexporter/metadata.yaml
+++ b/exporter/prometheusexporter/metadata.yaml
@@ -17,7 +17,6 @@ feature_gates:
     stage: beta
     from_version: "v0.132.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-specification/pull/4533
-    skip_strict_validation: true
 
 tests:
   config:

--- a/exporter/prometheusremotewriteexporter/metadata.yaml
+++ b/exporter/prometheusremotewriteexporter/metadata.yaml
@@ -16,25 +16,21 @@ feature_gates:
     stage: alpha
     from_version: v0.118.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36134
-    skip_strict_validation: true
   - id: exporter.prometheusremotewritexporter.RetryOn429
     description: When enabled, the Prometheus remote write exporter will retry 429 http status code. Requires exporter.prometheusremotewritexporter.metrics.RetryOn429 to be enabled.
     stage: alpha
     from_version: v0.101.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31924
-    skip_strict_validation: true
   - id: exporter.prometheusremotewritexporter.enableSendingRW2
     description: When enabled, the Prometheus remote write exporter will support sending rw2. Extra configuration is still required besides enabling this feature gate.
     stage: alpha
     from_version: v0.125.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35888
-    skip_strict_validation: true
   - id: exporter.prometheusremotewritexporter.removeTopLevelHTTPSettings
     stage: alpha
     description: "When enabled, it rejects top-level HTTP client settings (e.g. endpoint, tls, proxy_url); configure them under the http block instead."
     from_version: v0.158.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46209
-    skip_strict_validation: true
 tests:
   expect_consumer_error: true
   goleak:

--- a/exporter/pulsarexporter/metadata.yaml
+++ b/exporter/pulsarexporter/metadata.yaml
@@ -11,9 +11,7 @@ status:
     active: [dao-jun]
     emeritus: [dmitryax]
 
-# Update the exporter to pass the tests
 tests:
-  skip_lifecycle: true
   goleak:
     ignore:
       any:

--- a/exporter/rabbitmqexporter/metadata.yaml
+++ b/exporter/rabbitmqexporter/metadata.yaml
@@ -9,8 +9,3 @@ status:
   codeowners:
     active: [atoulme]
     emeritus: [swar8080]
-
-tests:
-  # Needed because the component intentionally fails during start-up if unable to connect to rabbitmq broker
-  skip_lifecycle: true
-  skip_shutdown: false

--- a/exporter/signalfxexporter/metadata.yaml
+++ b/exporter/signalfxexporter/metadata.yaml
@@ -20,7 +20,6 @@ feature_gates:
     description: Process entity events from logs pipeline and convert to dimension property updates
     from_version: v0.145.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45595
-    skip_strict_validation: true
 
 tests:
   config:

--- a/exporter/sumologicexporter/metadata.yaml
+++ b/exporter/sumologicexporter/metadata.yaml
@@ -10,10 +10,6 @@ status:
     active: [rnishtala-sumo, pankaj101A, jagan2221]
     emeritus: [aboguszewski-sumo, kasia-kujawa, mat-rumian, sumo-drosiek, chan-tim-sumo, echlebek, amdprophet]
 
-# TODO: Update the exporter to pass the tests
-tests:
-  skip_lifecycle: true
-
 telemetry:
   metrics:
     exporter_requests_bytes:

--- a/exporter/syslogexporter/metadata.yaml
+++ b/exporter/syslogexporter/metadata.yaml
@@ -8,7 +8,3 @@ status:
   distributions: [contrib]
   codeowners:
     active: [kasia-kujawa, rnishtala-sumo, andrzej-stencel]
-
-# TODO: Update the exporter to pass the tests
-tests:
-  skip_lifecycle: true

--- a/exporter/tencentcloudlogserviceexporter/metadata.yaml
+++ b/exporter/tencentcloudlogserviceexporter/metadata.yaml
@@ -9,9 +9,3 @@ status:
   codeowners:
     active: [wgliang]
     emeritus: [yiyang5055]
-
-# TODO: Update the exporter to pass the tests
-tests:
-  skip_lifecycle: true
-  goleak:
-    skip: true

--- a/extension/ackextension/metadata.yaml
+++ b/extension/ackextension/metadata.yaml
@@ -13,7 +13,3 @@ status:
   codeowners:
     active: [splunkericl]
     emeritus: [zpzhuSplunk]
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/extension/asapauthextension/metadata.yaml
+++ b/extension/asapauthextension/metadata.yaml
@@ -12,10 +12,3 @@ status:
   distributions: [contrib]
   codeowners:
     active: [jamesmoessis, MovieStoreGuy]
-
-# TODO: Update the extension to make the tests pass
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true
-  goleak:
-    skip: true

--- a/extension/awsproxy/metadata.yaml
+++ b/extension/awsproxy/metadata.yaml
@@ -14,8 +14,3 @@ status:
   distributions: [contrib]
   codeowners:
     active: [Aneurysm9, mxiamxia]
-
-tests:
-  skip_lifecycle: true
-  goleak:
-    skip: true

--- a/extension/datadogextension/metadata.yaml
+++ b/extension/datadogextension/metadata.yaml
@@ -12,8 +12,6 @@ status:
     emeritus: [jackgopack4, ankitpatel96]
 
 tests:
-  goleak:
-    skip: true
   config:
     api:
       key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/extension/encoding/awslogsencodingextension/metadata.yaml
+++ b/extension/encoding/awslogsencodingextension/metadata.yaml
@@ -25,14 +25,12 @@ feature_gates:
       When enabled, CloudTrail log userIdentity attributes will use 'aws.user_identity' prefix. This helps to preserve the attribute origin.
     from_version: v0.145.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45459
-    skip_strict_validation: true
   - id: extension.awslogsencoding.vpcflow.start.iso8601
     stage: alpha
     description: >-
       When enabled, aws.vpc.flow.start field will be formatted as ISO-8601 string instead of seconds since epoch integer.
     from_version: v0.138.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43390
-    skip_strict_validation: true
   - id: extension.encoding.awslogsencoding.DontEmitV0RPCConventions
     stage: alpha
     description: >-
@@ -41,7 +39,6 @@ feature_gates:
       Requires extension.encoding.awslogsencoding.EmitV1RPCConventions to also be enabled.
     from_version: v0.150.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47549
-    skip_strict_validation: true
   - id: extension.encoding.awslogsencoding.EmitV1RPCConventions
     stage: alpha
     description: >-
@@ -49,4 +46,3 @@ feature_gates:
       (semconv v1.40.0) instead of the deprecated rpc.system (semconv v1.38.0).
     from_version: v0.150.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47549
-    skip_strict_validation: true

--- a/extension/encoding/azureencodingextension/metadata.yaml
+++ b/extension/encoding/azureencodingextension/metadata.yaml
@@ -22,10 +22,8 @@ feature_gates:
     description: When enabled, v0 semconv log attribute names are not emitted.
     from_version: v0.149.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543
-    skip_strict_validation: true
   - id: extension.azureencoding.EmitV1LogConventions
     stage: alpha
     description: When enabled, v1 semconv log attribute names are emitted.
     from_version: v0.149.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543
-    skip_strict_validation: true

--- a/extension/encoding/googlecloudlogentryencodingextension/metadata.yaml
+++ b/extension/encoding/googlecloudlogentryencodingextension/metadata.yaml
@@ -24,7 +24,6 @@ feature_gates:
       semconv v1.38.0 attributes rpc.jsonrpc.error_code and rpc.jsonrpc.error_message.
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095
-    skip_strict_validation: true
 
 tests:
   config:

--- a/extension/googleclientauthextension/metadata.yaml
+++ b/extension/googleclientauthextension/metadata.yaml
@@ -12,7 +12,6 @@ status:
     active: [dashpole, aabmass, braydonk, jsuereth, psx95, ridwanmsharif]
 
 tests:
-  skip_lifecycle: true
   goleak:
     ignore:
       top:

--- a/extension/healthcheckextension/metadata.yaml
+++ b/extension/healthcheckextension/metadata.yaml
@@ -17,7 +17,6 @@ feature_gates:
     stage: alpha
     from_version: "v0.142.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42256
-    skip_strict_validation: true
 tests:
   config:
     endpoint: localhost:0

--- a/extension/jaegerremotesampling/metadata.yaml
+++ b/extension/jaegerremotesampling/metadata.yaml
@@ -9,7 +9,3 @@ status:
   - contrib
   codeowners:
     active: [yurishkuro, frzifus]
-
-# TODO: Update the extension to make the tests pass
-tests:
-  skip_lifecycle: true

--- a/extension/k8sleaderelector/metadata.yaml
+++ b/extension/k8sleaderelector/metadata.yaml
@@ -13,8 +13,5 @@ status:
   codeowners:
     active: [dmitryax, rakesh-garimella]
 
-# Skip life cycle tests as we need a real kubeconfig to run the lifecycle tests, as the test needs to generate a kubeconfig client. Enable them once we have a proper solution for this
 tests:
   config:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/extension/observer/cfgardenobserver/metadata.yaml
+++ b/extension/observer/cfgardenobserver/metadata.yaml
@@ -9,8 +9,3 @@ status:
   codeowners:
     active: [crobert-1, jriguera]
     emeritus: [m1rp, cemdk]
-
-# We don't want to make actual connections to CloudFoundry api in our tests
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/extension/observer/dockerobserver/metadata.yaml
+++ b/extension/observer/dockerobserver/metadata.yaml
@@ -11,8 +11,6 @@ status:
 
 # TODO: The tests are not passing on Windows. Either fix them or mark component as not supported on Windows.
 tests:
-  skip_lifecycle: true
-  skip_shutdown: true
   goleak:
     ignore:
       top:

--- a/extension/observer/ecsobserver/metadata.yaml
+++ b/extension/observer/ecsobserver/metadata.yaml
@@ -9,8 +9,3 @@ status:
   codeowners:
     active: [dmitryax]
     emeritus: [rmfitzpatrick]
-
-# TODO: Update the extension to make the tests pass
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/extension/observer/k8sobserver/metadata.yaml
+++ b/extension/observer/k8sobserver/metadata.yaml
@@ -10,10 +10,7 @@ status:
     active: [dmitryax, ChrsMark]
     emeritus: [rmfitzpatrick]
 
-# TODO: Update the extension to make the tests pass
 tests:
-  skip_lifecycle: true
-  skip_shutdown: true
   goleak:
     ignore:
       top:

--- a/extension/oidcauthextension/metadata.yaml
+++ b/extension/oidcauthextension/metadata.yaml
@@ -13,4 +13,3 @@ status:
 
 tests:
   config:
-  skip_lifecycle: true

--- a/extension/opampextension/metadata.yaml
+++ b/extension/opampextension/metadata.yaml
@@ -15,7 +15,6 @@ feature_gates:
     stage: alpha
     from_version: "v0.145.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45056
-    skip_strict_validation: true
 
 tests:
   config:

--- a/extension/storage/dbstorage/metadata.yaml
+++ b/extension/storage/dbstorage/metadata.yaml
@@ -10,7 +10,3 @@ status:
   distributions: [contrib]
   codeowners:
     active: [dmitryax, atoulme]
-
-# TODO: Update the extension to make the tests pass
-tests:
-  skip_lifecycle: true

--- a/extension/sumologicextension/metadata.yaml
+++ b/extension/sumologicextension/metadata.yaml
@@ -10,9 +10,6 @@ status:
     active: [rnishtala-sumo, pankaj101A, jagan2221]
     emeritus: [aboguszewski-sumo, kasia-kujawa, mat-rumian, sumo-drosiek, chan-tim-sumo, echlebek, amdprophet]
 
-# TODO: Update the extension to make the tests pass
 tests:
-  skip_lifecycle: true
-  skip_shutdown: true
   goleak:
     setup: "setupTestMain(m)"

--- a/internal/coreinternal/metadata.yaml
+++ b/internal/coreinternal/metadata.yaml
@@ -16,7 +16,6 @@ feature_gates:
       semconv v1.28.0 attribute db.system.
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45299
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.DontEmitV0FaaSConventions
     stage: alpha
     description: >-
@@ -24,7 +23,6 @@ feature_gates:
       semconv FaaS attributes like faas.execution.
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45293
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.DontEmitV0HTTPConventions
     stage: alpha
     description: >-
@@ -33,7 +31,6 @@ feature_gates:
       and http.client_ip.
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45293
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.DontEmitV0MessagingConventions
     stage: alpha
     description: >-
@@ -42,7 +39,6 @@ feature_gates:
       messaging.destination.kind (semconv v1.19.0).
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45077
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.DontEmitV0NetworkConventions
     stage: beta
     description: >-
@@ -50,7 +46,6 @@ feature_gates:
       semconv v1.12.0 attributes (net.host.ip, net.peer.ip, http.host, http.server_name).
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45076
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.DontEmitV0RPCConventions
     stage: beta
     description: >-
@@ -58,7 +53,6 @@ feature_gates:
       semconv RPC attributes rpc.service and peer.service.
     from_version: v0.148.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47548
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.EmitV1DatabaseConventions
     stage: alpha
     description: >-
@@ -66,7 +60,6 @@ feature_gates:
       (semconv v1.40.0) instead of the deprecated db.system (semconv v1.28.0).
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45299
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.EmitV1FaaSConventions
     stage: alpha
     description: >-
@@ -74,7 +67,6 @@ feature_gates:
       (semconv v1.40.0) alongside legacy faas.execution to support migration.
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45293
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.EmitV1HTTPConventions
     stage: alpha
     description: >-
@@ -84,7 +76,6 @@ feature_gates:
       http.client_ip to support migration.
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45293
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.EmitV1MessagingConventions
     stage: alpha
     description: >-
@@ -92,7 +83,6 @@ feature_gates:
       (semconv v1.40.0) alongside legacy messaging.destination to support migration.
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45077
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.EmitV1NetworkConventions
     stage: beta
     description: >-
@@ -104,7 +94,6 @@ feature_gates:
       translation in tests.
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45076
-    skip_strict_validation: true
   - id: internal.coreinternal.goldendataset.EmitV1RPCConventions
     stage: beta
     description: >-
@@ -113,4 +102,3 @@ feature_gates:
       peer.service to support migration.
     from_version: v0.148.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47548
-    skip_strict_validation: true

--- a/pkg/datadog/metadata.yaml
+++ b/pkg/datadog/metadata.yaml
@@ -16,7 +16,6 @@ feature_gates:
       When enabled, datadogexporter and datadogconnector use improved logic to compute operation name and resource name.
     from_version: v0.118.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36419
-    skip_strict_validation: true
 
   - id: datadog.EnableReceiveResourceSpansV2
     stage: beta
@@ -24,7 +23,6 @@ feature_gates:
       When enabled, use a refactored implementation of the span receiver which improves performance by 10% and deprecates some not-to-spec functionality.
     from_version: v0.118.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37171
-    skip_strict_validation: true
 
   - id: datadog.EnableScopeConvention
     stage: beta
@@ -32,7 +30,6 @@ feature_gates:
       When enabled, use otel.scope.name and otel.scope.version convention to set scope name and version instead of the deprecated otel.library.name and otel.library.version.
     from_version: v0.159.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49001
-    skip_strict_validation: true
 
   - id: exporter.datadogexporter.AddUnits
     stage: alpha
@@ -40,7 +37,6 @@ feature_gates:
       When enabled, the Datadog Exporter adds units to exported metrics.
     from_version: v0.157.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15280
-    skip_strict_validation: true
 
   - id: exporter.datadogexporter.DisableAllMetricRemapping
     stage: beta
@@ -48,7 +44,6 @@ feature_gates:
       When enabled the Datadog Exporter stops mapping OpenTelemetry semantic conventions to Datadog semantic conventions for all locally mapped conventions including system and runtime metrics.
     from_version: v0.146.0
     reference_url: https://docs.datadoghq.com/opentelemetry/schema_semantics/metrics_mapping/
-    skip_strict_validation: true
 
   - id: exporter.datadogexporter.EnableAttributeSliceMultiTagExporting
     stage: alpha
@@ -56,7 +51,6 @@ feature_gates:
       When enabled, attributes with slice values will have their elements turned into individual `key:value` Datadog tags.
     from_version: v0.142.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44859
-    skip_strict_validation: true
 
   - id: exporter.datadogexporter.InferIntervalForDeltaMetrics
     stage: alpha
@@ -64,7 +58,6 @@ feature_gates:
       When enabled, the exporter will infer the metrics interval for OTLP delta sums using a heuristic.
     from_version: v0.148.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46851
-    skip_strict_validation: true
 
   - id: exporter.datadogexporter.metricremappingdisabled
     stage: beta
@@ -72,4 +65,3 @@ feature_gates:
       When enabled the Datadog Exporter stops mapping OpenTelemetry semantic conventions to Datadog semantic conventions. This feature gate is only for internal use. [DEPRECATED] Use 'exporter.datadogexporter.DisableAllMetricRemapping' instead.
     from_version: v0.110.0
     reference_url: https://docs.datadoghq.com/opentelemetry/schema_semantics/metrics_mapping/
-    skip_strict_validation: true

--- a/pkg/experimentalmetricmetadata/metadata.yaml
+++ b/pkg/experimentalmetricmetadata/metadata.yaml
@@ -13,4 +13,3 @@ feature_gates:
     stage: alpha
     from_version: v0.156.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49667
-    skip_strict_validation: true

--- a/pkg/ottl/metadata.yaml
+++ b/pkg/ottl/metadata.yaml
@@ -17,25 +17,21 @@ feature_gates:
     stage: beta
     from_version: v0.141.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630
-    skip_strict_validation: true
 
   - id: "ottl.contexts.enableOTelColContext"
     description: Enable the `otelcol` context for OTTL. This allows users using `otelcol.*` paths in their OTTL statements and conditions.
     stage: beta
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46437
-    skip_strict_validation: true
 
   - id: "ottl.functions.enableLambda"
     description: Allow OTTL functions to take lambda arguments. When disabled, lambda arguments are rejected.
     stage: alpha
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48227
-    skip_strict_validation: true
 
   - id: "ottl.set.allowNil"
     description: When enabled, the set function passes nil values directly to the target.
     stage: alpha
     from_version: v0.158.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49741
-    skip_strict_validation: true

--- a/pkg/stanza/fileconsumer/metadata.yaml
+++ b/pkg/stanza/fileconsumer/metadata.yaml
@@ -16,28 +16,24 @@ feature_gates:
       When enabled, allows usage of the `delete_after_read` setting.
     from_version: v0.70.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16314
-    skip_strict_validation: true
   - id: filelog.allowHeaderMetadataParsing
     stage: beta
     description: >-
       When enabled, allows usage of the `header` setting.
     from_version: v0.73.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18198
-    skip_strict_validation: true
   - id: filelog.mtimeSortType
     stage: alpha
     description: >-
       When enabled, allows usage of `ordering_criteria.mode` = `mtime`.
     from_version: v0.89.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27812
-    skip_strict_validation: true
   - id: filelog.protobufCheckpointEncoding
     stage: beta
     description: >-
       Use protobuf encoding for checkpoint storage instead of JSON.
     from_version: v0.148.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43266
-    skip_strict_validation: true
   - id: filelog.requireExplicitTopN
     stage: alpha
     description: >-
@@ -46,14 +42,12 @@ feature_gates:
       back to the legacy default of 1.
     from_version: v0.159.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47444
-    skip_strict_validation: true
   - id: filelog.windows.caseInsensitive
     stage: beta
     description: >-
       On Windows, make matching patterns in include/exclude case insensitive.
     from_version: v0.142.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43777
-    skip_strict_validation: true
 
 telemetry:
   metrics:

--- a/pkg/stanza/metadata.yaml
+++ b/pkg/stanza/metadata.yaml
@@ -17,28 +17,24 @@ feature_gates:
       When enabled, allows usage of `assign_keys` transformer.
     from_version: v0.93.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30321
-    skip_strict_validation: true
   - id: logs.jsonParserArray
     stage: beta
     description: >-
       When enabled, allows usage of `json_array_parser`.
     from_version: v0.93.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30321
-    skip_strict_validation: true
   - id: parser.uri.ecscompliant
     stage: alpha
     description: >-
       When enabled resulting map will be in semconv compliant format.
     from_version: v0.103.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32906
-    skip_strict_validation: true
   - id: stanza.synchronousLogEmitter
     stage: alpha
     description: >-
       Prevents possible data loss in Stanza-based receivers by emitting logs synchronously.
     from_version: v0.122.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35456
-    skip_strict_validation: true
   - id: stanza.udp.useStableNetworkAttributes
     stage: alpha
     description: >-
@@ -49,11 +45,9 @@ feature_gates:
       net.peer.name).
     from_version: v0.158.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49050
-    skip_strict_validation: true
   - id: stanza.windows.eventDrivenScraping
     stage: alpha
     description: >-
       When enabled, the Stanza windows input wakes on API signals instead of polling on a fixed interval.
     from_version: v0.148.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47091
-    skip_strict_validation: true

--- a/pkg/translator/azurelogs/metadata.yaml
+++ b/pkg/translator/azurelogs/metadata.yaml
@@ -14,10 +14,8 @@ feature_gates:
     description: When enabled, v0 semconv attribute names are not emitted.
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45033
-    skip_strict_validation: true
   - id: pkg.translator.azurelogs.EmitV1LogConventions
     stage: alpha
     description: When enabled, v1 semconv attribute names are emitted.
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45033
-    skip_strict_validation: true

--- a/pkg/translator/faro/metadata.yaml
+++ b/pkg/translator/faro/metadata.yaml
@@ -17,7 +17,6 @@ feature_gates:
       Requires pkg.translator.faro.EmitV1DeploymentEnvironmentConventions to also be enabled.
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45074
-    skip_strict_validation: true
   - id: pkg.translator.faro.EmitV1DeploymentEnvironmentConventions
     stage: alpha
     description: >-
@@ -26,4 +25,3 @@ feature_gates:
       (semconv v1.26.0).
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45074
-    skip_strict_validation: true

--- a/pkg/translator/jaeger/metadata.yaml
+++ b/pkg/translator/jaeger/metadata.yaml
@@ -15,7 +15,6 @@ feature_gates:
       Requires pkg.translator.jaeger.EmitV1HttpConventions to also be enabled.
     from_version: v0.158.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45036
-    skip_strict_validation: true
   - id: pkg.translator.jaeger.EmitV1HttpConventions
     stage: alpha
     description: >-
@@ -24,4 +23,3 @@ feature_gates:
       (semconv v1.25.0).
     from_version: v0.158.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45036
-    skip_strict_validation: true

--- a/pkg/translator/prometheus/metadata.yaml
+++ b/pkg/translator/prometheus/metadata.yaml
@@ -12,4 +12,3 @@ feature_gates:
     stage: alpha
     from_version: v0.55.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8950
-    skip_strict_validation: true

--- a/pkg/translator/skywalking/metadata.yaml
+++ b/pkg/translator/skywalking/metadata.yaml
@@ -19,4 +19,3 @@ feature_gates:
       db.name, net.peer.name).
     from_version: v0.146.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44796
-    skip_strict_validation: true

--- a/pkg/translator/zipkin/metadata.yaml
+++ b/pkg/translator/zipkin/metadata.yaml
@@ -17,7 +17,6 @@ feature_gates:
       Requires pkg.translator.zipkin.EmitV1CloudResourceConventions to also be enabled.
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45080
-    skip_strict_validation: true
   - id: pkg.translator.zipkin.DontEmitV0HttpConventions
     stage: alpha
     description: >-
@@ -26,7 +25,6 @@ feature_gates:
       Requires pkg.translator.zipkin.EmitV1HttpConventions to also be enabled.
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45089
-    skip_strict_validation: true
   - id: pkg.translator.zipkin.DontEmitV0NetworkConventions
     stage: beta
     description: >-
@@ -36,7 +34,6 @@ feature_gates:
       Requires pkg.translator.zipkin.EmitV1NetworkConventions to also be enabled.
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45041
-    skip_strict_validation: true
   - id: pkg.translator.zipkin.DontEmitV0ScopeConventions
     stage: alpha
     description: >-
@@ -45,7 +42,6 @@ feature_gates:
       Requires pkg.translator.zipkin.EmitV1ScopeConventions to also be enabled.
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45089
-    skip_strict_validation: true
   - id: pkg.translator.zipkin.EmitV1CloudResourceConventions
     stage: alpha
     description: >-
@@ -54,7 +50,6 @@ feature_gates:
       (semconv v1.18.0).
     from_version: v0.155.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45080
-    skip_strict_validation: true
   - id: pkg.translator.zipkin.EmitV1HttpConventions
     stage: alpha
     description: >-
@@ -63,7 +58,6 @@ feature_gates:
       (semconv v1.25.0).
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45089
-    skip_strict_validation: true
   - id: pkg.translator.zipkin.EmitV1NetworkConventions
     stage: beta
     description: >-
@@ -73,7 +67,6 @@ feature_gates:
       peer.service (semconv v1.12.0).
     from_version: v0.147.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45041
-    skip_strict_validation: true
   - id: pkg.translator.zipkin.EmitV1ScopeConventions
     stage: alpha
     description: >-
@@ -82,4 +75,3 @@ feature_gates:
       otel.library.name and otel.library.version (semconv v1.25.0).
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45089
-    skip_strict_validation: true

--- a/processor/groupbytraceprocessor/metadata.yaml
+++ b/processor/groupbytraceprocessor/metadata.yaml
@@ -14,8 +14,6 @@ status:
     seeking_new: true
 tests:
   config:
-  goleak:
-    skip: true
 
 telemetry:
   metrics:

--- a/processor/k8sattributesprocessor/metadata.yaml
+++ b/processor/k8sattributesprocessor/metadata.yaml
@@ -241,14 +241,12 @@ feature_gates:
       When enabled, semconv legacy attributes are disabled.
     from_version: v0.145.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44589
-    skip_strict_validation: true
   - id: processor.k8sattributes.EmitV1K8sConventions
     stage: alpha
     description: >-
       When enabled, semconv stable attributes are enabled.
     from_version: v0.145.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44589
-    skip_strict_validation: true
   - id: processor.k8sattributes.ShareProcessorBetweenPipelines
     stage: alpha
     description: >-
@@ -256,27 +254,21 @@ feature_gates:
       across different signal type pipelines, reducing duplicate Kubernetes API watchers.
     from_version: v0.150.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2450
-    skip_strict_validation: true
   - id: processor.k8sattributes.telemetry.disableOldFormatMetrics
     stage: alpha
     description: >-
       When enabled, old formatted internal telemetry metrics are disabled.
     from_version: v0.146.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45871
-    skip_strict_validation: true
   - id: processor.k8sattributes.telemetry.enableNewFormatMetrics
     stage: alpha
     description: >-
       When enabled, new formatted internal telemetry metrics are enabled.
     from_version: v0.146.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45871
-    skip_strict_validation: true
 
 tests:
   config:
-  skip_lifecycle: true
-  goleak:
-    skip: true
 
 attributes:
   otelcol.signal:

--- a/processor/metricsgenerationprocessor/metadata.yaml
+++ b/processor/metricsgenerationprocessor/metadata.yaml
@@ -15,6 +15,5 @@ feature_gates:
     stage: alpha
     from_version: "v0.112.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35425
-    skip_strict_validation: true
 tests:
   config:

--- a/processor/resourcedetectionprocessor/internal/akamai/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/akamai/metadata.yaml
@@ -63,7 +63,3 @@ resource_attributes:
     description: The host instance type
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/alibaba/ecs/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/alibaba/ecs/metadata.yaml
@@ -63,7 +63,3 @@ resource_attributes:
     description: The host instance type
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/metadata.yaml
@@ -58,7 +58,3 @@ resource_attributes:
     description: The host instance type
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/metadata.yaml
@@ -94,7 +94,3 @@ resource_attributes:
     description: The cloud.region
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/aws/eks/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/metadata.yaml
@@ -64,7 +64,3 @@ resource_attributes:
     description: The EKS cluster name. This attribute is currently only available when running on EC2 instances, and requires permission to run the EC2:DescribeInstances action.
     type: string
     enabled: false
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/metadata.yaml
@@ -61,7 +61,3 @@ resource_attributes:
     description: The service.version
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/metadata.yaml
@@ -58,7 +58,3 @@ resource_attributes:
     description: The faas.version
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/azure/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/azure/metadata.yaml
@@ -68,7 +68,3 @@ resource_attributes:
     description: The hostname
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/digitalocean/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/digitalocean/metadata.yaml
@@ -33,7 +33,3 @@ resource_attributes:
     description: The hostname
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/dynatrace/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/dynatrace/metadata.yaml
@@ -6,7 +6,3 @@ status:
     alpha: [traces, metrics, logs]
   codeowners:
     active: [bacherfl, evan-bradley]
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/hetzner/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/hetzner/metadata.yaml
@@ -45,7 +45,3 @@ resource_attributes:
     description: The hostname
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/ibmcloud/classic/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/ibmcloud/classic/metadata.yaml
@@ -51,7 +51,3 @@ resource_attributes:
     description: The hostname of the instance.
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/ibmcloud/vpc/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/ibmcloud/vpc/metadata.yaml
@@ -75,7 +75,3 @@ resource_attributes:
     description: The instance profile name (e.g., bx2-2x8).
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/openstack/nova/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/openstack/nova/metadata.yaml
@@ -51,7 +51,3 @@ resource_attributes:
     description: The host instance type (Nova flavor name or ID)
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/oraclecloud/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/oraclecloud/metadata.yaml
@@ -69,7 +69,3 @@ resource_attributes:
     description: The OCI realm identifier for the isolated partition where the tenancy and resources reside, such as "oc1" or "oc2".
     enabled: true
     type: string
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/scaleway/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/scaleway/metadata.yaml
@@ -69,7 +69,3 @@ resource_attributes:
     description: The host instance type
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/tencent/cvm/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/tencent/cvm/metadata.yaml
@@ -63,7 +63,3 @@ resource_attributes:
     description: The host instance type
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/upcloud/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/upcloud/metadata.yaml
@@ -33,7 +33,3 @@ resource_attributes:
     description: The hostname
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/resourcedetectionprocessor/internal/vultr/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/vultr/metadata.yaml
@@ -39,7 +39,3 @@ resource_attributes:
     description: The hostname
     type: string
     enabled: true
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/processor/tailsamplingprocessor/metadata.yaml
+++ b/processor/tailsamplingprocessor/metadata.yaml
@@ -19,35 +19,30 @@ feature_gates:
     stage: alpha
     from_version: v0.152.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48348
-    skip_strict_validation: true
 
   - id: "processor.tailsamplingprocessor.metricstatcountspanssampled"
     description: "When enabled, a new metric stat_count_spans_sampled will be available in the tail sampling processor. Differently from stat_count_traces_sampled, this metric will count the number of spans sampled or not per sampling policy, where the original counts traces."
     stage: alpha
     from_version: v0.95.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30482
-    skip_strict_validation: true
 
   - id: "processor.tailsamplingprocessor.recordpolicy"
     description: "When enabled, attaches the name of the policy (and if applicable, composite policy) responsible for sampling a trace in the 'tailsampling.policy', 'tailsampling.composite_policy', and `tailsampling.cached_decision` attributes."
     stage: alpha
     from_version: v0.120.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35180
-    skip_strict_validation: true
 
   - id: "processor.tailsamplingprocessor.tailstorageextension"
     description: When enabled, allows configuring tail_storage to use a tail storage extension implementation.
     stage: alpha
     from_version: v0.150.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47331
-    skip_strict_validation: true
 
   - id: "processor.tailsamplingprocessor.usetracestate"
     description: "When enabled, sampling policies consult OpenTelemetry probability sampling information carried in W3C tracestate (the 'rv' and 'th' fields of the 'ot' section). The 'probabilistic' policy uses tracestate randomness for its sampling decision (falling back to the legacy FNV trace ID hash when no tracestate sampling info is present), and the processor rewrites the outgoing 'th' on sampled traces to the effective threshold across all matched policies."
     stage: alpha
     from_version: v0.154.0
     reference_url: https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/
-    skip_strict_validation: true
 
 tests:
   config:

--- a/processor/transformprocessor/metadata.yaml
+++ b/processor/transformprocessor/metadata.yaml
@@ -26,7 +26,6 @@ feature_gates:
     stage: alpha
     from_version: v0.103.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32080#issuecomment-2120764953
-    skip_strict_validation: true
     
 tests:
   config:

--- a/receiver/activedirectorydsreceiver/metadata.yaml
+++ b/receiver/activedirectorydsreceiver/metadata.yaml
@@ -240,8 +240,3 @@ metrics:
       value_type: int
     enabled: true
     stability: development
-
-# TODO: Update the receiver to pass the tests
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/receiver/activedirectoryinvreceiver/metadata.yaml
+++ b/receiver/activedirectoryinvreceiver/metadata.yaml
@@ -13,7 +13,3 @@ status:
   distributions: [contrib]
   codeowners:
     active: [pjanotti,pankaj101A, jagan2221]
-
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -35,7 +35,6 @@ feature_gates:
       Requires receiver.apache.enableNewFormatMetrics to also be enabled.
     from_version: v0.159.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47327
-    skip_strict_validation: true
   - id: receiver.apache.enableNewFormatMetrics
     stage: alpha
     description: >-
@@ -44,7 +43,6 @@ feature_gates:
       See the migration guide linked from the component README for the full mapping.
     from_version: v0.159.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47327
-    skip_strict_validation: true
 
 # Attributes marked (new) are emitted when receiver.apache.enableNewFormatMetrics is enabled.
 # All others are the original attributes, emitted by default.

--- a/receiver/awscontainerinsightreceiver/metadata.yaml
+++ b/receiver/awscontainerinsightreceiver/metadata.yaml
@@ -16,7 +16,3 @@ feature_gates:
     stage: alpha
     from_version: v0.143.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44052
-
-# TODO: Update the receiver to pass the tests
-tests:
-  skip_lifecycle: true

--- a/receiver/awsecscontainermetricsreceiver/metadata.yaml
+++ b/receiver/awsecscontainermetricsreceiver/metadata.yaml
@@ -9,11 +9,6 @@ status:
   codeowners:
     active: [Aneurysm9]
 
-# TODO: Update the receiver to pass the tests
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true
-
 feature_gates:
   - id: receiver.awsecscontainermetrics.DontEmitV0ContainerConventions
     stage: alpha
@@ -23,7 +18,6 @@ feature_gates:
       Requires receiver.awsecscontainermetrics.EmitV1ContainerConventions to also be enabled.
     from_version: v0.157.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45087
-    skip_strict_validation: true
   - id: receiver.awsecscontainermetrics.EmitV1ContainerConventions
     stage: alpha
     description: >-
@@ -31,5 +25,4 @@ feature_gates:
       instead of the deprecated container.image.tag (semconv v1.21.0).
     from_version: v0.157.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45087
-    skip_strict_validation: true
 

--- a/receiver/awslambdareceiver/metadata.yaml
+++ b/receiver/awslambdareceiver/metadata.yaml
@@ -11,8 +11,6 @@ status:
     emeritus: [axw]
 
 tests:
-  # TODO Fix this
-  skip_lifecycle: true
   config:
     s3:
       encoding: awslogs

--- a/receiver/awsxrayreceiver/metadata.yaml
+++ b/receiver/awsxrayreceiver/metadata.yaml
@@ -9,10 +9,6 @@ status:
   codeowners:
     active: [wangzlei, srprash]
 
-# TODO: Update the receiver to make the tests pass
-tests:
-  skip_lifecycle: true
-  skip_shutdown: true
 feature_gates:
   - id: receiver.awsxray.DontEmitV0HttpConventions
     stage: alpha

--- a/receiver/azureblobreceiver/metadata.yaml
+++ b/receiver/azureblobreceiver/metadata.yaml
@@ -10,8 +10,6 @@ status:
   codeowners:
     active: [eedorenko, mx-psi, dyl10s]
 
-# TODO: Update the exporter to pass the tests
 tests:
   config:
     connection_string: DefaultEndpointsProtocol=https;AccountName=accountName;AccountKey=+idLkHYcL0MUWIKYHm2j4Q==;EndpointSuffix=core.windows.net
-  skip_lifecycle: true

--- a/receiver/azureeventhubreceiver/metadata.yaml
+++ b/receiver/azureeventhubreceiver/metadata.yaml
@@ -14,4 +14,3 @@ status:
 
 tests:
   config:
-  skip_lifecycle: true

--- a/receiver/carbonreceiver/metadata.yaml
+++ b/receiver/carbonreceiver/metadata.yaml
@@ -14,7 +14,3 @@ status:
     active: [atoulme]
     emeritus: [aboguszewski-sumo]
     seeking_new: true
-
-# TODO: Update the exporter to pass the tests
-tests:
-  skip_lifecycle: true

--- a/receiver/chronyreceiver/metadata.yaml
+++ b/receiver/chronyreceiver/metadata.yaml
@@ -82,7 +82,3 @@ metrics:
       value_type: double
     attributes:
     - leap.status
-
-# TODO: Update the exporter to pass the tests
-tests:
-  skip_lifecycle: true

--- a/receiver/ciscoosreceiver/internal/scraper/systemscraper/metadata.yaml
+++ b/receiver/ciscoosreceiver/internal/scraper/systemscraper/metadata.yaml
@@ -48,5 +48,3 @@ metrics:
       value_type: double
 
 # TODO: Update the scraper to support test mode or mock SSH connections
-tests:
-  skip_lifecycle: true

--- a/receiver/cloudfoundryreceiver/metadata.yaml
+++ b/receiver/cloudfoundryreceiver/metadata.yaml
@@ -24,7 +24,5 @@ feature_gates:
     stage: beta
     from_version: "v0.117.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34824
-    skip_strict_validation: true
 tests:
   config:
-  skip_lifecycle: true

--- a/receiver/datadogreceiver/metadata.yaml
+++ b/receiver/datadogreceiver/metadata.yaml
@@ -23,23 +23,15 @@ feature_gates:
       already captured in the span name (service/method) and rpc.method.
     from_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095
-    skip_strict_validation: true
 
   - id: receiver.datadogreceiver.Enable128BitTraceID
     stage: beta
     description: When enabled, reconstructs full 128-bit TraceIDs for spans coming from Datadog instrumented services so they correlate with OpenTelemetry spans. Enabled by default; disable to fall back to 64-bit (zero-padded) TraceIDs.
     from_version: v0.125.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36926
-    skip_strict_validation: true
 
   - id: receiver.datadogreceiver.EnableMultiTagParsing
     stage: alpha
     description: When enabled, parses `key:value` tags with duplicate keys into a slice attribute.
     from_version: v0.142.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44747
-    skip_strict_validation: true
-
-tests:
-  skip_lifecycle: true # Skip lifecycle tests since there are multiple receivers that run on the same port
-  goleak:
-    skip: true # see https://github.com/cihub/seelog/issues/182

--- a/receiver/githubreceiver/metadata.yaml
+++ b/receiver/githubreceiver/metadata.yaml
@@ -25,7 +25,6 @@ feature_gates:
     stage: beta
     from_version: "v0.151.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44856
-    skip_strict_validation: true
 
 resource_attributes:
   vcs.owner.name:

--- a/receiver/googlecloudmonitoringreceiver/metadata.yaml
+++ b/receiver/googlecloudmonitoringreceiver/metadata.yaml
@@ -15,9 +15,5 @@ status:
     active: [dashpole, TylerHelmuth]
     emeritus: [abhishek-at-cloudwerx]
 
-# TODO: Update the receiver to pass the tests
 tests:
-  skip_lifecycle: true
   config:
-  goleak:
-    skip: true

--- a/receiver/googlecloudpubsubpushreceiver/metadata.yaml
+++ b/receiver/googlecloudpubsubpushreceiver/metadata.yaml
@@ -10,12 +10,6 @@ status:
     active: [constanca-m]
     emeritus: [axw]
 
-tests:
-  # start requires an encoding extension to exist
-  skip_lifecycle: true
-  # requires google credentials for the storage client
-  skip_shutdown: true
-
 telemetry:
   metrics:
     gcp.pubsub.input.uncompressed.size:

--- a/receiver/googlecloudpubsubreceiver/metadata.yaml
+++ b/receiver/googlecloudpubsubreceiver/metadata.yaml
@@ -44,7 +44,6 @@ tests:
     user_agent: user-agent
     timeout: 20s
     subscription: projects/my-project/subscriptions/otlp-subscription
-  skip_lifecycle: true
   goleak:
     ignore:
       # See https://github.com/census-instrumentation/opencensus-go/issues/1191 for more information.

--- a/receiver/googlecloudspannerreceiver/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/metadata.yaml
@@ -12,5 +12,3 @@ status:
     emeritus: [architjugran, varunraiko, harishbohara11, dsimil]
 tests:
   config:
-  goleak:
-    skip: true

--- a/receiver/hostmetricsreceiver/metadata.yaml
+++ b/receiver/hostmetricsreceiver/metadata.yaml
@@ -20,13 +20,11 @@ feature_gates:
     stage: beta
     from_version: "v0.98.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/28849
-    skip_strict_validation: true
   - id: receiver.hostmetricsreceiver.UseLinuxMemAvailable
     description: When enabled, the used value for the system.memory.usage and system.memory.utilization metrics will be based on the Linux kernel's MemAvailable statistic instead of MemFree, Buffers, and Cached.
     stage: beta
     from_version: "v0.137.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42221
-    skip_strict_validation: true
 
 tests:
   config:

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -1050,6 +1050,3 @@ metrics:
 
 tests:
   config:
-  skip_lifecycle: true
-  goleak:
-    skip: true

--- a/receiver/k8seventsreceiver/metadata.yaml
+++ b/receiver/k8seventsreceiver/metadata.yaml
@@ -13,9 +13,7 @@ status:
   codeowners:
     active: [dmitryax, TylerHelmuth, ChrsMark]
 
-# TODO: Update the receiver to pass the tests
 tests:
-  skip_lifecycle: true
   goleak:
     ignore:
       any:

--- a/receiver/k8sobjectsreceiver/metadata.yaml
+++ b/receiver/k8sobjectsreceiver/metadata.yaml
@@ -16,6 +16,3 @@ status:
 
 tests:
   config:
-  skip_lifecycle: true
-  goleak:
-    skip: true

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -22,7 +22,6 @@ feature_gates:
     from_version: v0.137.0
     to_version: v0.154.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41480
-    skip_strict_validation: true
 
 resource_attributes:
   kafka.cluster.alias:

--- a/receiver/kafkareceiver/metadata.yaml
+++ b/receiver/kafkareceiver/metadata.yaml
@@ -18,9 +18,7 @@ status:
     active: [pavolloffay, MovieStoreGuy, paulojmdias]
     emeritus: [axw]
 
-# TODO: Update the receiver to pass the tests
 tests:
-  skip_lifecycle: true
   goleak:
     ignore:
       top:

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -670,12 +670,9 @@ feature_gates:
       UsageNanoCores value.
     from_version: v0.156.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49477
-    skip_strict_validation: true
 
 tests:
   config:
     ca_file: "testdata/testcert.crt"
     key_file: "testdata/testkey.key"
     cert_file: "testdata/testcert.crt"
-  goleak:
-    skip: true

--- a/receiver/podmanreceiver/metadata.yaml
+++ b/receiver/podmanreceiver/metadata.yaml
@@ -144,7 +144,3 @@ metrics:
       value_type: int
       monotonic: true
       aggregation_temporality: cumulative
-
-# TODO: Update the receiver to pass the tests
-tests:
-  skip_lifecycle: true

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -24,7 +24,6 @@ feature_gates:
     stage: beta
     from_version: "v0.89.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30831
-    skip_strict_validation: true
 
   - id: receiver.postgresql.connectionPool
     description: Use of connection pooling

--- a/receiver/prometheusreceiver/metadata.yaml
+++ b/receiver/prometheusreceiver/metadata.yaml
@@ -31,7 +31,6 @@ feature_gates:
       This is disabled by default due to worse CPU performance with higher metric volumes.
     from_version: v0.113.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40355
-    skip_strict_validation: true
 
   - id: receiver.prometheusreceiver.IgnoreScopeInfoMetric
     stage: beta
@@ -39,4 +38,3 @@ feature_gates:
       When enabled, the `otel_scope_info` metric is ignored for scope attribute extraction.
     from_version: v0.148.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41502
-    skip_strict_validation: true

--- a/receiver/pulsarreceiver/metadata.yaml
+++ b/receiver/pulsarreceiver/metadata.yaml
@@ -14,9 +14,7 @@ status:
     active: [dao-jun]
     emeritus: [dmitryax]
 
-# TODO: Update the receiver to pass the tests
 tests:
-  skip_lifecycle: true
   goleak:
     ignore:
       any:

--- a/receiver/solacereceiver/metadata.yaml
+++ b/receiver/solacereceiver/metadata.yaml
@@ -19,7 +19,6 @@ tests:
       sasl_plain:
         username: username
         password: passwd
-  skip_lifecycle: true
 
 telemetry:
   metrics:

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -1445,7 +1445,6 @@ feature_gates:
       When enabled, the server.address and server.port resource attributes are removed from metrics.
     from_version: v0.129.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40141      
-    skip_strict_validation: true
 
 tests:
   config:

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -20,7 +20,6 @@ feature_gates:
     stage: beta
     from_version: "v0.153.0"
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33741
-    skip_strict_validation: true
 
 resource_attributes:
   vcenter.cluster.name:

--- a/receiver/windowseventlogreceiver/metadata.yaml
+++ b/receiver/windowseventlogreceiver/metadata.yaml
@@ -29,4 +29,3 @@ feature_gates:
       start collecting logs from specified channel.
     from_version: v0.150.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44156
-    skip_strict_validation: true


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Follows open-telemetry/opentelemetry-collector/pull/15682, adopts centralized mdatagen file.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
