### PR TITLE
[cmd/opampsupervisor] Ignore non-positive heartbeat interval from connection settings and revert it on failed reconnect

### DIFF
--- a/.chloggen/50268-supervisor-heartbeat-interval-guard.yaml
+++ b/.chloggen/50268-supervisor-heartbeat-interval-guard.yaml
@@ -1,0 +1,34 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ignore non-positive HeartbeatIntervalSeconds from OpAMP connection settings and revert the heartbeat interval when reconnecting with new settings fails
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50268]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously a ConnectionSettingsOffers message that left HeartbeatIntervalSeconds unset
+  overwrote the supervisor's current interval with zero, which opamp-go rejects for HTTP
+  transport and treats as "disable heartbeats" for WebSocket transport. On the HTTP path
+  the subsequent reconnect failed, and because the old interval was not restored the
+  fallback reconnect failed the same way, leaving the supervisor permanently disconnected.
+  Non-positive intervals are now ignored and the previous interval is restored when
+  reconnecting with new settings fails.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1113,8 +1113,12 @@ func (s *Supervisor) onOpampConnectionSettings(_ context.Context, settings *prot
 		return err
 	}
 
-	// Update the heartbeat interval if the agent supports it
-	if s.config.Capabilities.ReportsHeartbeat {
+	// Update the heartbeat interval if the agent supports it.
+	// A value of 0 means "use the current default"; skip the update to avoid
+	// passing a zero duration to the opamp-go sender, which rejects it for HTTP
+	// transport and silently disables heartbeats for WebSocket transport.
+	oldHeartbeatIntervalSeconds := s.heartbeatIntervalSeconds
+	if s.config.Capabilities.ReportsHeartbeat && settings.HeartbeatIntervalSeconds > 0 {
 		s.heartbeatIntervalSeconds = settings.HeartbeatIntervalSeconds
 	}
 
@@ -1130,8 +1134,9 @@ func (s *Supervisor) onOpampConnectionSettings(_ context.Context, settings *prot
 
 	if err := s.startOpAMPClient(); err != nil {
 		s.telemetrySettings.Logger.Error("Cannot connect to the OpAMP server using the new settings", zap.Error(err))
-		// revert the OpAMP server config
+		// revert the OpAMP server config and heartbeat interval
 		s.config.Server = oldServerConfig
+		s.heartbeatIntervalSeconds = oldHeartbeatIntervalSeconds
 		// start the OpAMP client with the old settings
 		if err := s.startOpAMPClient(); err != nil {
 			s.telemetrySettings.Logger.Error("Cannot reconnect to the OpAMP server after restoring old settings", zap.Error(err))

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1114,9 +1114,10 @@ func (s *Supervisor) onOpampConnectionSettings(_ context.Context, settings *prot
 	}
 
 	// Update the heartbeat interval if the agent supports it.
-	// A value of 0 means "use the current default"; skip the update to avoid
-	// passing a zero duration to the opamp-go sender, which rejects it for HTTP
-	// transport and silently disables heartbeats for WebSocket transport.
+	// Ignore non-positive intervals from the server and keep the current value.
+	// This avoids passing a zero duration to the opamp-go sender, which rejects
+	// it for HTTP transport and silently disables heartbeats for WebSocket
+	// transport.
 	oldHeartbeatIntervalSeconds := s.heartbeatIntervalSeconds
 	if s.config.Capabilities.ReportsHeartbeat && settings.HeartbeatIntervalSeconds > 0 {
 		s.heartbeatIntervalSeconds = settings.HeartbeatIntervalSeconds

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -3681,7 +3681,7 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 
 		mp := metric.NewMeterProvider()
-		t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+		t.Cleanup(func() { _ = mp.Shutdown(t.Context()) })
 		metrics, err := telemetry.NewMetrics(mp)
 		require.NoError(t, err)
 
@@ -3727,7 +3727,7 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 
 		t.Cleanup(func() {
 			cancel()
-			stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+			stopCtx, stopCancel := context.WithTimeout(t.Context(), time.Second)
 			defer stopCancel()
 			_ = s.opampClient.Stop(stopCtx)
 		})

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -3746,13 +3746,6 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 		return port
 	}
 
-	t.Run("nil settings is a no-op", func(t *testing.T) {
-		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
-		err := s.onOpampConnectionSettings(t.Context(), nil)
-		require.NoError(t, err)
-		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds)
-	})
-
 	t.Run("zero HeartbeatIntervalSeconds leaves interval unchanged when ReportsHeartbeat=true", func(t *testing.T) {
 		// Per the OpAMP spec, HeartbeatIntervalSeconds=0 means "use current default";
 		// the supervisor must NOT pass 0 to the opamp-go client (HTTP rejects it, WS disables heartbeats).
@@ -3785,13 +3778,11 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval should not change when capability is disabled")
 	})
 
-	t.Run("heartbeat interval reverted when startOpAMPClient fails with new settings", func(t *testing.T) {
+	t.Run("heartbeat interval reverted when reconnect with new settings fails", func(t *testing.T) {
 		// Old endpoint uses HTTP (Start is async → always returns nil).
 		// New endpoint uses WSS with an invalid CA cert: LoadTLSConfig fails synchronously
 		// before any connection is attempted, giving us a reliable way to trigger the
-		// revert path in onOpampConnectionSettings.
-		// After the failure the supervisor falls back to the old endpoint; both the
-		// server config and the heartbeat interval must be restored.
+		// heartbeat rollback path in onOpampConnectionSettings.
 		oldEndpoint := fmt.Sprintf("http://127.0.0.1:%d", freePort(t))
 
 		s := newTestSupervisor(t, oldEndpoint, true)
@@ -3809,7 +3800,6 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 			t.Logf("fallback also failed (expected in some environments): %v", err)
 		}
 		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval must be reverted after failed reconnect")
-		assert.Equal(t, oldEndpoint, s.config.Server.Endpoint, "server endpoint must be reverted after failed reconnect")
 	})
 }
 

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -3671,6 +3671,148 @@ func TestSupervisor_HealthCheckServer(t *testing.T) {
 	})
 }
 
+func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
+	// newTestSupervisor builds a minimal Supervisor for onOpampConnectionSettings tests.
+	// oldEndpoint should use the "http" scheme so that client.Start is asynchronous
+	// and never fails due to the server being absent.
+	newTestSupervisor := func(t *testing.T, oldEndpoint string, reportsHeartbeat bool) *Supervisor {
+		t.Helper()
+
+		ctx, cancel := context.WithCancel(t.Context())
+
+		mp := metric.NewMeterProvider()
+		t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+		metrics, err := telemetry.NewMetrics(mp)
+		require.NoError(t, err)
+
+		agentDesc := &atomic.Value{}
+		agentDesc.Store(&protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{
+				{
+					Key: "service.name",
+					Value: &protobufs.AnyValue{
+						Value: &protobufs.AnyValue_StringValue{StringValue: "test-collector"},
+					},
+				},
+			},
+		})
+		availComp := &atomic.Value{}
+
+		s := &Supervisor{
+			runCtx:       ctx,
+			runCtxCancel: cancel,
+			telemetrySettings: telemetrySettings{
+				TelemetrySettings: component.TelemetrySettings{
+					Logger: zap.NewNop(),
+				},
+			},
+			opampClient: &mockOpAMPClient{setHealthFunc: func(*protobufs.ComponentHealth) {}},
+			config: config.Supervisor{
+				Server: config.OpAMPServer{
+					Endpoint: oldEndpoint,
+				},
+				Capabilities: config.Capabilities{
+					ReportsHeartbeat: reportsHeartbeat,
+				},
+			},
+			heartbeatIntervalSeconds:       30,
+			persistentState:                &persistentState{InstanceID: uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb")},
+			agentDescription:               agentDesc,
+			availableComponents:            availComp,
+			effectiveConfig:                &atomic.Value{},
+			cfgState:                       &atomic.Value{},
+			agentConfigOwnTelemetrySection: &atomic.Value{},
+			metrics:                        metrics,
+		}
+
+		t.Cleanup(func() {
+			cancel()
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+			defer stopCancel()
+			_ = s.opampClient.Stop(stopCtx)
+		})
+
+		return s
+	}
+
+	// freePort returns a TCP port that is not currently listening.
+	// The WS opamp client will get "connection refused" when it tries to connect.
+	freePort := func(t *testing.T) int {
+		t.Helper()
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		port := ln.Addr().(*net.TCPAddr).Port
+		require.NoError(t, ln.Close())
+		return port
+	}
+
+	t.Run("nil settings is a no-op", func(t *testing.T) {
+		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
+		err := s.onOpampConnectionSettings(t.Context(), nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds)
+	})
+
+	t.Run("zero HeartbeatIntervalSeconds leaves interval unchanged when ReportsHeartbeat=true", func(t *testing.T) {
+		// Per the OpAMP spec, HeartbeatIntervalSeconds=0 means "use current default";
+		// the supervisor must NOT pass 0 to the opamp-go client (HTTP rejects it, WS disables heartbeats).
+		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
+		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
+			DestinationEndpoint:      fmt.Sprintf("http://127.0.0.1:%d", freePort(t)),
+			HeartbeatIntervalSeconds: 0,
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval should not change when server sends 0")
+	})
+
+	t.Run("positive HeartbeatIntervalSeconds updates interval when ReportsHeartbeat=true", func(t *testing.T) {
+		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
+		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
+			DestinationEndpoint:      fmt.Sprintf("http://127.0.0.1:%d", freePort(t)),
+			HeartbeatIntervalSeconds: 5,
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 5, s.heartbeatIntervalSeconds, "interval should be updated to server-provided value")
+	})
+
+	t.Run("HeartbeatIntervalSeconds is not updated when ReportsHeartbeat=false", func(t *testing.T) {
+		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), false)
+		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
+			DestinationEndpoint:      fmt.Sprintf("http://127.0.0.1:%d", freePort(t)),
+			HeartbeatIntervalSeconds: 5,
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval should not change when capability is disabled")
+	})
+
+	t.Run("heartbeat interval reverted when startOpAMPClient fails with new settings", func(t *testing.T) {
+		// Old endpoint uses HTTP (Start is async → always returns nil).
+		// New endpoint uses WSS with an invalid CA cert: LoadTLSConfig fails synchronously
+		// before any connection is attempted, giving us a reliable way to trigger the
+		// revert path in onOpampConnectionSettings.
+		// After the failure the supervisor falls back to the old endpoint; both the
+		// server config and the heartbeat interval must be restored.
+		oldEndpoint := fmt.Sprintf("http://127.0.0.1:%d", freePort(t))
+
+		s := newTestSupervisor(t, oldEndpoint, true)
+		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
+			DestinationEndpoint:      fmt.Sprintf("wss://127.0.0.1:%d", freePort(t)),
+			HeartbeatIntervalSeconds: 5,
+			Certificate: &protobufs.TLSCertificate{
+				// Invalid PEM causes LoadTLSConfig to fail synchronously.
+				CaCert: []byte("not-a-valid-pem-certificate"),
+			},
+		})
+		// The error may be nil (fallback succeeded) or non-nil (fallback also failed).
+		// In either case the heartbeat interval must be reverted to the original value.
+		if err != nil {
+			t.Logf("fallback also failed (expected in some environments): %v", err)
+		}
+		assert.EqualValues(t, 30, s.heartbeatIntervalSeconds, "interval must be reverted after failed reconnect")
+		assert.Equal(t, oldEndpoint, s.config.Server.Endpoint, "server endpoint must be reverted after failed reconnect")
+	})
+}
+
 func TestRemoteConfigConcurrentAccess(t *testing.T) {
 	cfg := setupSupervisorConfig(t, configTemplate)
 	s, err := NewSupervisor(t.Context(), nil, cfg)

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -3747,8 +3747,8 @@ func TestSupervisor_onOpampConnectionSettings(t *testing.T) {
 	}
 
 	t.Run("zero HeartbeatIntervalSeconds leaves interval unchanged when ReportsHeartbeat=true", func(t *testing.T) {
-		// Per the OpAMP spec, HeartbeatIntervalSeconds=0 means "use current default";
-		// the supervisor must NOT pass 0 to the opamp-go client (HTTP rejects it, WS disables heartbeats).
+		// Server-sent zero must leave the current interval unchanged; the supervisor
+		// must NOT pass 0 to the opamp-go client (HTTP rejects it, WS disables heartbeats).
 		s := newTestSupervisor(t, fmt.Sprintf("http://127.0.0.1:%d", freePort(t)), true)
 		err := s.onOpampConnectionSettings(t.Context(), &protobufs.OpAMPConnectionSettings{
 			DestinationEndpoint:      fmt.Sprintf("http://127.0.0.1:%d", freePort(t)),


### PR DESCRIPTION
#### Description

This picks up #48362, which the stale bot closed before anyone got to review it. Following @douglascamata's suggestion in #48363, I've cherry-picked @strawgate's original commits with their authorship intact and rebased them onto current `main`.

There are two bugs in `onOpampConnectionSettings`, and they feed into each other:

1. If an `OpAMPConnectionSettings` offer carries a non-positive `HeartbeatIntervalSeconds`, the supervisor applies it as-is and overwrites its current interval with zero. opamp-go won't accept a zero interval over HTTP (`heartbeat interval for httpclient must be greater than zero`), and over WebSocket it quietly turns heartbeats off instead.
2. If reconnecting with the new settings fails, the supervisor restores the previous server config but not the previous heartbeat interval, so the fallback reconnect fails for exactly the same reason. The OpAMP client is stopped at that point and never comes back. The process stays up and keeps logging, so nothing looks obviously broken, but it never polls the server again.

The practical result: a server that sends an offer with only `Headers` set — rotating a token, say, or handing out a per-agent credential at first enrollment — takes the agent offline for good. On first enrollment it never receives a collector config at all. Full analysis and repro steps are in #50268.

With this change, non-positive intervals are ignored and the current value is kept, and the previous interval is restored alongside the previous server config when the reconnect fails.

One difference from #48362: the third fix there (the missing `return` in `saveAndReportConfigStatus`) is dropped, since it has been fixed on `main` in the meantime. Its e2e test and the related test adjustments go with it. That's why one commit here is a partial cherry-pick, as noted in its commit message.

#### Link to tracking issue

Fixes #50268

#### Testing

- Unit tests cherry-picked from #48362 (`TestSupervisor_onOpampConnectionSettings`). They cover: a zero interval leaves the current value alone; a positive interval updates it; nothing is updated when `ReportsHeartbeat` is disabled; and the interval is reverted when reconnecting with the new settings fails.
- The full `cmd/opampsupervisor` suite, `make lint` and `make chlog-validate` pass locally.
- Validated end to end on `windows/amd64` against an OpAMP server sending Headers-only offers over HTTP, i.e. the scenario from #50268.

#### Documentation

Changelog entry added: `.chloggen/50268-supervisor-heartbeat-interval-guard.yaml`. No other documentation changes.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
