### PR TITLE
fix: emit plan_hash_value as raw Oracle value instead of hex-encoded string

### DIFF
--- a/.chloggen/oracledb-raw-plan-hash-value.yaml
+++ b/.chloggen/oracledb-raw-plan-hash-value.yaml
@@ -10,7 +10,7 @@ component: receiver/oracledb
 note: Emit `oracledb.plan_hash_value` as the raw value returned by Oracle rather than hex-encoding the string, making it directly correlatable with `V$SQL.PLAN_HASH_VALUE`.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50307]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/oracledb-raw-plan-hash-value.yaml
+++ b/.chloggen/oracledb-raw-plan-hash-value.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/oracledb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Emit `oracledb.plan_hash_value` as the raw value returned by Oracle rather than hex-encoding the string, making it directly correlatable with `V$SQL.PLAN_HASH_VALUE`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, `oracledb.plan_hash_value` was emitted as a hex-encoding of the ASCII bytes
+  of the string value (e.g. `4199919568` became `34313939393139353638`), making it
+  impossible to correlate directly with `V$SQL.PLAN_HASH_VALUE` in Oracle.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -1647,7 +1647,7 @@ sample query
 | client.port | TCP port used by the client. | Any Int | - |
 | network.peer.address | IP address of the peer client. | Any Str | - |
 | network.peer.port | TCP port used by the peer client. | Any Int | - |
-| oracledb.plan_hash_value | Binary hash value calculated on the query execution plan and used to identify similar query execution plans, reported in the HEX format. | Any Str | - |
+| oracledb.plan_hash_value | Numeric representation of the execution plan. | Any Str | - |
 | oracledb.sql_id | The SQL ID of the query. | Any Str | - |
 | oracledb.child_number | The child number of the query. | Any Str | - |
 | oracledb.child_address | Address of the child cursor. | Any Str | - |
@@ -1737,7 +1737,7 @@ Collection of event metrics for top N queries, filtered based on the highest CPU
 | oracledb.procedure_name | Name of the database object that a query is accessing. | Any Str | - |
 | oracledb.procedure_type | Type of the database object that a query is accessing. | Any Str | - |
 | db.query.comment_tags | Filtered SQL query comments extracted from leading block comments. Contains comma-separated key=value pairs for keys specified in allowed_comment_keys configuration. Used for correlation with APM traces. | Any Str | - |
-| oracledb.plan_hash_value | Binary hash value calculated on the query execution plan and used to identify similar query execution plans, reported in the HEX format. | Any Str | - |
+| oracledb.plan_hash_value | Numeric representation of the execution plan. | Any Str | - |
 | oracledb.plan.first_load | Time at which the plan was first loaded into the library cache, in the server's local timezone. Format: YYYY-MM-DD/HH:MM:SS | Any Str | - |
 | oracledb.plan.last_load | Plan load time in the server's local timezone. Format: YYYY-MM-DD/HH:MM:SS | Any Str | - |
 

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -226,7 +226,7 @@ attributes:
     description: "Plan load time in the server's local timezone. Format: YYYY-MM-DD/HH:MM:SS"
     type: string
   oracledb.plan_hash_value:
-    description: Binary hash value calculated on the query execution plan and used to identify similar query execution plans, reported in the HEX format.
+    description: Numeric representation of the execution plan.
     type: string
   oracledb.procedure_execution_count:
     description: The number of times the stored procedure has been executed, derived from the minimum statement execution count across all statements in the procedure (reporting delta). Please note, this is best effort and may not be accurate in some scenarios. Use with caution.

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	_ "embed"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1790,7 +1789,7 @@ func (s *oracleScraper) collectTopNMetricData(ctx context.Context, logs plog.Log
 				commandType:   commandType,
 				firstLoadTime: row[firstLoadTimeAttr],
 				lastLoadTime:  row[lastLoadTimeAttr],
-				planHashValue: hex.EncodeToString([]byte(row[planHashValueAttr])),
+				planHashValue: row[planHashValueAttr],
 				service:       row[serviceAttr],
 				dbNamespace:   row[dbNamespaceAttr],
 			}
@@ -1970,7 +1969,7 @@ func (s *oracleScraper) collectQuerySamples(ctx context.Context, logs plog.Logs)
 			continue
 		}
 
-		queryPlanHashVal := hex.EncodeToString([]byte(row[planHashValue]))
+		queryPlanHashVal := row[planHashValue]
 
 		queryDuration, err := strconv.ParseFloat(row[duration], 64)
 		if err != nil {

--- a/receiver/oracledbreceiver/testdata/expectedBlockedSessionFile.yaml
+++ b/receiver/oracledbreceiver/testdata/expectedBlockedSessionFile.yaml
@@ -42,7 +42,7 @@ resourceLogs:
                   intValue: "54441"
               - key: oracledb.plan_hash_value
                 value:
-                  stringValue: "31323334353637383930"
+                  stringValue: "1234567890"
               - key: oracledb.sql_id
                 value:
                   stringValue: 9fkq2mxyzabc1

--- a/receiver/oracledbreceiver/testdata/expectedIdleBlockerFile.yaml
+++ b/receiver/oracledbreceiver/testdata/expectedIdleBlockerFile.yaml
@@ -42,7 +42,7 @@ resourceLogs:
                   intValue: "54442"
               - key: oracledb.plan_hash_value
                 value:
-                  stringValue: "39383736353433323130"
+                  stringValue: "9876543210"
               - key: oracledb.sql_id
                 value:
                   stringValue: 7abc123def456

--- a/receiver/oracledbreceiver/testdata/expectedQueryTextAndPlanQuery.yaml
+++ b/receiver/oracledbreceiver/testdata/expectedQueryTextAndPlanQuery.yaml
@@ -108,7 +108,7 @@ resourceLogs:
                   stringValue: ""
               - key: oracledb.plan_hash_value
                 value:
-                  stringValue: "33313233343536373839"
+                  stringValue: "3123456789"
               - key: oracledb.plan.first_load
                 value:
                   stringValue: 2025-12-31/23:00:00

--- a/receiver/oracledbreceiver/testdata/expectedSamplesFile.yaml
+++ b/receiver/oracledbreceiver/testdata/expectedSamplesFile.yaml
@@ -42,7 +42,7 @@ resourceLogs:
                   intValue: "54440"
               - key: oracledb.plan_hash_value
                 value:
-                  stringValue: "34313939393139353638"
+                  stringValue: "4199919568"
               - key: oracledb.sql_id
                 value:
                   stringValue: 48bc50b6fuz4y


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Currently, `oracledb.plan_hash_value` is emitted in a hex-encoded format (e.g. 34313939393139353638 for the value 4199919568). This makes it difficult to correlate directly with V$SQL.PLAN_HASH_VALUE in Oracle, as the values appear mismatched even though it is just a format difference.
This PR switches to emitting the raw decimal value as returned by Oracle, which is directly queryable against V$SQL and V$SQL_PLAN.
@sv-splunk, could you clarify if there was a specific reason for hex-encoding this value in this [PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41312)? If so, happy to revert. If not, the raw decimal seems more useful for end users correlating plan hash values against Oracle views.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes
N/A
<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated test files to reflect the raw decimal values.
<!--Describe the documentation added.-->
#### Documentation
documentation.md regenerated to reflect the updated attribute description.
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
