### PR TITLE
[chore] Make stable version inputs optional in prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,13 +13,15 @@ on:
         required: true
         description: Current version (beta, like 0.69.1)
 
+      # The stable inputs are optional: the stable-base module set has no modules yet, so leave
+      # them empty until the first component is promoted to stable.
       candidate-stable:
-        required: true
-        description: Release candidate version (stable, like 1.1.0)
+        required: false
+        description: Release candidate version (stable, like 1.1.0). Leave empty if there are no stable modules.
 
       current-stable:
-        required: true
-        description: Current version (stable, like 1.0.0)
+        required: false
+        description: Current version (stable, like 1.0.0). Leave empty if there are no stable modules.
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -16,16 +16,24 @@ then
     exit 1
 fi
 
-if ! [[ ${CURRENT_STABLE} =~ $PATTERN ]]
+# The stable versions are optional: while the stable-base module set has no modules there is
+# nothing to bump, so a release can be prepared with the beta versions alone.
+STABLE_RELEASE=false
+if [[ -n ${CURRENT_STABLE} ]] || [[ -n ${CANDIDATE_STABLE} ]]
 then
-    echo "CURRENT_STABLE should follow a semver format and not be led by a v"
-    exit 1
-fi
+    STABLE_RELEASE=true
 
-if ! [[ ${CANDIDATE_STABLE} =~ $PATTERN ]]
-then
-    echo "CANDIDATE_STABLE should follow a semver format and not be led by a v"
-    exit 1
+    if ! [[ ${CURRENT_STABLE} =~ $PATTERN ]]
+    then
+        echo "CURRENT_STABLE should follow a semver format and not be led by a v"
+        exit 1
+    fi
+
+    if ! [[ ${CANDIDATE_STABLE} =~ $PATTERN ]]
+    then
+        echo "CANDIDATE_STABLE should follow a semver format and not be led by a v"
+        exit 1
+    fi
 fi
 
 # Expand CURRENT_BETA to escape . character by using [.]
@@ -51,10 +59,13 @@ git add --all
 git commit -m "changelog update ${CANDIDATE_BETA}"
 
 sed -i.bak "s/${CURRENT_BETA_ESCAPED}/${CANDIDATE_BETA}/g" versions.yaml
-sed -i.bak "s/${CURRENT_STABLE_ESCAPED}/${CANDIDATE_STABLE}/g" versions.yaml
+if [[ ${STABLE_RELEASE} == "true" ]]
+then
+    sed -i.bak "s/${CURRENT_STABLE_ESCAPED}/${CANDIDATE_STABLE}/g" versions.yaml
+fi
 find . -name "*.bak" -type f -delete
 git add versions.yaml
-git commit -m "update version.yaml ${CANDIDATE_BETA} ${CANDIDATE_STABLE}"
+git commit -m "update version.yaml ${CANDIDATE_BETA}${CANDIDATE_STABLE:+ ${CANDIDATE_STABLE}}"
 
 sed -i.bak "s/v${CURRENT_BETA_ESCAPED}/v${CANDIDATE_BETA}/g" ./cmd/oteltestbedcol/builder-config.yaml
 sed -i.bak "s/v${CURRENT_BETA_ESCAPED}/v${CANDIDATE_BETA}/g" ./cmd/otelcontribcol/builder-config.yaml
@@ -78,11 +89,17 @@ make otelcontribcol
 
 git push --set-upstream origin "${BRANCH}"
 
+STABLE_SED_LINE=""
+if [[ ${STABLE_RELEASE} == "true" ]]
+then
+    STABLE_SED_LINE="
+- sed -i.bak s/${CURRENT_STABLE_ESCAPED}/${CANDIDATE_STABLE}/g versions.yaml"
+fi
+
 gh pr create --head "$(git branch --show-current)" --title "[chore] Prepare release ${CANDIDATE_BETA}" --body "
 The following commands were run to prepare this release:
 - make chlog-update VERSION=v${CANDIDATE_BETA}
-- sed -i.bak s/${CURRENT_BETA_ESCAPED}/${CANDIDATE_BETA}/g versions.yaml
-- sed -i.bak s/${CURRENT_STABLE_ESCAPED}/${CANDIDATE_STABLE}/g versions.yaml
+- sed -i.bak s/${CURRENT_BETA_ESCAPED}/${CANDIDATE_BETA}/g versions.yaml${STABLE_SED_LINE}
 - make multimod-prerelease
 - make multimod-sync
 "

--- a/docs/release.md
+++ b/docs/release.md
@@ -43,6 +43,11 @@ For general information about all Collector repositories release procedures, see
    - `make push-tags MODSET=contrib-base`
    - `make push-tags MODSET=stable-base`
 
+   > **While `stable-base` has no modules:** leave `current-stable` and
+   > `candidate-stable` empty in the Prepare Release action and skip the
+   > `MODSET=stable-base` tag push. There is nothing to version until a component is
+   > promoted to stable.
+
    > **First-time bootstrap for `stable-base`:** The very first release of the
    > `stable-base` module set uses `current-stable=1.0.0` and
    > `candidate-stable=1.0.0` in the Prepare Release action (the sed is a no-op;


### PR DESCRIPTION
#### Description
The stable-base module set currently has no modules, so the candidate-stable and current-stable inputs of the Prepare Release action have nothing to bump. Make them optional and skip the versions.yaml stable sed when they are empty.

#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector/issues/15765

#### Authorship

- [x] I, a human, wrote this pull request description myself.

