### PR TITLE
[receiver/prometheusremotewritereceiver] Bound native histogram span expansion

### DIFF
--- a/.chloggen/50286-prw-bound-native-histogram-spans.yaml
+++ b/.chloggen/50286-prw-bound-native-histogram-spans.yaml
@@ -1,0 +1,16 @@
+change_type: bug_fix
+
+component: receiver/prometheus_remote_write
+
+note: Stop native histogram bucket spans from driving unbounded memory and CPU use.
+
+issues: [50286]
+
+subtext: |
+  A remote write request could describe a gap of billions of histogram buckets in
+  a few bytes, and the receiver reserved memory and iterated in proportion to that
+  gap. Bucket spans are now validated before conversion, and a native histogram is
+  dropped when its spans are invalid, when it would expand to more than 16384
+  buckets, or when a request has already used its budget of 4194304 buckets.
+
+change_logs: [user]

--- a/.chloggen/50292-prw-native-histogram-overflow-bucket.yaml
+++ b/.chloggen/50292-prw-native-histogram-overflow-bucket.yaml
@@ -1,0 +1,17 @@
+change_type: bug_fix
+
+component: receiver/prometheus_remote_write
+
+note: Drop the Prometheus overflow bucket when converting native histograms, instead of translating it.
+
+issues: [50292]
+
+subtext: |
+  The last bucket that maps to a finite OpenTelemetry bucket is 1024*2^schema.
+  The bucket above it is the Prometheus overflow bucket, which covers values past
+  the IEEE float range, and the Prometheus compatibility specification requires
+  overflow buckets to be dropped and left out of the count. It was previously
+  translated as an ordinary bucket. Buckets above the overflow bucket are not
+  allowed at all, and a histogram containing one is now dropped.
+
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/README.md
+++ b/receiver/prometheusremotewritereceiver/README.md
@@ -99,6 +99,25 @@ As mentioned in [Histogram Atomicity](#histogram-atomicity), Prometheus Classic 
 
 Summaries suffer from the same problem, a working Summary is composed by several time series just like Classic Histograms. The only difference is that instead of bucket boundaries, these time series represent pre-calculated quantiles. Since the quantiles can be sent in separate Remote Write requests, it's impossible to determine if the amount of quantiles received are enough to generate a complete Summary.
 
+### Native Histogram bucket spans
+
+Prometheus encodes Native Histogram buckets sparsely, as spans of populated buckets separated by gaps, while OTLP encodes them densely, as one contiguous list of bucket counts per range. A short list of spans can therefore describe a very wide dense range. Two limits bound the memory and CPU spent on that expansion:
+
+- A single histogram whose spans would expand to more than 16384 OpenTelemetry buckets, across its positive and negative ranges together, is dropped instead of translated.
+- Every histogram in one request shares a budget of 4194304 expanded buckets, because all of them stay in memory until the request has been translated. Histograms that no longer fit are dropped.
+
+Note that both limits count the dense range the spans expand into, not the number of populated buckets, so a histogram with few populated buckets spread very far apart can reach them.
+
+Histograms with invalid spans are dropped as well. The [Native Histograms specification](https://prometheus.io/docs/specs/native_histograms/#buckets) only allows the first span of a list to carry a negative offset, and requires the span lengths to sum to the number of bucket values sent.
+
+Bucket `1024*2^schema + 1` is the Prometheus overflow bucket. It covers values past the IEEE float range, so it is dropped and left out of the data point count rather than translated. The specification forbids using any bucket above it, so a histogram that does is treated as malformed and dropped.
+
+Stale markers are exempt from all of this. When the sum is the stale NaN the remaining histogram fields are ignored, so the spans are neither validated nor translated.
+
+Dropped histograms are logged and are not counted in the `X-Prometheus-Remote-Write-Histograms-Written` response header.
+
+The limits of 16384 buckets per histogram and 4194304 buckets per request are hardcoded and not configurable for now.
+
 ### Resource Metrics Cache
 
 `target_info` metrics and "normal" metrics are a match when they have the same job/instance labels (Please read the [specification](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#resource-attributes-1) for more details). But these metrics do not always come in the same Remote-Write request. For this reason, the receiver uses an internal LRU (Least Recently Used) and stateless cache implementation to store resource metrics across requests.

--- a/receiver/prometheusremotewritereceiver/README.md
+++ b/receiver/prometheusremotewritereceiver/README.md
@@ -99,24 +99,14 @@ As mentioned in [Histogram Atomicity](#histogram-atomicity), Prometheus Classic 
 
 Summaries suffer from the same problem, a working Summary is composed by several time series just like Classic Histograms. The only difference is that instead of bucket boundaries, these time series represent pre-calculated quantiles. Since the quantiles can be sent in separate Remote Write requests, it's impossible to determine if the amount of quantiles received are enough to generate a complete Summary.
 
-### Native Histogram bucket spans
+### Native Histogram expansion limits
 
-Prometheus encodes Native Histogram buckets sparsely, as spans of populated buckets separated by gaps, while OTLP encodes them densely, as one contiguous list of bucket counts per range. A short list of spans can therefore describe a very wide dense range. Two limits bound the memory and CPU spent on that expansion:
+Prometheus sends Native Histogram buckets as spans of populated buckets separated by gaps, while OTLP wants one contiguous list, so a short list of spans can describe a very wide one. Two limits bound what that expansion is allowed to cost:
 
-- A single histogram whose spans would expand to more than 16384 OpenTelemetry buckets, across its positive and negative ranges together, is dropped instead of translated.
-- Every histogram in one request shares a budget of 4194304 expanded buckets, because all of them stay in memory until the request has been translated. Histograms that no longer fit are dropped.
+    - A single histogram may expand to 16384 buckets, counting its positive and negative ranges together.
+    - All histograms in one request share a budget of 4194304 expanded buckets.
 
-Note that both limits count the dense range the spans expand into, not the number of populated buckets, so a histogram with few populated buckets spread very far apart can reach them.
-
-Histograms with invalid spans are dropped as well. The [Native Histograms specification](https://prometheus.io/docs/specs/native_histograms/#buckets) only allows the first span of a list to carry a negative offset, and requires the span lengths to sum to the number of bucket values sent.
-
-Bucket `1024*2^schema + 1` is the Prometheus overflow bucket. It covers values past the IEEE float range, so it is dropped and left out of the data point count rather than translated. The specification forbids using any bucket above it, so a histogram that does is treated as malformed and dropped.
-
-Stale markers are exempt from all of this. When the sum is the stale NaN the remaining histogram fields are ignored, so the spans are neither validated nor translated.
-
-Dropped histograms are logged and are not counted in the `X-Prometheus-Remote-Write-Histograms-Written` response header.
-
-The limits of 16384 buckets per histogram and 4194304 buckets per request are hardcoded and not configurable for now.
+Histograms past either limit are dropped, are not counted in the `X-Prometheus-Remote-Write-Histograms-Written` response header, and are logged. Both limits are hardcoded and not configurable for now.
 
 ### Resource Metrics Cache
 

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -339,6 +339,10 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 
 		// exemplarMap keeps track of exemplars and key is composed by scope_name:scope_version:metric_name:type
 		exemplarMap = collectExemplars(req, prw.settings, &stats)
+
+		// bucketBudget bounds what every Native Histogram in this request may expand into
+		// together, since all of it stays in memory until the request has been translated.
+		bucketBudget = histogramBucketBudget{remaining: maxExponentialHistogramBucketsPerRequest}
 	)
 
 	for i := range req.Timeseries {
@@ -397,7 +401,7 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		// Handle histograms separately due to their complex mixed-schema processing
 		if ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_HISTOGRAM ||
 			ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_UNSPECIFIED && len(ts.Histograms) > 0 {
-			prw.processHistogramTimeSeries(otelMetrics, ls, ts, si, metricName, unit, description, metricCache, scopeCache, &stats, modifiedResourceMetric, exemplarMap)
+			prw.processHistogramTimeSeries(otelMetrics, ls, ts, si, metricName, unit, description, metricCache, scopeCache, &stats, modifiedResourceMetric, exemplarMap, &bucketBudget)
 			continue
 		}
 
@@ -499,6 +503,11 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		}
 	}
 
+	if bucketBudget.exhausted {
+		prw.settings.Logger.Warn("Dropped Native Histograms that did not fit the request bucket budget",
+			zapcore.Field{Key: "max_buckets", Type: zapcore.Int64Type, Integer: maxExponentialHistogramBucketsPerRequest})
+	}
+
 	return otelMetrics, stats, badRequestErrors
 }
 
@@ -514,6 +523,7 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 	stats *promremote.WriteResponseStats,
 	modifiedRM map[uint64]pmetric.ResourceMetrics,
 	exemplarMap map[uint64]pmetric.ExemplarSlice,
+	bucketBudget *histogramBucketBudget,
 ) {
 	// Drop classic histogram series (those with samples)
 	if len(ts.Samples) != 0 {
@@ -557,6 +567,31 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 			)
 			continue
 		}
+
+		// Validate everything that can be checked without allocating, so that a histogram which
+		// is going to be dropped never reserves budget or leaves an empty metric behind. A stale
+		// marker is exempt because its remaining fields are ignored rather than translated.
+		var expLayout exponentialHistogramLayout
+		if histogramType == "exponential" && !value.IsStaleNaN(histogram.Sum) {
+			var err error
+			expLayout, err = validateExponentialHistogram(histogram)
+			if err != nil {
+				prw.settings.Logger.Info(
+					"Dropping Native Histogram that cannot be converted",
+					zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
+					zapcore.Field{Key: "job", Type: zapcore.StringType, String: ls.Get("job")},
+					zapcore.Field{Key: "instance", Type: zapcore.StringType, String: ls.Get("instance")},
+					zapcore.Field{Key: "timestamp", Type: zapcore.Int64Type, Integer: histogram.Timestamp},
+					zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: err},
+				)
+				continue
+			}
+			if !bucketBudget.reserve(expLayout) {
+				// Logged once for the request rather than once per histogram.
+				continue
+			}
+		}
+
 		if hashedLabels == 0 {
 			rm, hashedLabels = prw.getOrCreateRM(ls, otelMetrics, modifiedRM)
 			resourceID := identity.OfResource(rm.Resource())
@@ -626,7 +661,7 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 				exemplarSlice = histMetric.Histogram().DataPoints().At(0).Exemplars()
 			}
 		} else {
-			prw.addExponentialHistogramDatapoint(histMetric.ExponentialHistogram().DataPoints(), histogram, attrs, ls, stats)
+			prw.addExponentialHistogramDatapoint(histMetric.ExponentialHistogram().DataPoints(), histogram, expLayout, attrs, ls, stats)
 			if histMetric.ExponentialHistogram().DataPoints().Len() > 0 {
 				exemplarSlice = histMetric.ExponentialHistogram().DataPoints().At(0).Exemplars()
 			}
@@ -689,11 +724,20 @@ func addNumberDatapoints(datapoints pmetric.NumberDataPointSlice, ls labels.Labe
 	stats.Samples += len(ts.Samples)
 }
 
-func (prw *prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datapoints pmetric.ExponentialHistogramDataPointSlice, histogram *writev2.Histogram, attrs pcommon.Map, ls labels.Labels, stats *promremote.WriteResponseStats) {
-	// Drop Native Histogram with negative counts
-	if hasNegativeCounts(histogram) {
-		prw.settings.Logger.Info("Dropping Native Histogram series with negative counts",
-			zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
+// addExponentialHistogramDatapoint converts one exponential Native Histogram to an OTLP data
+// point. layout must come from validateExponentialHistogram for the same histogram.
+func (prw *prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datapoints pmetric.ExponentialHistogramDataPointSlice, histogram *writev2.Histogram, layout exponentialHistogramLayout, attrs pcommon.Map, ls labels.Labels, stats *promremote.WriteResponseStats) {
+	// A stale marker carries no distribution: the specification ignores the remaining fields when
+	// the sum is the stale NaN, so none of them are read.
+	if value.IsStaleNaN(histogram.Sum) {
+		dp := datapoints.AppendEmpty()
+		dp.SetStartTimestamp(pcommon.Timestamp(histogram.StartTimestamp * int64(time.Millisecond)))
+		dp.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * int64(time.Millisecond)))
+		dp.SetScale(histogram.Schema)
+		dp.SetZeroThreshold(histogram.ZeroThreshold)
+		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
+		attrs.CopyTo(dp.Attributes())
+		stats.Histograms++
 		return
 	}
 
@@ -702,21 +746,8 @@ func (prw *prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datap
 	dp.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * int64(time.Millisecond)))
 	dp.SetScale(histogram.Schema)
 	dp.SetZeroThreshold(histogram.ZeroThreshold)
+	setCountAndSum(histogram, dp)
 
-	// Set count and sum using common helper
-	if value.IsStaleNaN(histogram.Sum) {
-		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
-	} else {
-		setCountAndSum(histogram, dp)
-	}
-
-	// The maximum bucket index is derived from the formula (2^(2^-n))^i <= MaxFloat64.
-	// MaxFloat64 is approx 2^1024. So (2^-n) * i <= 1024 => i <= 1024 * 2^n.
-	// The bucket containing MaxFloat64 has index i_max = 1024 * 2^n.
-	// The next bucket (i_max + 1) is the +Inf overflow bucket, which is also allowed.
-	// Buckets with an index strictly greater than i_max + 1 must be dropped.
-	// See https://prometheus.io/docs/specs/native_histograms/#schema for more information.
-	overflowLimit := int32(math.Ldexp(1024, int(histogram.Schema))) + 1
 	var droppedCount uint64
 
 	// The difference between float and integer histograms is that float histograms are stored as absolute counts
@@ -726,30 +757,18 @@ func (prw *prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datap
 		zeroCountFloat := histogram.GetZeroCountFloat()
 		dp.SetZeroCount(uint64(zeroCountFloat))
 
-		if len(histogram.PositiveSpans) > 0 {
-			dp.Positive().SetOffset(histogram.PositiveSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
-			droppedCount += convertAbsoluteBuckets(histogram.PositiveSpans, histogram.PositiveCounts, dp.Positive().BucketCounts(), overflowLimit)
-		}
-		if len(histogram.NegativeSpans) > 0 {
-			dp.Negative().SetOffset(histogram.NegativeSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
-			droppedCount += convertAbsoluteBuckets(histogram.NegativeSpans, histogram.NegativeCounts, dp.Negative().BucketCounts(), overflowLimit)
-		}
+		droppedCount += convertAbsoluteBuckets(histogram.PositiveSpans, histogram.PositiveCounts, dp.Positive(), layout.positive)
+		droppedCount += convertAbsoluteBuckets(histogram.NegativeSpans, histogram.NegativeCounts, dp.Negative(), layout.negative)
 	} else {
 		// Integer histograms
 		zeroCountInt := histogram.GetZeroCountInt()
 		dp.SetZeroCount(zeroCountInt)
 
-		if len(histogram.PositiveSpans) > 0 {
-			dp.Positive().SetOffset(histogram.PositiveSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
-			droppedCount += convertDeltaBuckets(histogram.PositiveSpans, histogram.PositiveDeltas, dp.Positive().BucketCounts(), overflowLimit)
-		}
-		if len(histogram.NegativeSpans) > 0 {
-			dp.Negative().SetOffset(histogram.NegativeSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
-			droppedCount += convertDeltaBuckets(histogram.NegativeSpans, histogram.NegativeDeltas, dp.Negative().BucketCounts(), overflowLimit)
-		}
+		droppedCount += convertDeltaBuckets(histogram.PositiveSpans, histogram.PositiveDeltas, dp.Positive(), layout.positive)
+		droppedCount += convertDeltaBuckets(histogram.NegativeSpans, histogram.NegativeDeltas, dp.Negative(), layout.negative)
 	}
 
-	if droppedCount > 0 && !value.IsStaleNaN(histogram.Sum) {
+	if droppedCount > 0 {
 		count := dp.Count()
 		if droppedCount > count {
 			prw.settings.Logger.Info("Clamping Native Histogram count to zero due to inconsistent dropped overflow bucket count",
@@ -812,81 +831,256 @@ func hasNegativeCounts(histogram *writev2.Histogram) bool {
 	return false
 }
 
-// convertDeltaBuckets converts Prometheus native histogram spans and deltas to OpenTelemetry bucket counts
-// For integer buckets, the values are deltas between the buckets. i.e a bucket list of 1,2,-2 would correspond to a bucket count of 1,3,1
-func convertDeltaBuckets(spans []writev2.BucketSpan, deltas []int64, buckets pcommon.UInt64Slice, overflowLimit int32) uint64 {
-	// The total capacity is the sum of the deltas and the offsets of the spans.
-	totalCapacity := len(deltas)
-	for _, span := range spans {
-		totalCapacity += int(span.Offset)
-	}
-	buckets.EnsureCapacity(totalCapacity)
+// maxExponentialHistogramBuckets bounds the dense OTLP buckets one data point may expand into,
+// across both ranges, since a few bytes of sparse span offsets can describe billions of them.
+// A resource bound, not a spec value: 128KiB of bucket counts, still 2^64 of range at schema 8.
+const maxExponentialHistogramBuckets = 16 * 1024
 
-	bucketIdx := 0
-	bucketCount := int64(0)
-	var droppedCount uint64
-	initialOffset := spans[0].Offset
-	k := initialOffset
+// unrepresentableBucketIndex is the first Prometheus bucket index with no OTLP equivalent. Empty
+// spans saturate at it, since they carry an offset but no bucket.
+const unrepresentableBucketIndex = math.MaxInt32 + 1
+
+// maxExponentialHistogramBucketsPerRequest bounds what one request may expand into in total. The
+// per-data-point limit does not bound a request on its own, because every data point stays in
+// memory until the consumer takes the batch. 32MiB of bucket counts, 256 times the per-point limit.
+const maxExponentialHistogramBucketsPerRequest = 4 * 1024 * 1024
+
+// histogramBucketBudget is the share of maxExponentialHistogramBucketsPerRequest left in a request.
+type histogramBucketBudget struct {
+	remaining int64
+	exhausted bool
+}
+
+// reserve claims the buckets one data point needs, reporting whether they were still available.
+func (b *histogramBucketBudget) reserve(layout exponentialHistogramLayout) bool {
+	needed := layout.positive.numBuckets + layout.negative.numBuckets
+	if needed > b.remaining {
+		b.exhausted = true
+		return false
+	}
+	b.remaining -= needed
+	return true
+}
+
+// exponentialHistogramLayout is the validated dense layout of both ranges of a histogram.
+type exponentialHistogramLayout struct {
+	positive bucketSpanLayout
+	negative bucketSpanLayout
+}
+
+// bucketSpanLayout is the dense OTLP bucket range a validated span list expands into.
+type bucketSpanLayout struct {
+	hasBuckets bool  // false for an empty span list, and when every bucket overflows
+	firstIndex int64 // Prometheus index of the first bucket within the overflow limit
+	lastIndex  int64 // Prometheus index of the last bucket within the overflow limit
+	numBuckets int64 // bucket_counts length; may exceed a 32-bit int before validation
+}
+
+// otelOffset returns the OTLP offset of the layout, one below firstIndex: an OTLP offset
+// addresses the lower bound of a bucket, a Prometheus index the upper bound.
+func (l bucketSpanLayout) otelOffset() int32 {
+	return int32(l.firstIndex - 1)
+}
+
+// exponentialHistogramFiniteLimit returns the highest Prometheus bucket index that maps to a finite
+// OTLP bucket, the one holding MaxFloat64. The bucket above it is the Prometheus overflow bucket.
+// See https://prometheus.io/docs/specs/native_histograms/#schema
+func exponentialHistogramFiniteLimit(histogramSchema int32) int32 {
+	return int32(math.Ldexp(1024, int(histogramSchema)))
+}
+
+// validateExponentialHistogram returns the dense layout the spans of an exponential Native
+// Histogram expand into. An error means it cannot be translated. The caller checks the schema.
+func validateExponentialHistogram(histogram *writev2.Histogram) (exponentialHistogramLayout, error) {
+	// Checked before the budget is reserved, so a histogram that is going to be dropped never
+	// takes buckets a later valid one needs.
+	if hasNegativeCounts(histogram) {
+		return exponentialHistogramLayout{}, errors.New("histogram has negative counts")
+	}
+
+	finiteLimit := exponentialHistogramFiniteLimit(histogram.Schema)
+
+	positiveValues, negativeValues := len(histogram.PositiveDeltas), len(histogram.NegativeDeltas)
+	if histogram.IsFloatHistogram() {
+		positiveValues, negativeValues = len(histogram.PositiveCounts), len(histogram.NegativeCounts)
+	}
+
+	positive, err := validateBucketSpanLayout(histogram.PositiveSpans, positiveValues, finiteLimit)
+	if err != nil {
+		return exponentialHistogramLayout{}, fmt.Errorf("positive spans: %w", err)
+	}
+	negative, err := validateBucketSpanLayout(histogram.NegativeSpans, negativeValues, finiteLimit)
+	if err != nil {
+		return exponentialHistogramLayout{}, fmt.Errorf("negative spans: %w", err)
+	}
+
+	// Both ranges live in one data point, so they share one budget.
+	if positive.numBuckets+negative.numBuckets > maxExponentialHistogramBuckets {
+		return exponentialHistogramLayout{}, fmt.Errorf(
+			"spans expand to %d buckets, more than the maximum of %d",
+			positive.numBuckets+negative.numBuckets, maxExponentialHistogramBuckets,
+		)
+	}
+
+	return exponentialHistogramLayout{positive: positive, negative: negative}, nil
+}
+
+// validateBucketSpanLayout validates one bucket span list and computes the dense OTLP range it
+// expands into. Per https://prometheus.io/docs/specs/native_histograms/#buckets only the first span
+// may have a negative offset, and the span lengths must sum to the number of bucket values sent.
+// A span of length zero produces no bucket but still shifts the spans that follow it.
+//
+// Offsets are untrusted int32 wire fields, so indexes are computed in int64 and the expansion is
+// bounded here, before it can reach an allocation, a loop bound or a slice index.
+func validateBucketSpanLayout(spans []writev2.BucketSpan, valueCount int, finiteLimit int32) (bucketSpanLayout, error) {
+	var (
+		layout      bucketSpanLayout
+		nextIndex   int64 // index the next span's offset is relative to
+		spanBuckets uint64
+	)
 
 	for spanIdx, span := range spans {
-		if spanIdx > 0 {
-			for i := int32(0); i < span.Offset; i++ {
-				if k <= overflowLimit {
-					buckets.Append(uint64(0))
-				}
-				k++
-			}
+		if spanIdx > 0 && span.Offset < 0 {
+			return bucketSpanLayout{}, fmt.Errorf("span number %d has negative offset %d", spanIdx+1, span.Offset)
 		}
+
+		start := nextIndex + int64(span.Offset)
+
+		spanBuckets += uint64(span.Length)
+		if spanBuckets > uint64(valueCount) {
+			return bucketSpanLayout{}, fmt.Errorf("spans define more buckets than the %d bucket values provided", valueCount)
+		}
+
+		nextIndex = start + int64(span.Length)
+		if span.Length == 0 {
+			// An empty span produces no bucket, so its index need not be representable. Saturating
+			// keeps a run of them inside int64; a bucket built on one is rejected below anyway.
+			nextIndex = min(nextIndex, unrepresentableBucketIndex)
+			continue
+		}
+		// Only the bucket directly above the finite range is the +Inf overflow bucket, and the
+		// specification forbids using anything past it. Rejecting here also keeps every index
+		// well inside int64, since offsets after the first span only ever move forwards.
+		if nextIndex-1 > int64(finiteLimit)+1 {
+			return bucketSpanLayout{}, fmt.Errorf("bucket index %d is past the overflow bucket at %d", nextIndex-1, finiteLimit+1)
+		}
+
+		// The overflow bucket itself is consumed but dropped, so it must not widen the range.
+		last := min(nextIndex-1, int64(finiteLimit))
+		if start > last {
+			continue
+		}
+		if !layout.hasBuckets {
+			if start-1 < math.MinInt32 {
+				return bucketSpanLayout{}, fmt.Errorf("bucket index %d cannot be expressed as an OTLP offset", start)
+			}
+			layout.hasBuckets = true
+			layout.firstIndex = start
+		}
+		layout.lastIndex = last
+	}
+
+	if spanBuckets != uint64(valueCount) {
+		return bucketSpanLayout{}, fmt.Errorf("spans define %d bucket values, %d provided", spanBuckets, valueCount)
+	}
+	if !layout.hasBuckets {
+		return bucketSpanLayout{}, nil
+	}
+
+	// The two ranges share one limit, so it is taken once in validateExponentialHistogram.
+	layout.numBuckets = layout.lastIndex - layout.firstIndex + 1
+
+	return layout, nil
+}
+
+// convertDeltaBuckets converts Prometheus spans and deltas to OTLP bucket counts, returning the
+// population of the overflow buckets it dropped. Deltas are cumulative: 1,2,-2 means counts of
+// 1,3,1. layout must come from validateBucketSpanLayout for the same spans.
+func convertDeltaBuckets(spans []writev2.BucketSpan, deltas []int64, dest pmetric.ExponentialHistogramDataPointBuckets, layout bucketSpanLayout) uint64 {
+	buckets := prepareBuckets(dest, layout)
+
+	var (
+		bucketIdx    int
+		bucketCount  int64
+		droppedCount uint64
+		nextIndex    int64
+		nextAppend   = layout.firstIndex // no gap before the first bucket, the OTLP offset places it
+	)
+
+	for _, span := range spans {
+		start := nextIndex + int64(span.Offset)
+		// A zero length span appends nothing but still shifts the spans after it.
+		nextIndex = start + int64(span.Length)
+
 		for i := uint32(0); i < span.Length; i++ {
+			// Deltas are cumulative, so dropped buckets still have to be accumulated.
 			bucketCount += deltas[bucketIdx]
 			bucketIdx++
 
-			if k <= overflowLimit {
-				buckets.Append(uint64(bucketCount))
-			} else {
+			index := start + int64(i)
+			if !layout.hasBuckets || index > layout.lastIndex {
 				droppedCount += uint64(bucketCount)
+				continue
 			}
-			k++
+			nextAppend = appendGap(buckets, nextAppend, index)
+			buckets.Append(uint64(bucketCount))
 		}
 	}
 	return droppedCount
 }
 
-// convertAbsoluteBuckets converts Prometheus native histogram spans and absolute counts to OpenTelemetry bucket counts
-// For float buckets, the values are absolute counts, and must be 0 or positive.
-func convertAbsoluteBuckets(spans []writev2.BucketSpan, counts []float64, buckets pcommon.UInt64Slice, overflowLimit int32) uint64 {
-	// The total capacity is the sum of the counts and the offsets of the spans.
-	totalCapacity := len(counts)
+// convertAbsoluteBuckets converts Prometheus spans and float counts to OTLP bucket counts,
+// returning the population of the overflow buckets it dropped. Float bucket values are absolute.
+// layout must come from validateBucketSpanLayout for the same spans.
+func convertAbsoluteBuckets(spans []writev2.BucketSpan, counts []float64, dest pmetric.ExponentialHistogramDataPointBuckets, layout bucketSpanLayout) uint64 {
+	buckets := prepareBuckets(dest, layout)
+
+	var (
+		bucketIdx    int
+		droppedCount uint64
+		nextIndex    int64
+		nextAppend   = layout.firstIndex // no gap before the first bucket, the OTLP offset places it
+	)
+
 	for _, span := range spans {
-		totalCapacity += int(span.Offset)
-	}
-	buckets.EnsureCapacity(totalCapacity)
+		start := nextIndex + int64(span.Offset)
+		// A zero length span appends nothing but still shifts the spans after it.
+		nextIndex = start + int64(span.Length)
 
-	bucketIdx := 0
-	var droppedCount uint64
-	initialOffset := spans[0].Offset
-	k := initialOffset
-
-	for spanIdx, span := range spans {
-		if spanIdx > 0 {
-			for i := int32(0); i < span.Offset; i++ {
-				if k <= overflowLimit {
-					buckets.Append(uint64(0))
-				}
-				k++
-			}
-		}
 		for i := uint32(0); i < span.Length; i++ {
-			if k <= overflowLimit {
-				buckets.Append(uint64(counts[bucketIdx]))
-			} else {
-				droppedCount += uint64(counts[bucketIdx])
-			}
+			count := uint64(counts[bucketIdx])
 			bucketIdx++
-			k++
+
+			index := start + int64(i)
+			if !layout.hasBuckets || index > layout.lastIndex {
+				droppedCount += count
+				continue
+			}
+			nextAppend = appendGap(buckets, nextAppend, index)
+			buckets.Append(count)
 		}
 	}
 	return droppedCount
+}
+
+// prepareBuckets sets the OTLP offset and reserves exactly what the validated layout needs.
+func prepareBuckets(dest pmetric.ExponentialHistogramDataPointBuckets, layout bucketSpanLayout) pcommon.UInt64Slice {
+	buckets := dest.BucketCounts()
+	if layout.hasBuckets {
+		dest.SetOffset(layout.otelOffset())
+		buckets.EnsureCapacity(int(layout.numBuckets)) // bounded by validateExponentialHistogram
+	}
+	return buckets
+}
+
+// appendGap fills the empty buckets before index and returns where the next bucket goes. Gaps are
+// only filled ahead of a bucket that is actually appended, so a trailing gap costs nothing and the
+// iteration count is bounded by the layout, not by the offsets on the wire.
+func appendGap(buckets pcommon.UInt64Slice, nextAppend, index int64) int64 {
+	for ; nextAppend < index; nextAppend++ {
+		buckets.Append(0)
+	}
+	return index + 1
 }
 
 // extractAttributes returns metric data point attributes, excluding job, instance, metric name, and all otel_scope_* labels.

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -576,7 +576,7 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 			var err error
 			expLayout, err = validateExponentialHistogram(histogram)
 			if err != nil {
-				prw.settings.Logger.Info(
+				prw.settings.Logger.Error(
 					"Dropping Native Histogram that cannot be converted",
 					zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
 					zapcore.Field{Key: "job", Type: zapcore.StringType, String: ls.Get("job")},

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -819,29 +820,8 @@ func TestTranslateV2(t *testing.T) {
 				Histograms: 0,
 				Exemplars:  0,
 			},
-			expectedMetrics: func() pmetric.Metrics {
-				metrics := pmetric.NewMetrics()
-				rm := metrics.ResourceMetrics().AppendEmpty()
-				attrs := rm.Resource().Attributes()
-				attrs.PutStr("service.namespace", "service-x")
-				attrs.PutStr("service.name", "test")
-				attrs.PutStr("service.instance.id", "107cn001")
-
-				sm := rm.ScopeMetrics().AppendEmpty()
-				sm.Scope().SetName("scope1")
-				sm.Scope().SetVersion("v1")
-
-				m := sm.Metrics().AppendEmpty()
-				m.SetName("test_metric")
-				m.SetUnit("")
-				m.SetDescription("")
-				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
-
-				hist := m.SetEmptyExponentialHistogram()
-				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-
-				return metrics
-			}(),
+			// Rejected before the resource, scope and metric are built, so nothing is emitted.
+			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
 			name: "exponential histogram - float",
@@ -973,28 +953,8 @@ func TestTranslateV2(t *testing.T) {
 				Histograms: 0,
 				Exemplars:  0,
 			},
-			expectedMetrics: func() pmetric.Metrics {
-				metrics := pmetric.NewMetrics()
-				rm := metrics.ResourceMetrics().AppendEmpty()
-				attrs := rm.Resource().Attributes()
-				attrs.PutStr("service.namespace", "service-x")
-				attrs.PutStr("service.name", "test")
-				attrs.PutStr("service.instance.id", "107cn001")
-
-				sm := rm.ScopeMetrics().AppendEmpty()
-				sm.Scope().SetName("scope1")
-				sm.Scope().SetVersion("v1")
-
-				m := sm.Metrics().AppendEmpty()
-				m.SetName("test_metric")
-				m.SetUnit("")
-				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
-
-				hist := m.SetEmptyExponentialHistogram()
-				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-
-				return metrics
-			}(),
+			// Rejected before the resource, scope and metric are built, so nothing is emitted.
+			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
 			name: "reset hint gauge should be dropped",
@@ -1751,11 +1711,79 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
+			name: "exponential histogram - stale NaN sum ignores its spans",
+			// The remaining fields of a stale marker are ignored, so spans that would otherwise
+			// be rejected must neither drop the marker nor be walked. These span lengths do not
+			// match the deltas, which is exactly the shape that must not reach the converter.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Sum:            math.Float64frombits(value.StaleNaN),
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         0,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+								PositiveDeltas: []int64{1, 2},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Histograms: 1,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.namespace", "service-x")
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "107cn001")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("scope1")
+				sm.Scope().SetVersion("v1")
+
+				m := sm.Metrics().AppendEmpty()
+				m.SetName("test_metric")
+				m.SetUnit("")
+				m.SetDescription("")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+
+				hist := m.SetEmptyExponentialHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp := hist.DataPoints().AppendEmpty()
+				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetScale(0)
+				dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
+
+				return metrics
+			}(),
+		},
+		{
 			name: "exponential histogram - overflow buckets dropped",
-			// This test case verifies that the bucket with index 1026 is dropped because the limit is 1025 at scale 0 (1024 + 1 for +Inf bucket).
-			// Bucket 1025 is valid (+Inf bucket).
-			// The original count was 50. Bucket 1025 has count 10. Bucket 1026 has count 30 (10 + 20).
-			// Bucket 1026 overflows (> 1025) and is dropped.
+			// Bucket 1024 is the last one mapping to a finite OTLP bucket at scale 0, so it is kept.
+			// Bucket 1025 is the Prometheus overflow bucket: it covers values past the IEEE float
+			// range, and the compatibility specification requires it to be dropped and left out of
+			// the count.
+			// The original count was 50. Bucket 1024 has count 10, bucket 1025 has count 30 (10 + 20).
 			// The total count is updated to 50 - 30 = 20.
 			request: &writev2.Request{
 				Symbols: []string{
@@ -1780,7 +1808,7 @@ func TestTranslateV2(t *testing.T) {
 								Timestamp:      1,
 								StartTimestamp: 1,
 								Schema:         0,
-								PositiveSpans:  []writev2.BucketSpan{{Offset: 1025, Length: 2}},
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 1024, Length: 2}},
 								PositiveDeltas: []int64{10, 20},
 							},
 						},
@@ -1822,11 +1850,453 @@ func TestTranslateV2(t *testing.T) {
 				dp.SetSum(100)
 				dp.SetCount(20)
 
-				dp.Positive().SetOffset(1024)
+				dp.Positive().SetOffset(1023)
 				dp.Positive().BucketCounts().FromRaw([]uint64{10})
 
 				return metrics
 			}(),
+		},
+		{
+			name: "exponential histogram - float overflow buckets dropped",
+			// The float twin of the case above. It walks a different converter, so the integer
+			// case does not cover it: bucket 1024 is kept, bucket 1025 is the overflow bucket and
+			// is dropped along with its 30 observations, leaving a count of 50 - 30.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountFloat{CountFloat: 50},
+								Sum:            100,
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         0,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 1024, Length: 2}},
+								PositiveCounts: []float64{10, 30},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Histograms: 1,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.namespace", "service-x")
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "107cn001")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("scope1")
+				sm.Scope().SetVersion("v1")
+
+				m := sm.Metrics().AppendEmpty()
+				m.SetName("test_metric")
+				m.SetUnit("")
+				m.SetDescription("")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+
+				hist := m.SetEmptyExponentialHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp := hist.DataPoints().AppendEmpty()
+				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetScale(0)
+				dp.SetSum(100)
+				dp.SetCount(20)
+
+				dp.Positive().SetOffset(1023)
+				dp.Positive().BucketCounts().FromRaw([]uint64{10})
+
+				return metrics
+			}(),
+		},
+		{
+			name: "exponential histogram - malformed negative spans drop the histogram",
+			// Both ranges are validated. The positive one is well formed here, so this is the
+			// only shape that reaches the negative range's error path.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountInt{CountInt: 3},
+								Sum:            6,
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         0,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+								PositiveDeltas: []int64{1, 1},
+								// Three buckets promised, two values sent.
+								NegativeSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+								NegativeDeltas: []int64{1, 0},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed: true,
+			},
+			expectedMetrics: pmetric.NewMetrics(),
+		},
+		{
+			name: "exponential histogram - trailing empty span is not materialized",
+			// A trailing span of length 0 carries an offset but no bucket, so it must not
+			// widen the dense representation.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountInt{CountInt: 4},
+								Sum:            6,
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         0,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}, {Offset: 100_000_000, Length: 0}},
+								PositiveDeltas: []int64{1, 2},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Histograms: 1,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.namespace", "service-x")
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "107cn001")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("scope1")
+				sm.Scope().SetVersion("v1")
+
+				m := sm.Metrics().AppendEmpty()
+				m.SetName("test_metric")
+				m.SetUnit("")
+				m.SetDescription("")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+
+				hist := m.SetEmptyExponentialHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp := hist.DataPoints().AppendEmpty()
+				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetScale(0)
+				dp.SetSum(6)
+				dp.SetCount(4)
+
+				dp.Positive().SetOffset(-1)
+				dp.Positive().BucketCounts().FromRaw([]uint64{1, 3})
+
+				return metrics
+			}(),
+		},
+		{
+			name: "exponential histogram - leading empty span keeps its offset",
+			// A span of length 0 produces no bucket, but its offset still shifts the spans
+			// after it, so the single bucket lands on index -10 + 3 = -7.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountInt{CountInt: 5},
+								Sum:            10,
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         0,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: -10, Length: 0}, {Offset: 3, Length: 1}},
+								PositiveDeltas: []int64{5},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Histograms: 1,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.namespace", "service-x")
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "107cn001")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("scope1")
+				sm.Scope().SetVersion("v1")
+
+				m := sm.Metrics().AppendEmpty()
+				m.SetName("test_metric")
+				m.SetUnit("")
+				m.SetDescription("")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+
+				hist := m.SetEmptyExponentialHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp := hist.DataPoints().AppendEmpty()
+				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetScale(0)
+				dp.SetSum(10)
+				dp.SetCount(5)
+
+				dp.Positive().SetOffset(-8)
+				dp.Positive().BucketCounts().FromRaw([]uint64{5})
+
+				return metrics
+			}(),
+		},
+		{
+			name: "exponential histogram - bucket past the overflow bucket is dropped",
+			// Only index 1025 is the +Inf overflow bucket at scale 0. Bucket 100000001 is past it,
+			// which the specification forbids, so the whole histogram is treated as malformed.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountInt{CountInt: 50},
+								Sum:            100,
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         0,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 100_000_000, Length: 1}},
+								PositiveDeltas: []int64{10, 20},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed: true,
+			},
+			expectedMetrics: pmetric.NewMetrics(),
+		},
+		{
+			name: "exponential histogram - spans expanding past the bucket limit are dropped",
+			// Buckets 0 and 16384 are both within the schema 8 limit, but expanding them into a
+			// dense range needs 16385 buckets, one more than maxExponentialHistogramBuckets.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountInt{CountInt: 2},
+								Sum:            2,
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         8,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 16383, Length: 1}},
+								PositiveDeltas: []int64{1, 0},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed: true,
+			},
+			expectedMetrics: pmetric.NewMetrics(),
+		},
+		{
+			name: "exponential histogram - float spans expanding past the bucket limit are dropped",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountFloat{CountFloat: 2},
+								Sum:            2,
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         8,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 16383, Length: 1}},
+								PositiveCounts: []float64{1, 1},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed: true,
+			},
+			expectedMetrics: pmetric.NewMetrics(),
+		},
+		{
+			name: "exponential histogram - negative offset after the first span is dropped",
+			// Prometheus only allows the first span of a list to move backwards.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountInt{CountInt: 2},
+								Sum:            2,
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         0,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: -1, Length: 1}},
+								PositiveDeltas: []int64{1, 0},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed: true,
+			},
+			expectedMetrics: pmetric.NewMetrics(),
+		},
+		{
+			name: "exponential histogram - spans longer than the bucket values are dropped",
+			// The span promises three buckets and the histogram carries two deltas, so the
+			// third bucket has no value to read.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountInt{CountInt: 3},
+								Sum:            3,
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         0,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+								PositiveDeltas: []int64{1, 2},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed: true,
+			},
+			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
 			name: "multiple histogram metrics with exemplars",
@@ -3048,6 +3518,338 @@ func TestTranslateV2(t *testing.T) {
 			assert.Equal(t, buildMetaDataMapByID(tc.expectedMetrics), buildMetaDataMapByID(metrics))
 		})
 	}
+}
+
+func TestValidateBucketSpanLayout(t *testing.T) {
+	// The last bucket that maps to a finite OTLP bucket: 1024*2^schema.
+	const (
+		schema0Limit = 1024
+		schema8Limit = 262144
+	)
+
+	for _, tc := range []struct {
+		name          string
+		spans         []writev2.BucketSpan
+		valueCount    int
+		overflowLimit int32
+		expected      bucketSpanLayout
+		expectError   string
+	}{
+		{
+			name:          "no spans",
+			overflowLimit: schema0Limit,
+		},
+		{
+			name:          "single span",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 3}},
+			valueCount:    3,
+			overflowLimit: schema0Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: 0, lastIndex: 2, numBuckets: 3},
+		},
+		{
+			name:          "negative offset on the first span",
+			spans:         []writev2.BucketSpan{{Offset: -10, Length: 2}},
+			valueCount:    2,
+			overflowLimit: schema0Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: -10, lastIndex: -9, numBuckets: 2},
+		},
+		{
+			name:          "leading empty span shifts the first bucket",
+			spans:         []writev2.BucketSpan{{Offset: -10, Length: 0}, {Offset: 3, Length: 1}},
+			valueCount:    1,
+			overflowLimit: schema0Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: -7, lastIndex: -7, numBuckets: 1},
+		},
+		{
+			name:          "intermediate empty span shifts the buckets after it",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 5, Length: 0}, {Offset: 3, Length: 1}},
+			valueCount:    2,
+			overflowLimit: schema0Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: 0, lastIndex: 9, numBuckets: 10},
+		},
+		{
+			name:          "trailing empty span adds no buckets",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 100_000_000, Length: 0}},
+			valueCount:    1,
+			overflowLimit: schema0Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: 0, lastIndex: 0, numBuckets: 1},
+		},
+		{
+			name:          "only empty spans",
+			spans:         []writev2.BucketSpan{{Offset: 100_000_000, Length: 0}},
+			overflowLimit: schema0Limit,
+		},
+		{
+			name:          "span straddling the last finite bucket",
+			spans:         []writev2.BucketSpan{{Offset: 1023, Length: 3}},
+			valueCount:    3,
+			overflowLimit: schema0Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: 1023, lastIndex: 1024, numBuckets: 2},
+		},
+		{
+			name:          "the overflow bucket alone is not retained",
+			spans:         []writev2.BucketSpan{{Offset: 1025, Length: 1}},
+			valueCount:    1,
+			overflowLimit: schema0Limit,
+		},
+		{
+			name:          "bucket past the overflow bucket is rejected",
+			spans:         []writev2.BucketSpan{{Offset: 2000, Length: 1}},
+			valueCount:    1,
+			overflowLimit: schema0Limit,
+			expectError:   "bucket index 2000 is past the overflow bucket at 1025",
+		},
+		{
+			name:          "bucket one past the overflow bucket is rejected",
+			spans:         []writev2.BucketSpan{{Offset: 1026, Length: 1}},
+			valueCount:    1,
+			overflowLimit: schema0Limit,
+			expectError:   "bucket index 1026 is past the overflow bucket at 1025",
+		},
+		{
+			name:          "distant bucket is past the overflow bucket",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 100_000_000, Length: 1}},
+			valueCount:    2,
+			overflowLimit: schema0Limit,
+			expectError:   "is past the overflow bucket",
+		},
+		{
+			name:          "exactly the bucket limit",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 16382, Length: 1}},
+			valueCount:    2,
+			overflowLimit: schema8Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: 0, lastIndex: 16383, numBuckets: maxExponentialHistogramBuckets},
+		},
+		{
+			// One range on its own is not held to the limit any more, only the two together are.
+			name:          "one bucket past the limit",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 16383, Length: 1}},
+			valueCount:    2,
+			overflowLimit: schema8Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: 0, lastIndex: 16384, numBuckets: 16385},
+		},
+		{
+			name:          "negative offset after the first span",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: -1, Length: 1}},
+			valueCount:    2,
+			overflowLimit: schema0Limit,
+			expectError:   "span number 2 has negative offset -1",
+		},
+		{
+			name:          "spans longer than the bucket values",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 3}},
+			valueCount:    2,
+			overflowLimit: schema0Limit,
+			expectError:   "spans define more buckets than the 2 bucket values provided",
+		},
+		{
+			name:          "spans shorter than the bucket values",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 1}},
+			valueCount:    2,
+			overflowLimit: schema0Limit,
+			expectError:   "spans define 1 bucket values, 2 provided",
+		},
+		{
+			name:          "first bucket index has no OTLP offset",
+			spans:         []writev2.BucketSpan{{Offset: math.MinInt32, Length: 1}},
+			valueCount:    1,
+			overflowLimit: schema0Limit,
+			expectError:   "cannot be expressed as an OTLP offset",
+		},
+		{
+			name:          "trailing empty spans past the end of int32",
+			spans:         []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 2_000_000_000, Length: 0}, {Offset: 2_000_000_000, Length: 0}},
+			valueCount:    1,
+			overflowLimit: schema0Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: 0, lastIndex: 0, numBuckets: 1},
+		},
+		{
+			name:          "bucket index past the end of int32",
+			spans:         []writev2.BucketSpan{{Offset: 2_000_000_000, Length: 1}, {Offset: 2_000_000_000, Length: 1}},
+			valueCount:    2,
+			overflowLimit: schema0Limit,
+			expectError:   "bucket index 2000000000 is past the overflow bucket",
+		},
+		{
+			// The bucket directly above the finite range is the +Inf bucket. It is consumed and
+			// dropped, and a span may straddle the boundary into it.
+			name:          "span reaching the overflow bucket is accepted",
+			spans:         []writev2.BucketSpan{{Offset: 1024, Length: 2}},
+			valueCount:    2,
+			overflowLimit: schema0Limit,
+			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: 1024, lastIndex: 1024, numBuckets: 1},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			layout, err := validateBucketSpanLayout(tc.spans, tc.valueCount, tc.overflowLimit)
+			if tc.expectError != "" {
+				assert.ErrorContains(t, err, tc.expectError)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, layout)
+		})
+	}
+}
+
+func TestSpanRangeWiderThanInt32(t *testing.T) {
+	// Both indexes come from untrusted int32 offsets, so the distance between them can be wider
+	// than a 32-bit int holds. The limit has to be applied to the int64 before anything narrows it.
+	spans := []writev2.BucketSpan{
+		{Offset: math.MinInt32 + 1, Length: 1},
+		{Offset: math.MaxInt32, Length: 1},
+		{Offset: 1023, Length: 1},
+	}
+	layout, err := validateBucketSpanLayout(spans, 3, exponentialHistogramFiniteLimit(0))
+	require.NoError(t, err)
+
+	// Comparing against an int64 also pins the field's type: narrowing it to an int makes this
+	// assertion fail rather than quietly truncating on the builds where an int is 32 bits.
+	assert.Greater(t, layout.numBuckets, int64(math.MaxInt32), "the range does not fit an int32")
+
+	_, err = validateExponentialHistogram(&writev2.Histogram{
+		Schema:         0,
+		Count:          &writev2.Histogram_CountInt{CountInt: 1},
+		PositiveSpans:  spans,
+		PositiveDeltas: []int64{1, 0, 0},
+	})
+	assert.ErrorContains(t, err, "more than the maximum of")
+}
+
+func TestValidateExponentialHistogramSharesTheBucketBudget(t *testing.T) {
+	// Each range on its own expands to 8192 buckets, so only the sum can exceed the limit.
+	halfTheLimit := []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 8190, Length: 1}}
+	oneMore := []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 8191, Length: 1}}
+
+	fits := &writev2.Histogram{
+		Schema:         8,
+		PositiveSpans:  halfTheLimit,
+		PositiveDeltas: []int64{1, 0},
+		NegativeSpans:  halfTheLimit,
+		NegativeDeltas: []int64{1, 0},
+	}
+	layout, err := validateExponentialHistogram(fits)
+	require.NoError(t, err)
+	assert.Equal(t, int64(maxExponentialHistogramBuckets), layout.positive.numBuckets+layout.negative.numBuckets)
+
+	exceeds := &writev2.Histogram{
+		Schema:         8,
+		PositiveSpans:  halfTheLimit,
+		PositiveDeltas: []int64{1, 0},
+		NegativeSpans:  oneMore,
+		NegativeDeltas: []int64{1, 0},
+	}
+	_, err = validateExponentialHistogram(exceeds)
+	assert.ErrorContains(t, err, "spans expand to 16385 buckets")
+}
+
+func TestHistogramBucketBudgetReserve(t *testing.T) {
+	budget := histogramBucketBudget{remaining: 10}
+
+	fits := exponentialHistogramLayout{
+		positive: bucketSpanLayout{numBuckets: 4},
+		negative: bucketSpanLayout{numBuckets: 4},
+	}
+	require.True(t, budget.reserve(fits))
+	assert.Equal(t, int64(2), budget.remaining)
+	assert.False(t, budget.exhausted)
+
+	// Positive and negative are charged together, so 3 no longer fits in the remaining 2.
+	tooBig := exponentialHistogramLayout{
+		positive: bucketSpanLayout{numBuckets: 2},
+		negative: bucketSpanLayout{numBuckets: 1},
+	}
+	assert.False(t, budget.reserve(tooBig))
+	assert.Equal(t, int64(2), budget.remaining, "a rejected reservation must not consume budget")
+	assert.True(t, budget.exhausted)
+
+	// A later, smaller histogram can still be admitted.
+	assert.True(t, budget.reserve(exponentialHistogramLayout{positive: bucketSpanLayout{numBuckets: 2}}))
+	assert.Equal(t, int64(0), budget.remaining)
+}
+
+func TestRequestBucketBudgetLimitsHistogramExpansion(t *testing.T) {
+	// Each histogram expands to exactly the per-data-point limit from two spans and two deltas,
+	// so the request budget admits maxExponentialHistogramBucketsPerRequest/maxExponentialHistogramBuckets
+	// of them and rejects the rest. Without a request budget a body of these is unbounded.
+	const perRequest = maxExponentialHistogramBucketsPerRequest / maxExponentialHistogramBuckets
+
+	histograms := make([]writev2.Histogram, 0, perRequest+1)
+	for i := range perRequest + 1 {
+		histograms = append(histograms, writev2.Histogram{
+			Count:          &writev2.Histogram_CountInt{CountInt: 2},
+			Sum:            1,
+			Timestamp:      int64(i + 1),
+			StartTimestamp: 1,
+			Schema:         8,
+			PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 16382, Length: 1}},
+			PositiveDeltas: []int64{1, 0},
+		})
+	}
+
+	prwReceiver := setupMetricsReceiver(t)
+	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+		Symbols: []string{"", "__name__", "test_metric", "job", "service-x/test", "instance", "107cn001"},
+		Timeseries: []writev2.TimeSeries{
+			{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: histograms,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).ExponentialHistogram().DataPoints()
+	assert.Equal(t, perRequest, dps.Len(), "the histogram past the request budget must not be translated")
+	assert.Equal(t, perRequest, stats.Histograms, "rejected histograms must not be reported as written")
+	assert.Equal(t, maxExponentialHistogramBuckets, dps.At(0).Positive().BucketCounts().Len())
+}
+
+func TestConvertDeltaBucketsWhenEveryBucketOverflows(t *testing.T) {
+	// A histogram holding nothing but the +Inf overflow bucket. It is consumed and dropped, so
+	// the layout retains nothing at all.
+	spans := []writev2.BucketSpan{{Offset: 1025, Length: 1}}
+	deltas := []int64{10}
+
+	layout, err := validateBucketSpanLayout(spans, len(deltas), exponentialHistogramFiniteLimit(0))
+	require.NoError(t, err)
+	require.False(t, layout.hasBuckets)
+
+	dp := pmetric.NewExponentialHistogramDataPoint()
+	dropped := convertDeltaBuckets(spans, deltas, dp.Positive(), layout)
+
+	assert.Equal(t, uint64(10), dropped)
+	assert.Empty(t, dp.Positive().BucketCounts().AsRaw())
+	assert.Equal(t, int32(0), dp.Positive().Offset())
+}
+
+func TestExponentialHistogramSpanExpansionIsBounded(t *testing.T) {
+	// The trailing span carries a large offset but no bucket, so the conversion has to stay
+	// proportional to the two buckets that are emitted rather than to the offset.
+	spans := []writev2.BucketSpan{{Offset: 0, Length: 2}, {Offset: 100_000_000, Length: 0}}
+	deltas := []int64{1, 2}
+
+	layout, err := validateBucketSpanLayout(spans, len(deltas), exponentialHistogramFiniteLimit(0))
+	require.NoError(t, err)
+	require.Equal(t, int64(2), layout.numBuckets)
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	dp := pmetric.NewExponentialHistogramDataPoint()
+	dropped := convertDeltaBuckets(spans, deltas, dp.Positive(), layout)
+
+	runtime.ReadMemStats(&after)
+
+	assert.Zero(t, dropped)
+	assert.Equal(t, int32(-1), dp.Positive().Offset())
+	assert.Equal(t, []uint64{1, 3}, dp.Positive().BucketCounts().AsRaw())
+	// Reserving one bucket per unit of offset would allocate 800MB here, so the budget only has
+	// to be far below that to catch it.
+	assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(8<<20))
 }
 
 type nonMutatingConsumer struct{}

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -3755,7 +3755,7 @@ func TestHistogramBucketBudgetReserve(t *testing.T) {
 	assert.Equal(t, int64(2), budget.remaining)
 	assert.False(t, budget.exhausted)
 
-	// Positive and negative are charged together, so 3 no longer fits in the remaining 2.
+	// Positive and negative are charged together, so 3 does not fit in the remaining 2.
 	tooBig := exponentialHistogramLayout{
 		positive: bucketSpanLayout{numBuckets: 2},
 		negative: bucketSpanLayout{numBuckets: 1},


### PR DESCRIPTION
#### Description

Prometheus encodes native histogram buckets sparsely, as a list of spans where each offset is the gap since the previous span. OTLP encodes the same buckets densely, as one contiguous `bucket_counts` array per range. Translating between the two means materializing every gap, and a gap costs a few bytes to describe but one `uint64` per bucket to represent.

`convertDeltaBuckets` and `convertAbsoluteBuckets` did not account for that. Both summed the raw span offsets into the bucket capacity before doing anything else:

```go
totalCapacity := len(deltas)
for _, span := range spans {
	totalCapacity += int(span.Offset)
}
buckets.EnsureCapacity(totalCapacity)
```

`span.Offset` is a zigzag `int32` on the wire, so one span can ask for two billion buckets. The `overflowLimit` guard added in #47745 is applied to `buckets.Append` inside the loop, never to this capacity, and the capacity is computed first. A remote write request of a few dozen bytes reserves hundreds of MiB.

Capping the capacity on its own is not enough, because the loop that follows is bounded by the same untrusted value: `for i := int32(0); i < span.Offset; i++` runs once per unit of offset whether or not anything is appended. And there is a third problem in the same code, unrelated to size: nothing checked the span lengths against the number of bucket values sent, so `deltas[bucketIdx]` could read past the end of the slice.

##### Span rules this depends on

The Native Histograms specification, in the [Buckets](https://prometheus.io/docs/specs/native_histograms/#buckets) section, states three rules that the previous code did not enforce:

> Only the first span in each list can have a negative offset.

> Empty spans (with a length of zero) are valid and MAY be used, although they are generally not useful and they SHOULD be eliminated

> The sum of all length values in each span list MUST be equal to the length of the corresponding bucket list.

They all matter here. A negative offset on a later span moves the bucket indexes backwards, which no clamp on the upper end can bound. An empty span produces no bucket, but its offset still shifts everything after it, so it cannot simply be skipped either: for `{-10, 0}, {3, 1}` the single bucket belongs at index -7, not 3. These are the same rules `checkHistogramSpans` applies in `prometheus/model/histogram`.

##### What this changes

Spans are now validated once, before a data point is allocated, in `processHistogramTimeSeries` next to the existing schema check. The validation walks the spans in `int64`, applies the three rules above, clips each span to the overflow limit, and returns the dense range the spans expand into. A histogram is dropped when its spans are malformed or when that range would need more than 16384 buckets.

Conversion then reserves exactly that range, and only fills a gap immediately ahead of a bucket it is about to append. A trailing gap therefore costs nothing, and the iteration count is bounded by the buckets that are emitted rather than by the offsets on the wire.

The way #47745 handles the overflow bucket is kept: it is dropped on its own and left out of the data point count, rather than the whole histogram being rejected. Where exactly that boundary sits did change, and that is the part worth being precise about, because only one index is the overflow bucket.

At scale 0 the last bucket that maps to a finite OTLP bucket is 1024 and the overflow bucket is 1025. A span reaching 1025 keeps its finite buckets and drops that one. A span reaching 1026 or anything above it is not an overflow bucket at all, it is a bucket the specification forbids, so the histogram is rejected. `{Offset: 0, Length: 1}, {Offset: 100000000, Length: 1}` therefore rejects the request rather than expanding to a hundred million buckets, and `TestValidateBucketSpanLayout` pins both the far case and index 1026 one past the boundary.

Stale markers are handled ahead of all of this. The specification says the remaining histogram fields are ignored when the sum is the stale NaN, so a stale marker now becomes a `NoRecordedValue` data point without its spans being validated or translated. Previously the bucket conversion ran for stale markers too, and adding validation in front of it would otherwise have let a stale marker be dropped over spans that are supposed to be ignored.

##### Two corrections to the inherited mapping

While rewriting the converter I checked its boundaries against the [Prometheus compatibility specification](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/), and two things it inherited do not match.

The overflow boundary was off by one. `1024*2^schema` is the last bucket that maps to a finite OTLP bucket; the one above it is the Prometheus overflow bucket, and the specification says "Overflow buckets MUST be dropped and not counted in the overall `Count`". It was being translated as an ordinary bucket. This changes the expectation in the regression test from #47745, which is worth a close look, so I moved its span down by one index to keep the test exercising both sides of the boundary. In practice this only affects buckets covering values above MaxFloat64.

Separately, everything checkable without allocating, including negative bucket counts, now runs before the request budget is reserved. Otherwise a histogram destined to be dropped could reserve part of the budget a later valid histogram needed, making the output depend on the order the timeseries arrived in, and it would still leave an empty metric container behind.

##### Bounding the request, not just the data point

A per data point limit does not bound a request. `TimeSeries` has a repeated `histograms` field, and every translated data point stays in memory until the whole request is handed to the consumer, so the limit above caps each data point at 128KiB but says nothing about how many of them a request may contain.

I measured it on this branch. A histogram that expands to the full 16384 buckets costs 37 bytes on the wire and 131375 bytes in pdata, an amplification of about 3553x. Extrapolated to the 20MiB default `max_request_body_size`, one request could still reach roughly 69GiB.

So the histograms in a request now also share a budget of 4194304 expanded buckets, reserved after validation and before anything is allocated. The same measurement with the budget in place admits 256 of those histograms and stops at 32MiB, whatever the request size. Stale markers do not consume budget, since they expand to nothing.

##### About the bucket limit

16384 is the number @jmacd suggested on the issue. It is not a constant from either specification and I would rather say so than dress it up.

It is worth being precise about what it counts, because it is not what Prometheus counts. `native_histogram_bucket_limit` bounds the *populated* buckets of a histogram; it defaults to `0`, no limit, and when it is set Prometheus reduces the resolution first and only fails the scrape if that is not enough. The limit here bounds the *dense range the spans expand into*, because that is what OTLP has to allocate. The two only coincide for a dense histogram. A histogram with a handful of populated buckets spread tens of thousands of indexes apart is inside Prometheus' limit and outside this one, and would be dropped. That is the real cost of this approach and it seems better to say it here than to have it found in review.

Bounding the dense size is at least the usual thing to do on the OTel side. The SDK's exponential histogram aggregation bounds exactly that with `MaxSize`, default 160 per range, and downscales to stay under it. 16384 is two orders of magnitude looser than that, holds one data point to 128KiB of bucket counts, and at schema 8, the finest schema Prometheus produces, covers a value range of 2^64, so the spans have to straddle roughly 19 orders of magnitude before the width alone reaches the limit.

Doing what Prometheus does and reducing the resolution would be nicer than dropping, but that is a real histogram transformation and felt like too much for a bug fix. Truncating at the limit instead seemed worse than dropping, since it would silently change the distribution while leaving `Count` looking consistent.

I kept it as a constant rather than a config option, on the same "one thing at a time" reasoning, and documented it under Known Limitations next to the existing hardcoded resource metrics cache limit. Happy to make it configurable if you would rather have that.

##### Not in scope

NHCB is untouched. `convertNHCBBuckets` sizes its output from `CustomValues`, so span offsets do not drive its allocation there. `receiver/prometheusreceiver` has a similar zero fill loop but reaches it from a different trust boundary, so I left it out rather than turn this into a change to two ingestion paths.

#### Link to tracking issue
Fixes #50286

#### Testing

Driving `translateV2` with the same requests on `main` and on this branch:

| spans | before | after |
| --- | --- | --- |
| `{0,2}, {100000000,0}` | 800,014,360 B allocated | 8,232 B, translated |
| `{0,1}, {100000000,1}` | 800,014,440 B allocated | 8,280 B, rejected |
| `{0,3}` with two deltas | `panic: runtime error: index out of range [2] with length 2` | dropped, no metric emitted |

762 MiB matches the figure in the issue. The panic is the span length problem above; it is reachable from `POST /api/v1/write`, so it is included here rather than filed separately.

New cases in `TestTranslateV2`: trailing empty span, leading empty span keeping its offset, a distant bucket overflowing without the data point being dropped, spans past the bucket limit on both the integer and the float path, a negative offset on a later span, span lengths longer than the values, and a stale marker whose spans do not match its deltas, which is the shape that must not reach the converter. `TestValidateBucketSpanLayout` covers the span rules directly in 18 cases, including the boundary at exactly 16384 and at 16385 buckets and trailing empty spans past the end of int32, plus tests for the shared positive and negative budget, for the case where every bucket overflows, for the request budget arithmetic, and one asserting the conversion does not allocate in proportion to the offset. `TestRequestBucketBudgetLimitsHistogramExpansion` sends one histogram more than the request budget allows and asserts the extra one is neither translated nor reported as written. The overflow test from #47745 keeps its shape and its expected count of 20; its span moved down one index so that it still exercises a retained bucket and a dropped one under the corrected boundary.

While writing these I also checked the converter against Prometheus' own `PositiveBucketIterator` as an independent oracle, over 48000 randomly generated span layouts across schemas -4, 0, 3 and 8 on both the integer and float paths, comparing bucket contents, dropped overflow totals, the retained index range and the emitted OTLP offset. A fuzz run over the validator and both converters reached 9.5 million executions with no failures. Those harnesses are not part of this PR.

Since this adds a validation pass over the spans, I benchmarked a realistic histogram (schema 3, 24 populated buckets across 5 spans, 20 series per request), median of 8 runs:

| | before | after | |
| --- | --- | --- | --- |
| ns/op | 67122 | 61690 | -8.1% |
| B/op | 23662 | 18846 | -20.4% |
| allocs/op | 358 | 318 | -11.2% |

It comes out slightly ahead, because the old capacity estimate was wrong in the other direction too: for an ordinary histogram the offsets sum to less than the buckets that get appended, so the slice had to grow, while the validated layout reserves exactly what is written.

#### Documentation

Two changelog entries, since the overflow bucket correction is a separate user visible change from the resource bound. Added a "Native Histogram bucket spans" entry under Known Limitations in the receiver README: both limits, what gets dropped, that they count the dense expansion rather than the populated buckets, that stale markers are exempt, and that neither limit is configurable for now. It follows the shape of the existing resource metrics cache entry, which documents its own hardcoded limit the same way.

#### Authorship

- [x] I, a human, wrote this pull request description myself.

