### PR TITLE
[pkg/stanza] Add `drop_field` parser functionality

### DIFF
--- a/.chloggen/stanza_operator_drop_field.yaml
+++ b/.chloggen/stanza_operator_drop_field.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `drop_field` functionality to all parser operators.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50362]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This allows all parser operators to delete a field after the data is parsed out of it.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/docs/operators/json_parser.md
+++ b/pkg/stanza/docs/operators/json_parser.md
@@ -10,6 +10,7 @@ The `json_parser` operator parses the string-type field selected by `parse_from`
 | `output`     | Next in pipeline | The connected operator(s) that will receive all outbound entries. |
 | `parse_from` | `body`           | The [field](../types/field.md) from which the value will be parsed. |
 | `parse_to`   | `attributes`     | The [field](../types/field.md) to which the value will be parsed. |
+| `drop_field` | `false`          | Whether to drop the `parse_from` field after parsing. |
 | `on_error`   | `send`           | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
 | `if`         |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
 | `timestamp`  | `nil`            | An optional [timestamp](../types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator. |

--- a/pkg/stanza/docs/operators/severity_parser.md
+++ b/pkg/stanza/docs/operators/severity_parser.md
@@ -13,6 +13,7 @@ The `severity_parser` operator sets the severity on an entry by parsing a value 
 | `preset`         | `default`         | A predefined set of values that should be interpreted at specific severity levels. |
 | `mapping`        |                   | A formatted set of values that should be interpreted as severity levels. |
 | `overwrite_text` | `false`           | If `true`, the severity text will be set to the [standard short name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#displaying-severity) corresponding to the severity number. |
+| `drop_field`     | `false`           | If `true`, the `parse_from` field will be removed from the entry after parsing. |
 | `if`             |                   | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
 
 ### Example Configurations

--- a/pkg/stanza/docs/operators/time_parser.md
+++ b/pkg/stanza/docs/operators/time_parser.md
@@ -13,6 +13,7 @@ The `time_parser` operator sets the timestamp on an entry by parsing a value fro
 | `layout`               | required         | The exact layout of the timestamp to be parsed. |
 | `location`             | `Local`          | The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database. [This page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) contains many examples, such as `America/New_York`. |
 | `time_zone_locations`  |                  | An optional map of timezone abbreviations to IANA location names (e.g. `PDT: America/Los_Angeles`). When the `%Z` directive is used and the parsed abbreviation matches a key in this map, the corresponding IANA location is used for parsing instead of `location`. This allows correct parsing of log streams that contain timestamps from multiple timezones. |
+| `drop_field`           | `false`          | If `true`, the `parse_from` field will be removed from the entry after parsing. |
 | `if`                   |                  | An [expression](../types/expression.md) that, when set, will be evaluated to determine whether this operator should be used for the given entry. This allows you to do easy conditional parsing without branching logic with routers. |
 | `on_error`             | `send`           | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
 

--- a/pkg/stanza/docs/types/severity.md
+++ b/pkg/stanza/docs/types/severity.md
@@ -14,6 +14,7 @@ Parser operators can parse a severity and attach the resulting value to a log en
 | `preset`         | `default` | A predefined set of values that should be interpretted at specific severity levels. |
 | `mapping`        |           | A custom set of values that should be interpretted at designated severity levels. |
 | `overwrite_text` | `false`   | If `true`, the severity text will be set to the [recommended short name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#displaying-severity) corresponding to the severity number. |
+| `drop_field`     | `false`   | If `true`, the `parse_from` field will be removed from the entry after parsing. |
 
 Note that by default the severity _text_ will be set to the original value which was interpreted into a severity number. In order to set the severity text to a standard short name (e.g. `ERROR`, `INFO3`, etc.), set `overwrite_text` to `true`.
 

--- a/pkg/stanza/docs/types/timestamp.md
+++ b/pkg/stanza/docs/types/timestamp.md
@@ -13,6 +13,7 @@ If a timestamp block is specified, the parser operator will perform the timestam
 | `layout`               | required   | The exact layout of the timestamp to be parsed. |
 | `location`             | `Local`    | The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database. [This page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) contains many examples, such as `America/New_York`. |
 | `time_zone_locations`  |            | An optional map of timezone abbreviations to IANA location names (e.g. `PDT: America/Los_Angeles`). When the `%Z` directive is used and the parsed abbreviation matches a key in this map, the corresponding IANA location is used for parsing instead of `location`. This allows correct parsing of log streams that contain timestamps from multiple timezones. |
+| `drop_field`           | `false`    | If `true`, the `parse_from` field will be removed from the entry after parsing. |
 
 ## Layout Types
 
@@ -142,7 +143,7 @@ service:
 ```
 
 Note that this configuration has a side effect of creating a `timestamp_field` attribute for each log record.
-To get rid of the attribute, use the `remove` operator:
+To get rid of the attribute, add `drop_field: true` to the `timestamp` block (or use the `remove` operator):
 
 ```yaml
 exporters:

--- a/pkg/stanza/operator/helper/config.schema.yaml
+++ b/pkg/stanza/operator/helper/config.schema.yaml
@@ -76,6 +76,8 @@ $defs:
     description: SeverityConfig allows users to specify how to parse a severity from a field.
     type: object
     properties:
+      drop_field:
+        type: boolean
       mapping:
         type: object
         additionalProperties:
@@ -97,6 +99,8 @@ $defs:
     description: TimeParser is a helper that parses time onto an entry.
     type: object
     properties:
+      drop_field:
+        type: boolean
       layout:
         type: string
       layout_type:

--- a/pkg/stanza/operator/helper/drop_field.go
+++ b/pkg/stanza/operator/helper/drop_field.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package helper // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+
+import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+
+// DropFieldConfig provides configuration for dropping parsed fields from an entry.
+type DropFieldConfig struct {
+	DropField bool `mapstructure:"drop_field,omitempty"`
+}
+
+// Drop deletes the field from the entry if DropField is set to true.
+func (c DropFieldConfig) Drop(ent *entry.Entry, field entry.Field) {
+	if c.DropField {
+		ent.Delete(field)
+	}
+}

--- a/pkg/stanza/operator/helper/parser.go
+++ b/pkg/stanza/operator/helper/parser.go
@@ -31,6 +31,7 @@ func NewParserConfig(operatorID, operatorType string) ParserConfig {
 // ParserConfig provides the basic implementation of a parser config.
 type ParserConfig struct {
 	TransformerConfig `mapstructure:",squash"`
+	DropFieldConfig   `mapstructure:",squash"`
 	ParseFrom         entry.Field         `mapstructure:"parse_from"`
 	ParseTo           entry.RootableField `mapstructure:"parse_to"`
 	BodyField         *entry.Field        `mapstructure:"body"`
@@ -53,6 +54,7 @@ func (c ParserConfig) Build(set component.TelemetrySettings) (ParserOperator, er
 
 	parserOperator := ParserOperator{
 		TransformerOperator: transformerOperator,
+		DropFieldConfig:     c.DropFieldConfig,
 		ParseFrom:           c.ParseFrom,
 		ParseTo:             c.ParseTo.Field,
 		BodyField:           c.BodyField,
@@ -90,9 +92,10 @@ func (c ParserConfig) Build(set component.TelemetrySettings) (ParserOperator, er
 // ParserOperator provides a basic implementation of a parser operator.
 type ParserOperator struct {
 	TransformerOperator
-	ParseFrom       entry.Field
-	ParseTo         entry.Field
-	BodyField       *entry.Field
+	DropFieldConfig
+	ParseFrom entry.Field
+	ParseTo   entry.Field
+	BodyField *entry.Field
 	TimeParser      *TimeParser
 	SeverityParser  *SeverityParser
 	TraceParser     *TraceParser
@@ -243,6 +246,7 @@ func (p *ParserOperator) ParseWith(ctx context.Context, entry *entry.Entry, pars
 	if scopeNameParserErr != nil {
 		return handle(fmt.Errorf("scope_name parser: %w", scopeNameParserErr))
 	}
+	p.Drop(entry, p.ParseFrom)
 	return nil
 }
 

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -658,6 +658,110 @@ func TestParserFields(t *testing.T) {
 				return e
 			},
 		},
+		{
+			"ParseFromBodyFieldWithDrop",
+			func(cfg *ParserConfig) {
+				cfg.ParseFrom = entry.NewBodyField("one", "two")
+				cfg.DropField = true
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Body = map[string]any{
+					"one": map[string]any{
+						"two": keyValue,
+					},
+				}
+				return e
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Body = map[string]any{
+					"one": map[string]any{},
+				}
+				e.Attributes = map[string]any{
+					"key": "value",
+				}
+				return e
+			},
+		},
+		{
+			"ParseFromAttributeFieldWithDrop",
+			func(cfg *ParserConfig) {
+				cfg.ParseFrom = entry.NewAttributeField("one", "two")
+				cfg.DropField = true
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Attributes = map[string]any{
+					"one": map[string]any{
+						"two": keyValue,
+					},
+				}
+				return e
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Attributes = map[string]any{
+					"key": "value",
+					"one": map[string]any{},
+				}
+				return e
+			},
+		},
+		{
+			"ParseFromResourceFieldWithDrop",
+			func(cfg *ParserConfig) {
+				cfg.ParseFrom = entry.NewResourceField("one", "two")
+				cfg.DropField = true
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Resource = map[string]any{
+					"one": map[string]any{
+						"two": keyValue,
+					},
+				}
+				return e
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Attributes = map[string]any{
+					"key": "value",
+				}
+				e.Resource = map[string]any{
+					"one": map[string]any{},
+				}
+				return e
+			},
+		},
+		{
+			"ParseFromBodyRootWithDrop",
+			func(cfg *ParserConfig) {
+				cfg.ParseFrom = entry.NewBodyField()
+				cfg.DropField = true
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Body = keyValue
+				return e
+			},
+			func() *entry.Entry {
+				e := entry.New()
+				e.ObservedTimestamp = now
+				e.Body = nil
+				e.Attributes = map[string]any{
+					"key": "value",
+				}
+				return e
+			},
+		},
 	}
 
 	parse := func(i any) (any, error) {

--- a/pkg/stanza/operator/helper/severity.go
+++ b/pkg/stanza/operator/helper/severity.go
@@ -14,6 +14,7 @@ import (
 
 // SeverityParser is a helper that parses severity onto an entry.
 type SeverityParser struct {
+	DropFieldConfig
 	ParseFrom     entry.Field
 	Mapping       severityMap
 	overwriteText bool
@@ -40,6 +41,7 @@ func (p *SeverityParser) Parse(ent *entry.Entry) error {
 
 	ent.Severity = severity
 	ent.SeverityText = sevText
+	p.Drop(ent, p.ParseFrom)
 	return nil
 }
 

--- a/pkg/stanza/operator/helper/severity_builder.go
+++ b/pkg/stanza/operator/helper/severity_builder.go
@@ -112,10 +112,11 @@ func NewSeverityConfig() SeverityConfig {
 
 // SeverityConfig allows users to specify how to parse a severity from a field.
 type SeverityConfig struct {
-	ParseFrom     *entry.Field   `mapstructure:"parse_from,omitempty"`
-	Preset        string         `mapstructure:"preset,omitempty"`
-	Mapping       map[string]any `mapstructure:"mapping,omitempty"`
-	OverwriteText bool           `mapstructure:"overwrite_text,omitempty"`
+	DropFieldConfig `mapstructure:",squash"`
+	ParseFrom       *entry.Field   `mapstructure:"parse_from,omitempty"`
+	Preset          string         `mapstructure:"preset,omitempty"`
+	Mapping         map[string]any `mapstructure:"mapping,omitempty"`
+	OverwriteText   bool           `mapstructure:"overwrite_text,omitempty"`
 }
 
 // Build builds a SeverityParser from a SeverityConfig
@@ -151,9 +152,10 @@ func (c *SeverityConfig) Build(_ component.TelemetrySettings) (SeverityParser, e
 	}
 
 	p := SeverityParser{
-		ParseFrom:     *c.ParseFrom,
-		Mapping:       operatorMapping,
-		overwriteText: c.OverwriteText,
+		DropFieldConfig: c.DropFieldConfig,
+		ParseFrom:       *c.ParseFrom,
+		Mapping:         operatorMapping,
+		overwriteText:   c.OverwriteText,
 	}
 
 	return p, nil

--- a/pkg/stanza/operator/helper/severity_test.go
+++ b/pkg/stanza/operator/helper/severity_test.go
@@ -552,6 +552,30 @@ func (tc severityTestCase) run(parseFrom entry.Field) func(*testing.T) {
 	}
 }
 
+func TestSeverityParserDropField(t *testing.T) {
+	t.Parallel()
+
+	parseFrom := entry.NewBodyField("severity_field")
+	cfg := &SeverityConfig{
+		ParseFrom:       &parseFrom,
+		DropFieldConfig: DropFieldConfig{DropField: true},
+	}
+
+	set := componenttest.NewNopTelemetrySettings()
+	severityParser, err := cfg.Build(set)
+	require.NoError(t, err)
+
+	ent := entry.New()
+	require.NoError(t, ent.Set(parseFrom, "INFO"))
+
+	err = severityParser.Parse(ent)
+	require.NoError(t, err)
+
+	require.Equal(t, entry.Info, ent.Severity)
+	_, ok := ent.Get(parseFrom)
+	require.False(t, ok, "expected parseFrom field to be dropped")
+}
+
 func TestBuildCustomMapping(t *testing.T) {
 	t.Parallel()
 
@@ -622,6 +646,15 @@ func TestUnmarshalSeverityConfig(t *testing.T) {
 					c := newHelpersConfig()
 					c.Severity = NewSeverityConfig()
 					c.Severity.Preset = "http"
+					return c
+				}(),
+			},
+			{
+				Name: "drop_field",
+				Expect: func() *helpersConfig {
+					c := newHelpersConfig()
+					c.Severity = NewSeverityConfig()
+					c.Severity.DropField = true
 					return c
 				}(),
 			},

--- a/pkg/stanza/operator/helper/testdata/severity.yaml
+++ b/pkg/stanza/operator/helper/testdata/severity.yaml
@@ -19,3 +19,7 @@ preset:
   type: helpers_test
   severity:
     preset: http
+drop_field:
+  type: helpers_test
+  severity:
+    drop_field: true

--- a/pkg/stanza/operator/helper/testdata/timestamp.yaml
+++ b/pkg/stanza/operator/helper/testdata/timestamp.yaml
@@ -20,3 +20,7 @@ time_zone_locations:
     time_zone_locations:
       PDT: America/Los_Angeles
       NZST: Pacific/Auckland
+drop_field:
+  type: helpers_test
+  time:
+    drop_field: true

--- a/pkg/stanza/operator/helper/time.go
+++ b/pkg/stanza/operator/helper/time.go
@@ -42,6 +42,7 @@ func NewTimeParser() TimeParser {
 
 // TimeParser is a helper that parses time onto an entry.
 type TimeParser struct {
+	DropFieldConfig   `mapstructure:",squash"`
 	ParseFrom         *entry.Field      `mapstructure:"parse_from"`
 	Layout            string            `mapstructure:"layout"`
 	LayoutType        string            `mapstructure:"layout_type"`
@@ -220,6 +221,7 @@ func (t *TimeParser) Parse(entry *entry.Entry) error {
 		return fmt.Errorf("unsupported layout type: %s", t.LayoutType)
 	}
 
+	t.Drop(entry, *t.ParseFrom)
 	return nil
 }
 

--- a/pkg/stanza/operator/helper/time_test.go
+++ b/pkg/stanza/operator/helper/time_test.go
@@ -754,6 +754,35 @@ func TestUnmarshalTimeConfig(t *testing.T) {
 					return c
 				}(),
 			},
+			{
+				Name: "drop_field",
+				Expect: func() *helpersConfig {
+					c := newHelpersConfig()
+					c.Time = NewTimeParser()
+					c.Time.DropField = true
+					return c
+				}(),
+			},
 		},
 	}.Run(t)
+}
+
+func TestTimeParserDropField(t *testing.T) {
+	t.Parallel()
+
+	parseFrom := entry.NewBodyField("timestamp_field")
+	tp := &TimeParser{
+		LayoutType: EpochKey,
+		Layout:     "s",
+		ParseFrom:       &parseFrom,
+		DropFieldConfig: DropFieldConfig{DropField: true},
+	}
+
+	ent := makeTestEntry(parseFrom, "1136214245")
+	require.NoError(t, tp.Validate())
+	require.NoError(t, tp.Parse(ent))
+
+	require.Equal(t, time.Unix(1136214245, 0), ent.Timestamp)
+	_, ok := ent.Get(parseFrom)
+	require.False(t, ok, "expected parseFrom field to be dropped")
 }

--- a/pkg/stanza/operator/parser/jsonparser/config_test.go
+++ b/pkg/stanza/operator/parser/jsonparser/config_test.go
@@ -118,6 +118,14 @@ func TestConfig(t *testing.T) {
 					return p
 				}(),
 			},
+			{
+				Name: "drop_field",
+				Expect: func() *Config {
+					p := NewConfig()
+					p.DropField = true
+					return p
+				}(),
+			},
 		},
 	}.Run(t)
 }

--- a/pkg/stanza/operator/parser/jsonparser/parser_test.go
+++ b/pkg/stanza/operator/parser/jsonparser/parser_test.go
@@ -246,6 +246,42 @@ func TestParser(t *testing.T) {
 				Body: `{"int":1,"float":1.0,"nested":{"int":2,"float":2.0,"array":[1,2]},"array":[3,4]}`,
 			},
 		},
+		{
+			"drop_field",
+			func(p *Config) {
+				p.DropField = true
+			},
+			&entry.Entry{
+				Body: `{"superkey":"superval"}`,
+			},
+			&entry.Entry{
+				Attributes: map[string]any{
+					"superkey": "superval",
+				},
+				Body: nil,
+			},
+		},
+		{
+			"drop_field_from_subfield",
+			func(p *Config) {
+				p.ParseFrom = entry.NewBodyField("raw_json")
+				p.DropField = true
+			},
+			&entry.Entry{
+				Body: map[string]any{
+					"raw_json": `{"superkey":"superval"}`,
+					"other":    "value",
+				},
+			},
+			&entry.Entry{
+				Attributes: map[string]any{
+					"superkey": "superval",
+				},
+				Body: map[string]any{
+					"other": "value",
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/stanza/operator/parser/jsonparser/testdata/config.yaml
+++ b/pkg/stanza/operator/parser/jsonparser/testdata/config.yaml
@@ -40,3 +40,6 @@ timestamp:
 parse_ints:
   type: json_parser
   parse_ints: true
+drop_field:
+  type: json_parser
+  drop_field: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds a `drop_field` config option to all relevant parsers. This will allow for dropping the original field after the data is parsed out of it.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50362

<!--Describe what testing was performed and which tests were added.-->
#### Testing
I ran a collector with this filelog receiver config:

```yaml
  filelog:
    include:
      - dummy_app_logs.json
    start_at: beginning
    operators:
      # 1. Parse JSON log string into record attributes
      - type: json_parser

      # 2. Parse nanosecond epoch timestamp from attributes.timeUnixNano -> sets top-level timestamp
      - type: time_parser
        parse_from: attributes.timeUnixNano
        drop_field: true
        layout_type: epoch
        layout: ns

      # 3. Parse severity from attributes.severityText -> sets top-level severityNumber/Text
      - type: severity_parser
        parse_from: attributes.severityText
        drop_field: true

      # 4. Flatten the nested "attributes" object up into the log record's top-level attributes
      - type: flatten
        field: attributes.attributes

      # 5. Move body string to actual log record body
      - type: move
        from: attributes.body
        to: body
```

With a log file like:

```json
{"timeUnixNano":1786487437272250721,"severityText":"INFO","eventName":"service.starting","attributes":{"service.namespace":"app-ns","service.name":"app","service.version":"2026.08"},"body":"My App starting up"}
```

And received the following debug exporter output:

```
2026-08-19T15:14:20.390Z        info    ResourceLog #0
Resource SchemaURL: 
ScopeLogs #0
ScopeLogs SchemaURL: 
InstrumentationScope  
LogRecord #0
ObservedTimestamp: 2026-08-19 15:14:20.29241677 +0000 UTC
Timestamp: 2026-08-11 22:30:37.272250624 +0000 UTC
SeverityText: INFO
SeverityNumber: Info(9)
Body: Str(My App starting up)
Attributes:
     -> service.version: Str(2026.08)
     -> service.namespace: Str(app-ns)
     -> eventName: Str(service.starting)
     -> service.name: Str(app)
     -> log.file.name: Str(dummy_app_logs.log)
Trace ID: 
Span ID: 
Flags: 0
```

<!--Describe the documentation added.-->
#### Documentation
The field has been documented in each parser's documentation.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->

#### AI Usage Disclosure

I leveraged Google Antigravity for much of the code within this PR.