### PR TITLE
[receiver/prometheusremotewritereceiver] Fix float NHCB bucket values across spans

### DIFF
--- a/.chloggen/nhcb-float-multi-span-bucket-index.yaml
+++ b/.chloggen/nhcb-float-multi-span-bucket-index.yaml
@@ -1,0 +1,14 @@
+change_type: bug_fix
+
+component: receiver/prometheus_remote_write
+
+note: Read the correct bucket values for float custom bucket histograms that use more than one span.
+
+issues: [50331]
+
+subtext: |
+  The float branch restarted the bucket value index at every span, so the second
+  and later spans of a Native Histogram with Custom Buckets were filled with the
+  values belonging to the first span. The integer branch was already correct.
+
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -980,15 +980,18 @@ func convertNHCBBuckets(histogram *writev2.Histogram) []uint64 {
 	if histogram.IsFloatHistogram() {
 		// Float histograms: values are absolute counts
 		bucketIdx := 0
+		countIdx := 0
+
 		for _, span := range histogram.PositiveSpans {
 			// Skip empty buckets based on offset
 			bucketIdx += int(span.Offset)
 
 			// Fill buckets for this span
-			for i := uint32(0); i < span.Length && bucketIdx < len(bucketCounts) && i < uint32(len(histogram.PositiveCounts)); i++ {
+			for i := uint32(0); i < span.Length && bucketIdx < len(bucketCounts) && countIdx < len(histogram.PositiveCounts); i++ {
 				if bucketIdx >= 0 && bucketIdx < len(bucketCounts) {
-					bucketCounts[bucketIdx] = uint64(histogram.PositiveCounts[i])
+					bucketCounts[bucketIdx] = uint64(histogram.PositiveCounts[countIdx])
 				}
+				countIdx++
 				bucketIdx++
 			}
 		}

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -1200,6 +1200,77 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
+			name: "NHCB translation with float counts across multiple spans",
+			// The second span must read the bucket values that follow the first span's, so bucket
+			// 0 gets 10 and bucket 2 gets 20. The integer path above already does this.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__",
+					"test_hncb_histogram",
+					"job",
+					"test",
+					"instance",
+					"localhost:8080",
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Timestamp:      123456789,
+								StartTimestamp: 123456000,
+								Schema:         -53,
+								Sum:            30.0,
+								Count:          &writev2.Histogram_CountFloat{CountFloat: 30},
+								CustomValues:   []float64{1.0, 2.0, 5.0},
+								PositiveSpans: []writev2.BucketSpan{
+									{Offset: 0, Length: 1},
+									{Offset: 1, Length: 1},
+								},
+								PositiveCounts: []float64{10, 20},
+							},
+						},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Histograms: 1,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "localhost:8080")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("OpenTelemetry Collector")
+				sm.Scope().SetVersion("latest")
+				m1 := sm.Metrics().AppendEmpty()
+				m1.SetName("test_hncb_histogram")
+				m1.SetUnit("")
+				m1.SetDescription("")
+				m1.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+				hist := m1.SetEmptyHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp := hist.DataPoints().AppendEmpty()
+				dp.SetStartTimestamp(pcommon.Timestamp(123456000 * int64(time.Millisecond)))
+				dp.SetTimestamp(pcommon.Timestamp(123456789 * int64(time.Millisecond)))
+				dp.SetSum(30.0)
+				dp.SetCount(30)
+				dp.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 5.0})
+				dp.BucketCounts().FromRaw([]uint64{10, 0, 20, 0})
+
+				return metrics
+			}(),
+		},
+		{
 			name: "NHCB translation with stale NaN",
 			request: &writev2.Request{
 				Symbols: []string{


### PR DESCRIPTION
> **Superseded by #50343, closing this.**
>
> The indexing bug described below is real, but the stable Prometheus to OTLP mapping requires float flavored native histograms to be dropped, custom buckets included. #50343 removes this conversion path entirely, so the line this PR fixes no longer exists there, and it carries a test asserting that a float NHCB histogram is rejected rather than translated.
>
> Fixing the output of a path that is about to be deleted, and having a test depend on that output, would leave the receiver relying on behaviour the specification does not allow. If #50337 concludes that a documented non-standard extension is wanted after all, this can be reopened, since the branch and the analysis below still stand.

---

#### Description

`convertNHCBBuckets` has two branches, one for integer bucket values and one for float ones. The integer branch keeps a `deltaIdx` declared outside the span loop, so it walks the value list once from start to end. The float branch instead indexes the values with `i`, the counter of the inner per-span loop, and `i` restarts at zero for every span.

The result is that a Native Histogram with Custom Buckets whose buckets are split across more than one span gets the first span's values copied into every later span:

```go
// float branch, before
for i := uint32(0); i < span.Length && bucketIdx < len(bucketCounts) && i < uint32(len(histogram.PositiveCounts)); i++ {
    bucketCounts[bucketIdx] = uint64(histogram.PositiveCounts[i])
    bucketIdx++
}
```

This gives the float branch its own `countIdx` with the same lifetime as the integer branch's `deltaIdx`. The bound on the inner loop moves to `countIdx` as well, so the value list is still never read past its end, which is what the old `i < uint32(len(...))` condition was there for.

A single span is the usual shape for NHCB, which is probably why this survived. Nothing rejects multiple spans though, so until now the receiver quietly emitted wrong bucket counts instead of failing.

I did not touch the integer branch, and I did not change anything else about how NHCB is validated. There is more to look at in this function, unsorted or non-finite custom bounds and the bucketless case for example, but those are separate problems and this one is small enough to stand on its own.

#### Link to tracking issue
Fixes #50331

#### Testing

Added a case to `TestTranslateV2` that sends three custom values, so four buckets, with the two populated buckets split across two spans:

```go
CustomValues:   []float64{1.0, 2.0, 5.0},
PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 1, Length: 1}},
PositiveCounts: []float64{10, 20},
```

Expected `[10 0 20 0]`, which is what the integer path already produces for the equivalent histogram. Before the change the same request produced `[10 0 10 0]`. I checked that by reverting just the two lines and re-running the case, and it fails on exactly that bucket:

```
--- FAIL: TestTranslateV2/NHCB_translation_with_float_counts_across_multiple_spans
    expected: []uint64{0xa, 0x0, 0x14, 0x0}
    actual  : []uint64{0xa, 0x0, 0xa, 0x0}
```

The rest of the package tests are unchanged and still pass, including the existing single-span NHCB cases and the NHCB stale marker case.

#### Documentation

None. This is a translation fix with no configuration or documented behaviour attached to it.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.
