### PR TITLE
Translate OTLP Start timestamp to PRWv2 Start timestamp

### DIFF
--- a/.chloggen/prwv2-start-timestamp-exporter.yaml
+++ b/.chloggen/prwv2-start-timestamp-exporter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheus_remote_write
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Send the start timestamp of cumulative sums, histograms and summaries as `start_timestamp` when using the Remote Write 2.0 protobuf message.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50089]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/prwv2-start-timestamp.yaml
+++ b/.chloggen/prwv2-start-timestamp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`FromMetricsV2` now translates the start timestamp of cumulative sums, histograms and summaries into `start_timestamp`."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50089]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/translator/prometheusremotewrite/helper_v2.go
+++ b/pkg/translator/prometheusremotewrite/helper_v2.go
@@ -78,12 +78,13 @@ func (c *prometheusConverterV2) addResourceTargetInfoV2(resource pcommon.Resourc
 }
 
 // addSampleWithLabels is a helper function to create and add a sample with labels
-func (c *prometheusConverterV2) addSampleWithLabels(sampleValue float64, timestamp int64, noRecordedValue bool,
+func (c *prometheusConverterV2) addSampleWithLabels(sampleValue float64, timestamp, startTimestamp int64, noRecordedValue bool,
 	baseName string, baseLabels []prompb.Label, labelName, labelValue string, metadata metadata,
 ) {
 	sample := &writev2.Sample{
-		Value:     sampleValue,
-		Timestamp: timestamp,
+		Value:          sampleValue,
+		Timestamp:      timestamp,
+		StartTimestamp: startTimestamp,
 	}
 	if noRecordedValue {
 		sample.Value = math.Float64frombits(value.StaleNaN)
@@ -102,6 +103,7 @@ func (c *prometheusConverterV2) addSummaryDataPoints(dataPoints pmetric.SummaryD
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
 		timestamp := convertTimeStamp(pt.Timestamp())
+		startTimestamp := convertTimeStamp(pt.StartTimestamp())
 		baseLabels, err := createAttributes(resource, pt.Attributes(), scope, settings.ExternalLabels, nil, false, c.labelNamer, settings.DisableScopeInfo)
 		if err != nil {
 			errs = multierr.Append(errs, err)
@@ -110,14 +112,14 @@ func (c *prometheusConverterV2) addSummaryDataPoints(dataPoints pmetric.SummaryD
 		noRecordedValue := pt.Flags().NoRecordedValue()
 
 		// Add sum and count samples
-		c.addSampleWithLabels(pt.Sum(), timestamp, noRecordedValue, baseName+sumStr, baseLabels, "", "", metadata)
-		c.addSampleWithLabels(float64(pt.Count()), timestamp, noRecordedValue, baseName+countStr, baseLabels, "", "", metadata)
+		c.addSampleWithLabels(pt.Sum(), timestamp, startTimestamp, noRecordedValue, baseName+sumStr, baseLabels, "", "", metadata)
+		c.addSampleWithLabels(float64(pt.Count()), timestamp, startTimestamp, noRecordedValue, baseName+countStr, baseLabels, "", "", metadata)
 
 		// Process quantiles
 		for i := 0; i < pt.QuantileValues().Len(); i++ {
 			qt := pt.QuantileValues().At(i)
 			percentileStr := strconv.FormatFloat(qt.Quantile(), 'f', -1, 64)
-			c.addSampleWithLabels(qt.Value(), timestamp, noRecordedValue, baseName, baseLabels, quantileStr, percentileStr, metadata)
+			c.addSampleWithLabels(qt.Value(), timestamp, startTimestamp, noRecordedValue, baseName, baseLabels, quantileStr, percentileStr, metadata)
 		}
 	}
 	return errs
@@ -130,6 +132,7 @@ func (c *prometheusConverterV2) addHistogramDataPoints(dataPoints pmetric.Histog
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
 		timestamp := convertTimeStamp(pt.Timestamp())
+		startTimestamp := convertTimeStamp(pt.StartTimestamp())
 		baseLabels, err := createAttributes(resource, pt.Attributes(), scope, settings.ExternalLabels, nil, false, c.labelNamer, settings.DisableScopeInfo)
 		if err != nil {
 			errs = multierr.Append(errs, err)
@@ -156,11 +159,11 @@ func (c *prometheusConverterV2) addHistogramDataPoints(dataPoints pmetric.Histog
 		// If the sum is unset, it indicates the _sum metric point should be
 		// omitted
 		if pt.HasSum() {
-			c.addSampleWithLabels(pt.Sum(), timestamp, noRecordedValue, baseName+sumStr, baseLabels, "", "", metadata)
+			c.addSampleWithLabels(pt.Sum(), timestamp, startTimestamp, noRecordedValue, baseName+sumStr, baseLabels, "", "", metadata)
 		}
 
 		// treat count as a sample in an individual TimeSeries
-		c.addSampleWithLabels(float64(pt.Count()), timestamp, noRecordedValue, baseName+countStr, baseLabels, "", "", metadata)
+		c.addSampleWithLabels(float64(pt.Count()), timestamp, startTimestamp, noRecordedValue, baseName+countStr, baseLabels, "", "", metadata)
 
 		// cumulative count for conversion to cumulative histogram
 		var cumulativeCount uint64
@@ -170,10 +173,10 @@ func (c *prometheusConverterV2) addHistogramDataPoints(dataPoints pmetric.Histog
 			bound := pt.ExplicitBounds().At(i)
 			cumulativeCount += pt.BucketCounts().At(i)
 			boundStr := strconv.FormatFloat(bound, 'f', -1, 64)
-			c.addSampleWithLabels(float64(cumulativeCount), timestamp, noRecordedValue, baseName+bucketStr, baseLabels, leStr, boundStr, metadata)
+			c.addSampleWithLabels(float64(cumulativeCount), timestamp, startTimestamp, noRecordedValue, baseName+bucketStr, baseLabels, leStr, boundStr, metadata)
 		}
 		// add le=+Inf bucket
-		c.addSampleWithLabels(float64(pt.Count()), timestamp, noRecordedValue, baseName+bucketStr, baseLabels, leStr, pInfStr, metadata)
+		c.addSampleWithLabels(float64(pt.Count()), timestamp, startTimestamp, noRecordedValue, baseName+bucketStr, baseLabels, leStr, pInfStr, metadata)
 
 		// TODO implement exemplars support
 	}

--- a/pkg/translator/prometheusremotewrite/helper_v2_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_v2_test.go
@@ -164,6 +164,7 @@ func TestAddResourceTargetInfoV2(t *testing.T) {
 
 func TestPrometheusConverterV2_AddSummaryDataPoints(t *testing.T) {
 	ts := pcommon.Timestamp(time.Now().UnixNano())
+	startTs := ts - pcommon.Timestamp(time.Hour)
 	tests := []struct {
 		name   string
 		metric func() pmetric.Metric
@@ -178,7 +179,10 @@ func TestPrometheusConverterV2_AddSummaryDataPoints(t *testing.T) {
 
 				dp := metric.Summary().DataPoints().AppendEmpty()
 				dp.SetTimestamp(ts)
-				dp.SetStartTimestamp(ts)
+				dp.SetStartTimestamp(startTs)
+				qt := dp.QuantileValues().AppendEmpty()
+				qt.SetQuantile(0.5)
+				qt.SetValue(1)
 
 				return metric
 			},
@@ -189,11 +193,15 @@ func TestPrometheusConverterV2_AddSummaryDataPoints(t *testing.T) {
 				sumLabels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_summary" + sumStr},
 				}
+				quantileLabels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_summary"},
+					{Name: model.QuantileLabel, Value: "0.5"},
+				}
 				return map[uint64]*writev2.TimeSeries{
 					timeSeriesSignature(labels): {
 						LabelsRefs: []uint32{1, 3},
 						Samples: []writev2.Sample{
-							{Value: 0, Timestamp: convertTimeStamp(ts)},
+							{Value: 0, Timestamp: convertTimeStamp(ts), StartTimestamp: convertTimeStamp(startTs)},
 						},
 						Metadata: writev2.Metadata{
 							Type:    writev2.Metadata_METRIC_TYPE_SUMMARY,
@@ -203,7 +211,17 @@ func TestPrometheusConverterV2_AddSummaryDataPoints(t *testing.T) {
 					timeSeriesSignature(sumLabels): {
 						LabelsRefs: []uint32{1, 2},
 						Samples: []writev2.Sample{
-							{Value: 0, Timestamp: convertTimeStamp(ts)},
+							{Value: 0, Timestamp: convertTimeStamp(ts), StartTimestamp: convertTimeStamp(startTs)},
+						},
+						Metadata: writev2.Metadata{
+							Type:    writev2.Metadata_METRIC_TYPE_SUMMARY,
+							HelpRef: 0,
+						},
+					},
+					timeSeriesSignature(quantileLabels): {
+						LabelsRefs: []uint32{1, 4, 5, 6},
+						Samples: []writev2.Sample{
+							{Value: 1, Timestamp: convertTimeStamp(ts), StartTimestamp: convertTimeStamp(startTs)},
 						},
 						Metadata: writev2.Metadata{
 							Type:    writev2.Metadata_METRIC_TYPE_SUMMARY,
@@ -286,6 +304,7 @@ func TestPrometheusConverterV2_AddSummaryDataPoints(t *testing.T) {
 
 func TestPrometheusConverterV2_AddHistogramDataPoints(t *testing.T) {
 	ts := pcommon.Timestamp(time.Now().UnixNano())
+	startTs := ts - pcommon.Timestamp(time.Hour)
 	tests := []struct {
 		name     string
 		metric   func() pmetric.Metric
@@ -303,7 +322,7 @@ func TestPrometheusConverterV2_AddHistogramDataPoints(t *testing.T) {
 
 				pt := metric.Histogram().DataPoints().AppendEmpty()
 				pt.SetTimestamp(ts)
-				pt.SetStartTimestamp(ts)
+				pt.SetStartTimestamp(startTs)
 
 				return metric
 			},
@@ -319,7 +338,7 @@ func TestPrometheusConverterV2_AddHistogramDataPoints(t *testing.T) {
 					timeSeriesSignature(infLabels): {
 						LabelsRefs: []uint32{1, 3, 4, 5},
 						Samples: []writev2.Sample{
-							{Value: 0, Timestamp: convertTimeStamp(ts)},
+							{Value: 0, Timestamp: convertTimeStamp(ts), StartTimestamp: convertTimeStamp(startTs)},
 						},
 						Metadata: writev2.Metadata{
 							Type:    writev2.Metadata_METRIC_TYPE_HISTOGRAM,
@@ -329,7 +348,7 @@ func TestPrometheusConverterV2_AddHistogramDataPoints(t *testing.T) {
 					timeSeriesSignature(labels): {
 						LabelsRefs: []uint32{1, 2},
 						Samples: []writev2.Sample{
-							{Value: 0, Timestamp: convertTimeStamp(ts)},
+							{Value: 0, Timestamp: convertTimeStamp(ts), StartTimestamp: convertTimeStamp(startTs)},
 						},
 						Metadata: writev2.Metadata{
 							Type:    writev2.Metadata_METRIC_TYPE_HISTOGRAM,
@@ -516,6 +535,7 @@ func TestPrometheusConverterV2_AddSampleWithLabels(t *testing.T) {
 		name            string
 		sampleValue     float64
 		timestamp       int64
+		startTimestamp  int64
 		noRecordedValue bool
 		baseName        string
 		baseLabels      []prompb.Label
@@ -584,6 +604,39 @@ func TestPrometheusConverterV2_AddSampleWithLabels(t *testing.T) {
 						LabelsRefs: []uint32{1, 2, 3, 4},
 						Samples: []writev2.Sample{
 							{Value: 100.0, Timestamp: 1234567890000},
+						},
+						Metadata: writev2.Metadata{
+							Type:    writev2.Metadata_METRIC_TYPE_COUNTER,
+							HelpRef: 5,
+							UnitRef: 0,
+						},
+					},
+				}
+			},
+		},
+		{
+			name:           "sample with start timestamp",
+			sampleValue:    7.0,
+			timestamp:      1234567890000,
+			startTimestamp: 1234567880000,
+			baseName:       "test_metric_with_start",
+			baseLabels: []prompb.Label{
+				{Name: "base_label", Value: "base_value"},
+			},
+			metadata: metadata{
+				Type: writev2.Metadata_METRIC_TYPE_COUNTER,
+				Help: "Test counter",
+			},
+			want: func() map[uint64]*writev2.TimeSeries {
+				labels := []prompb.Label{
+					{Name: "base_label", Value: "base_value"},
+					{Name: model.MetricNameLabel, Value: "test_metric_with_start"},
+				}
+				return map[uint64]*writev2.TimeSeries{
+					timeSeriesSignature(labels): {
+						LabelsRefs: []uint32{1, 2, 3, 4},
+						Samples: []writev2.Sample{
+							{Value: 7.0, Timestamp: 1234567890000, StartTimestamp: 1234567880000},
 						},
 						Metadata: writev2.Metadata{
 							Type:    writev2.Metadata_METRIC_TYPE_COUNTER,
@@ -705,6 +758,7 @@ func TestPrometheusConverterV2_AddSampleWithLabels(t *testing.T) {
 			converter.addSampleWithLabels(
 				tt.sampleValue,
 				tt.timestamp,
+				tt.startTimestamp,
 				tt.noRecordedValue,
 				tt.baseName,
 				tt.baseLabels,

--- a/pkg/translator/prometheusremotewrite/histograms_v2.go
+++ b/pkg/translator/prometheusremotewrite/histograms_v2.go
@@ -21,14 +21,16 @@ import (
 // histograms.go); it produces a writev2.Histogram with custom buckets.
 func explicitToNHCBHistogramV2(pt pmetric.HistogramDataPoint) (writev2.Histogram, error) {
 	timestamp := convertTimeStamp(pt.Timestamp())
+	startTimestamp := convertTimeStamp(pt.StartTimestamp())
 
 	if pt.Flags().NoRecordedValue() {
 		// Staleness is signaled by a stale-NaN Sum; Count is ignored.
 		// https://prometheus.io/docs/specs/native_histograms/#staleness-markers
 		return writev2.Histogram{
-			Schema:    histogram.CustomBucketsSchema,
-			Sum:       math.Float64frombits(value.StaleNaN),
-			Timestamp: timestamp,
+			Schema:         histogram.CustomBucketsSchema,
+			Sum:            math.Float64frombits(value.StaleNaN),
+			Timestamp:      timestamp,
+			StartTimestamp: startTimestamp,
 		}, nil
 	}
 
@@ -36,14 +38,17 @@ func explicitToNHCBHistogramV2(pt pmetric.HistogramDataPoint) (writev2.Histogram
 	if err != nil {
 		return writev2.Histogram{}, err
 	}
+	var out writev2.Histogram
 	switch {
 	case h != nil:
-		return writev2.FromIntHistogram(timestamp, h), nil
+		out = writev2.FromIntHistogram(timestamp, h)
 	case fh != nil:
-		return writev2.FromFloatHistogram(timestamp, fh), nil
+		out = writev2.FromFloatHistogram(timestamp, fh)
 	default:
 		return writev2.Histogram{}, errors.New("convertnhcb produced neither an integer nor a float histogram")
 	}
+	out.StartTimestamp = startTimestamp
+	return out, nil
 }
 
 func (c *prometheusConverterV2) addExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
@@ -122,6 +127,9 @@ func exponentialToNativeHistogramV2(p pmetric.ExponentialHistogramDataPoint) (wr
 		NegativeDeltas: nDeltas,
 
 		Timestamp: convertTimeStamp(p.Timestamp()),
+		// Cumulative histograms count from their start timestamp, which is the
+		// created timestamp Prometheus expects.
+		StartTimestamp: convertTimeStamp(p.StartTimestamp()),
 	}
 
 	if p.Flags().NoRecordedValue() {

--- a/pkg/translator/prometheusremotewrite/histograms_v2_test.go
+++ b/pkg/translator/prometheusremotewrite/histograms_v2_test.go
@@ -415,14 +415,16 @@ func BenchmarkConvertBucketLayoutV2(b *testing.B) {
 }
 
 func TestExplicitToNHCBHistogramV2(t *testing.T) {
+	startTimestamp := testHistTimestamp - pcommon.Timestamp(time.Hour)
 	tests := []struct {
-		name        string
-		hist        func() pmetric.HistogramDataPoint
-		wantValues  []float64
-		wantCount   uint64
-		wantSum     float64
-		wantBuckets []nhcbBucket
-		stale       bool
+		name               string
+		hist               func() pmetric.HistogramDataPoint
+		wantValues         []float64
+		wantCount          uint64
+		wantSum            float64
+		wantBuckets        []nhcbBucket
+		wantStartTimestamp int64
+		stale              bool
 	}{
 		{
 			name:        "consistent count and buckets",
@@ -431,6 +433,19 @@ func TestExplicitToNHCBHistogramV2(t *testing.T) {
 			wantCount:   10,
 			wantSum:     42.5,
 			wantBuckets: []nhcbBucket{{1, 1}, {2, 3}, {3, 6}, {math.Inf(1), 10}},
+		},
+		{
+			name: "start timestamp",
+			hist: func() pmetric.HistogramDataPoint {
+				pt := newTestExplicitHistogram().Histogram().DataPoints().At(0)
+				pt.SetStartTimestamp(startTimestamp)
+				return pt
+			},
+			wantValues:         []float64{1, 2, 3},
+			wantCount:          10,
+			wantSum:            42.5,
+			wantBuckets:        []nhcbBucket{{1, 1}, {2, 3}, {3, 6}, {math.Inf(1), 10}},
+			wantStartTimestamp: convertTimeStamp(startTimestamp),
 		},
 		{
 			// Count below the bucket sum is clamped up so the +Inf bucket stays non-negative.
@@ -510,6 +525,7 @@ func TestExplicitToNHCBHistogramV2(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, histogram.CustomBucketsSchema, h.Schema, "must be NHCB schema -53")
 			assert.Equal(t, convertTimeStamp(testHistTimestamp), h.Timestamp)
+			assert.Equal(t, tt.wantStartTimestamp, h.StartTimestamp, "start timestamp")
 
 			if tt.stale {
 				assert.True(t, math.IsNaN(h.Sum), "stale marker signaled by stale-NaN sum")
@@ -567,6 +583,7 @@ func TestExponentialToNativeHistogramV2(t *testing.T) {
 					PositiveSpans:  []writev2.BucketSpan{{Offset: 2, Length: 2}},
 					PositiveDeltas: []int64{1, 0},
 					Timestamp:      500,
+					StartTimestamp: 100,
 				}
 			},
 		},
@@ -600,6 +617,7 @@ func TestExponentialToNativeHistogramV2(t *testing.T) {
 					PositiveSpans:  []writev2.BucketSpan{{Offset: 2, Length: 2}},
 					PositiveDeltas: []int64{1, 0},
 					Timestamp:      500,
+					StartTimestamp: 100,
 				}
 			},
 		},

--- a/pkg/translator/prometheusremotewrite/number_data_points_v2.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_v2.go
@@ -67,7 +67,7 @@ func (c *prometheusConverterV2) addSumNumberDataPoints(dataPoints pmetric.Number
 
 		sample := &writev2.Sample{
 			// convert ns to ms
-			Timestamp: convertTimeStamp(pt.Timestamp()),
+			Timestamp:      convertTimeStamp(pt.Timestamp()),
 			StartTimestamp: convertTimeStamp(pt.StartTimestamp()),
 		}
 		switch pt.ValueType() {

--- a/pkg/translator/prometheusremotewrite/number_data_points_v2.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_v2.go
@@ -68,6 +68,7 @@ func (c *prometheusConverterV2) addSumNumberDataPoints(dataPoints pmetric.Number
 		sample := &writev2.Sample{
 			// convert ns to ms
 			Timestamp: convertTimeStamp(pt.Timestamp()),
+			StartTimestamp: convertTimeStamp(pt.StartTimestamp()),
 		}
 		switch pt.ValueType() {
 		case pmetric.NumberDataPointValueTypeInt:

--- a/pkg/translator/prometheusremotewrite/number_data_points_v2_test.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_v2_test.go
@@ -85,6 +85,38 @@ func TestPrometheusConverterV2_addGaugeNumberDataPoints(t *testing.T) {
 			},
 		},
 		{
+			// Gauges have no counter semantics, so the start timestamp is not
+			// carried over to the sample.
+			name: "gauge with start timestamp",
+			metric: func() pmetric.Metric {
+				metric := getIntGaugeMetric(
+					"test",
+					pcommon.NewMap(),
+					1, ts,
+				)
+				metric.Gauge().DataPoints().At(0).SetStartTimestamp(pcommon.Timestamp(ts) - pcommon.Timestamp(time.Hour))
+				return metric
+			},
+			want: func() map[uint64]*writev2.TimeSeries {
+				labels := []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test"},
+				}
+				return map[uint64]*writev2.TimeSeries{
+					timeSeriesSignature(labels): {
+						LabelsRefs: []uint32{1, 2},
+						Samples: []writev2.Sample{
+							{Timestamp: convertTimeStamp(pcommon.Timestamp(ts)), Value: 1},
+						},
+						Metadata: writev2.Metadata{
+							Type:    writev2.Metadata_METRIC_TYPE_GAUGE,
+							HelpRef: 3,
+							UnitRef: 4,
+						},
+					},
+				}
+			},
+		},
+		{
 			name: "gauge with staleNaN",
 			metric: func() pmetric.Metric {
 				return getIntGaugeMetric(
@@ -204,6 +236,7 @@ func TestPrometheusConverterV2_addGaugeNumberDataPointsDuplicate(t *testing.T) {
 
 func TestPrometheusConverterV2_addSumNumberDataPoints(t *testing.T) {
 	ts := pcommon.Timestamp(time.Now().UnixNano())
+	startTs := ts - pcommon.Timestamp(time.Hour)
 	tests := []struct {
 		name   string
 		metric func() pmetric.Metric
@@ -285,7 +318,7 @@ func TestPrometheusConverterV2_addSumNumberDataPoints(t *testing.T) {
 				dp := metric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(1)
 				dp.SetTimestamp(ts)
-				dp.SetStartTimestamp(ts)
+				dp.SetStartTimestamp(startTs)
 
 				return metric
 			},
@@ -297,7 +330,7 @@ func TestPrometheusConverterV2_addSumNumberDataPoints(t *testing.T) {
 					timeSeriesSignature(labels): {
 						LabelsRefs: []uint32{1, 2},
 						Samples: []writev2.Sample{
-							{Value: 1, Timestamp: convertTimeStamp(ts)},
+							{Value: 1, Timestamp: convertTimeStamp(ts), StartTimestamp: convertTimeStamp(startTs)},
 						},
 						Metadata: writev2.Metadata{
 							Type:    writev2.Metadata_METRIC_TYPE_COUNTER,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Problem discovered while trying to re-introduce the Prometheus Remote Write compliance tests at https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/50089.


#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
