### PR TITLE
[chore] Exclude bot-blocked hosts from link check

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -10,7 +10,10 @@ exclude  = [
     "^https://techdocs.akamai.com",
     "^https://www.vultr.com",
     "^https://docs.splunk.com",
-    "^https://docs.honeycomb.io"
+    "^https://docs.honeycomb.io",
+    "^https://www.ibm.com",
+    "^https://access.redhat.com",
+    "^https://superuser.com"
 ]
 
 # better to be safe and avoid failures


### PR DESCRIPTION
Fixes check-links CI failure e.g. http://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/32064346582/job/95493165190?pr=50291