### PR TITLE
[exporter/elasticsearch] Fix ignored `timeout` config regression

### DIFF
--- a/.chloggen/elasticsearchexporter_fix-timeout.yaml
+++ b/.chloggen/elasticsearchexporter_fix-timeout.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix ignored `timeout` config regression
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50316]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/esclient.go
+++ b/exporter/elasticsearchexporter/esclient.go
@@ -56,6 +56,19 @@ func countRetriesInterceptor() elastictransport.InterceptorFunc {
 	}
 }
 
+// timeoutInterceptor injects a context that enforces a timeout per http request over the wire.
+func timeoutInterceptor(perRequestTimeout time.Duration) elastictransport.InterceptorFunc {
+	return func(next elastictransport.RoundTripFunc) elastictransport.RoundTripFunc {
+		return func(req *http.Request) (*http.Response, error) {
+			// ctx is not reused across retries
+			// Therefore, timeoutInterceptor would not result in nesting of WithTimeout
+			ctx, cancel := context.WithTimeout(req.Context(), perRequestTimeout)
+			defer cancel()
+			return next(req.WithContext(ctx))
+		}
+	}
+}
+
 // clientLogger implements the estransport.Logger interface
 // that is required by the Elasticsearch client for logging.
 type clientLogger struct {
@@ -264,6 +277,7 @@ func newElasticsearchClient(
 			elastictransportversion.Version,
 		),
 		Interceptors: []elastictransport.InterceptorFunc{
+			timeoutInterceptor(httpClient.Timeout),
 			countRetriesInterceptor(),
 		},
 	}

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -3775,7 +3775,8 @@ func TestExporterTimeout_NoRetryOnTimeout(t *testing.T) {
 
 func TestExporterTimeout_Independent(t *testing.T) {
 	// Server responds with HTTP 429 for first few attempts.
-	// Ensure timeout is not shared across retries by checking the last attempt exceeds configured timeout
+	// Ensure timeout is not shared across retries by
+	// checking the total time elapsed across attempts exceeds configured timeout
 	successfulOnAttempt := 3
 	var count atomic.Int32
 	server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, r *http.Request) {

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -3743,3 +3743,73 @@ func actionGetValue(t *testing.T, actionJSON json.RawMessage, target string) str
 	require.True(t, ok, "the type of action.create.%s was not string", target)
 	return vString
 }
+
+func TestExporterTimeout_NoRetryOnTimeout(t *testing.T) {
+	var count atomic.Int32
+	done := make(chan struct{}, 1)
+	defer close(done)
+	server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, r *http.Request) {
+		if count.Add(1) == 1 {
+			<-done
+		}
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	exporter := newTestLogsExporter(t, server.URL, func(cfg *Config) {
+		cfg.ClientConfig.Timeout = 50 * time.Millisecond
+		cfg.Retry.Enabled = true
+		cfg.Retry.MaxRetries = 1
+		cfg.Retry.InitialInterval = 1 * time.Millisecond
+		cfg.QueueBatchConfig.Get().Batch.Get().MinSize = 0
+		cfg.QueueBatchConfig.Get().WaitForResult = true
+	})
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.LogRecords().AppendEmpty()
+	logs.MarkReadOnly()
+	err := exporter.ConsumeLogs(t.Context(), logs)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, int32(1), count.Load())
+}
+
+func TestExporterTimeout_Independent(t *testing.T) {
+	// Server responds with HTTP 429 for first few attempts.
+	// Ensure timeout is not shared across retries by checking the last attempt exceeds configured timeout
+	successfulOnAttempt := 3
+	var count atomic.Int32
+	server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, r *http.Request) {
+		if int(count.Add(1)) < successfulOnAttempt {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	timeout := 50 * time.Millisecond
+	exporter := newTestLogsExporter(t, server.URL, func(cfg *Config) {
+		cfg.ClientConfig.Timeout = timeout
+		cfg.Retry.Enabled = true
+		cfg.Retry.MaxRetries = 1000
+		// Since backoff uses equal jitter, the actual wait may be the configured interval / 2.
+		// Configure to 2 * timeout to offset that effect.
+		cfg.Retry.InitialInterval = 2 * timeout
+		cfg.Retry.MaxInterval = 2 * timeout
+
+		cfg.QueueBatchConfig.Get().Batch.Get().MinSize = 0
+		cfg.QueueBatchConfig.Get().WaitForResult = true
+	})
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.LogRecords().AppendEmpty()
+	logs.MarkReadOnly()
+
+	start := time.Now()
+	err := exporter.ConsumeLogs(t.Context(), logs)
+	var errFlushFailed docappender.ErrorFlushFailed
+	assert.ErrorAs(t, err, &errFlushFailed)
+	assert.ErrorContains(t, err, "418")
+	assert.Equal(t, int32(successfulOnAttempt), count.Load())
+	assert.GreaterOrEqual(t, time.Now().Sub(start), timeout)
+}

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -3748,7 +3748,7 @@ func TestExporterTimeout_NoRetryOnTimeout(t *testing.T) {
 	var count atomic.Int32
 	done := make(chan struct{}, 1)
 	defer close(done)
-	server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, r *http.Request) {
+	server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, _ *http.Request) {
 		if count.Add(1) == 1 {
 			<-done
 		}
@@ -3779,7 +3779,7 @@ func TestExporterTimeout_Independent(t *testing.T) {
 	// checking the total time elapsed across attempts exceeds configured timeout
 	successfulOnAttempt := 3
 	var count atomic.Int32
-	server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, r *http.Request) {
+	server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, _ *http.Request) {
 		if int(count.Add(1)) < successfulOnAttempt {
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
@@ -3812,5 +3812,5 @@ func TestExporterTimeout_Independent(t *testing.T) {
 	assert.ErrorAs(t, err, &errFlushFailed)
 	assert.ErrorContains(t, err, "418")
 	assert.Equal(t, int32(successfulOnAttempt), count.Load())
-	assert.GreaterOrEqual(t, time.Now().Sub(start), timeout)
+	assert.GreaterOrEqual(t, time.Since(start), timeout)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix `timeout` config being ignored and becoming effectively infinite, which is a regression from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49834.

After this fix, the `timeout` should be applied per retry AND not shared between retries in a request.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50316

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
