### PR TITLE
[receiver/otlpjsonfile] count spans and metrics before handing them to the next consumer

### DIFF
--- a/.chloggen/fix-otlpjsonfile-count-after-consume.yaml
+++ b/.chloggen/fix-otlpjsonfile-count-after-consume.yaml
@@ -1,0 +1,34 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/otlp_json_file
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a panic and a zeroed accepted-data count by reading the span and metric counts before the data is handed to the next consumer
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50314]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `EndTracesOp`/`EndMetricsOp` received `SpanCount()`/`MetricCount()` evaluated after
+  `ConsumeTraces`/`ConsumeMetrics` had already returned. By that point a consumer that
+  declares `MutatesData` may own the data - the `batch` processor's background goroutine
+  moves the resource slice out and nils the source - so the receiver counted state it no
+  longer owned. It reported 0 accepted spans or metric points, and could read a torn slice
+  header and crash the collector. The logs path in the same file has captured its count
+  before consuming since #29274.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -143,6 +143,7 @@ func createMetricsReceiver(_ context.Context, settings receiver.Settings, config
 			if err != nil {
 				obsrecv.EndMetricsOp(ctx, metadata.Type.String(), 0, err)
 			} else {
+				metricCount := m.MetricCount()
 				if m.ResourceMetrics().Len() != 0 {
 					// Appends token.Attributes
 					for i := 0; i < m.ResourceMetrics().Len(); i++ {
@@ -157,7 +158,7 @@ func createMetricsReceiver(_ context.Context, settings receiver.Settings, config
 					}
 					err = metrics.ConsumeMetrics(ctx, m)
 				}
-				obsrecv.EndMetricsOp(ctx, metadata.Type.String(), m.MetricCount(), err)
+				obsrecv.EndMetricsOp(ctx, metadata.Type.String(), metricCount, err)
 			}
 		}
 		return nil
@@ -192,6 +193,7 @@ func createTracesReceiver(_ context.Context, settings receiver.Settings, configu
 			if err != nil {
 				obsrecv.EndTracesOp(ctx, metadata.Type.String(), 0, err)
 			} else {
+				spanCount := t.SpanCount()
 				if t.ResourceSpans().Len() != 0 {
 					// Appends token.Attributes
 					for i := 0; i < t.ResourceSpans().Len(); i++ {
@@ -206,7 +208,7 @@ func createTracesReceiver(_ context.Context, settings receiver.Settings, configu
 					}
 					err = traces.ConsumeTraces(ctx, t)
 				}
-				obsrecv.EndTracesOp(ctx, metadata.Type.String(), t.SpanCount(), err)
+				obsrecv.EndTracesOp(ctx, metadata.Type.String(), spanCount, err)
 			}
 		}
 		return nil

--- a/receiver/otlpjsonfilereceiver/file_test.go
+++ b/receiver/otlpjsonfilereceiver/file_test.go
@@ -4,8 +4,10 @@
 package otlpjsonfilereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver"
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -22,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/testdata"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/receiver/xreceiver"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/attrs"
@@ -380,4 +384,127 @@ func TestEmptyLine(t *testing.T) {
 			require.Empty(tt, ls.AllLogs())
 		}, time.Second, 10*time.Millisecond)
 	})
+}
+
+// movingTracesConsumer takes ownership of the traces it is handed the way
+// batchprocessor's background goroutine does: it moves the resource spans out
+// of the caller's ptrace.Traces, leaving it empty.
+type movingTracesConsumer struct {
+	mu   sync.Mutex
+	held ptrace.Traces
+}
+
+func (*movingTracesConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+func (c *movingTracesConsumer) ConsumeTraces(_ context.Context, td ptrace.Traces) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	td.ResourceSpans().MoveAndAppendTo(c.held.ResourceSpans())
+	return nil
+}
+
+func (c *movingTracesConsumer) spanCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.held.SpanCount()
+}
+
+// movingMetricsConsumer is the metrics counterpart of movingTracesConsumer.
+type movingMetricsConsumer struct {
+	mu   sync.Mutex
+	held pmetric.Metrics
+}
+
+func (*movingMetricsConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+func (c *movingMetricsConsumer) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	md.ResourceMetrics().MoveAndAppendTo(c.held.ResourceMetrics())
+	return nil
+}
+
+func (c *movingMetricsConsumer) metricCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.held.MetricCount()
+}
+
+func assertReceiverCount(t *testing.T, tel *componenttest.Telemetry, metricName string, want int64) {
+	t.Helper()
+	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
+		got, err := tel.GetMetric(metricName)
+		if !assert.NoError(tt, err) {
+			return
+		}
+		sum, ok := got.Data.(metricdata.Sum[int64])
+		if !assert.True(tt, ok) {
+			return
+		}
+		if assert.Len(tt, sum.DataPoints, 1) {
+			assert.Equal(tt, want, sum.DataPoints[0].Value)
+		}
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestFileTracesReceiverCountsSpansBeforeConsuming(t *testing.T) {
+	tempFolder := t.TempDir()
+	cfg := createDefaultConfig().(*Config)
+	cfg.Config.Include = []string{filepath.Join(tempFolder, "*")}
+	cfg.Config.StartAt = "beginning"
+
+	tel := componenttest.NewTelemetry()
+	set := receivertest.NewNopSettings(metadata.Type)
+	set.TelemetrySettings = tel.NewTelemetrySettings()
+
+	sink := &movingTracesConsumer{held: ptrace.NewTraces()}
+	rcvr, err := NewFactory().CreateTraces(t.Context(), set, cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, rcvr.Shutdown(t.Context())) })
+
+	td := testdata.GenerateTraces(3)
+	want := int64(td.SpanCount())
+	require.NotZero(t, want)
+	b, err := (&ptrace.JSONMarshaler{}).MarshalTraces(td)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tempFolder, "traces.json"), append(b, '\n'), 0o600))
+
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		assert.Equal(tt, int(want), sink.spanCount())
+	}, 5*time.Second, 10*time.Millisecond)
+	assertReceiverCount(t, tel, "otelcol_receiver_accepted_spans", want)
+}
+
+func TestFileMetricsReceiverCountsMetricsBeforeConsuming(t *testing.T) {
+	tempFolder := t.TempDir()
+	cfg := createDefaultConfig().(*Config)
+	cfg.Config.Include = []string{filepath.Join(tempFolder, "*")}
+	cfg.Config.StartAt = "beginning"
+
+	tel := componenttest.NewTelemetry()
+	set := receivertest.NewNopSettings(metadata.Type)
+	set.TelemetrySettings = tel.NewTelemetrySettings()
+
+	sink := &movingMetricsConsumer{held: pmetric.NewMetrics()}
+	rcvr, err := NewFactory().CreateMetrics(t.Context(), set, cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, rcvr.Shutdown(t.Context())) })
+
+	md := testdata.GenerateMetrics(3)
+	want := int64(md.MetricCount())
+	require.NotZero(t, want)
+	b, err := (&pmetric.JSONMarshaler{}).MarshalMetrics(md)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tempFolder, "metrics.json"), append(b, '\n'), 0o600))
+
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		assert.Equal(tt, int(want), sink.metricCount())
+	}, 5*time.Second, 10*time.Millisecond)
+	assertReceiverCount(t, tel, "otelcol_receiver_accepted_metric_points", want)
 }

--- a/receiver/otlpjsonfilereceiver/go.mod
+++ b/receiver/otlpjsonfilereceiver/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.159.1-0.20260827211935-bdb5c072803c
 	go.opentelemetry.io/collector/receiver/receivertest v0.159.1-0.20260827211935-bdb5c072803c
 	go.opentelemetry.io/collector/receiver/xreceiver v0.159.1-0.20260827211935-bdb5c072803c
+	go.opentelemetry.io/otel/sdk/metric v1.46.0
 	go.uber.org/zap v1.28.0
 )
 
@@ -64,7 +65,6 @@ require (
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.159.1-0.20260827211935-bdb5c072803c // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.46.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.46.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/sys v0.47.0 // indirect


### PR DESCRIPTION
#### Description

The traces and metrics paths read t.SpanCount()/m.MetricCount() in the EndTracesOp/EndMetricsOp call, which runs after ConsumeTraces/ConsumeMetrics has already handed the data to the next consumer. A consumer that declares MutatesData may take ownership of it: batchprocessor's ConsumeTraces only enqueues the value and returns, and a background goroutine then calls MoveAndAppendTo, which nils the source slice. The receiver therefore counts state it no longer owns, and either reports 0 accepted spans or metric points, or reads a torn slice header and crashes with a SIGSEGV inside ResourceSpansSlice.At.

Capture the counts before the data is handed downstream, the way the logs path in the same file has done since #29274. The `ResourceSpans().Len() != 0` / `ResourceMetrics().Len() != 0` guards are deliberately left as they are: switching them to the captured count would stop forwarding entries that have resources but no spans/metrics, which would be a behavior change beyond this fix.

#### Link to tracking issue

Fixes #50314

#### Testing

Two regression tests added (`TestFileTracesReceiverCountsSpansBeforeConsuming`, `TestFileMetricsReceiverCountsMetricsBeforeConsuming`): each hands the receiver a consumer that declares `MutatesData: true` and takes ownership of the data synchronously, then asserts `otelcol_receiver_accepted_spans` / `otelcol_receiver_accepted_metric_points`. Both fail on `main` with `expected: 3, actual: 0` and pass with the fix - deterministic, no race detector or load needed. `make lint` and `make test` are clean in the component (27 tests, with `-race`).

#### Authorship

- [x] I, a human, wrote this pull request description myself.