### PR TITLE
[receiver/prometheusremotewritereceiver] Make a write request all or nothing

### DIFF
--- a/.chloggen/50337-prw-histogram-mapping-conformance.yaml
+++ b/.chloggen/50337-prw-histogram-mapping-conformance.yaml
@@ -1,0 +1,23 @@
+change_type: bug_fix
+
+component: receiver/prometheus_remote_write
+
+note: Drop float flavored native histograms and rebuild the data point count from the translated buckets.
+
+issues: [50337]
+
+subtext: |
+  The Prometheus compatibility specification requires native histograms of the
+  float or gauge flavors to be dropped; float ones were being converted, with
+  fractional and non-finite bucket populations forced through an unsigned
+  integer conversion. It also derives the count from the zero count plus the
+  retained bucket populations, while the receiver copied the count Prometheus
+  sent and then subtracted the overflow buckets, which does not agree whenever
+  an observation is not represented by a bucket. Custom bucket histograms copied
+  the count without adjusting it at all, so one that observed NaN was emitted
+  with a count larger than its buckets account for. A custom bucket histogram
+  carrying no bounds was dropped rather than translated, and a stale marker was
+  lost when the buckets it carries could not be summed. The sum is now left
+  unset when the count is zero, which OpenTelemetry requires.
+
+change_logs: [user]

--- a/.chloggen/50337-prw-histogram-mapping-conformance.yaml
+++ b/.chloggen/50337-prw-histogram-mapping-conformance.yaml
@@ -17,7 +17,11 @@ subtext: |
   the count without adjusting it at all, so one that observed NaN was emitted
   with a count larger than its buckets account for. A custom bucket histogram
   carrying no bounds was dropped rather than translated, and a stale marker was
-  lost when the buckets it carries could not be summed. The sum is now left
-  unset when the count is zero, which OpenTelemetry requires.
+  lost when the buckets it carries could not be summed. Deltas that take a
+  running bucket count below zero are refused rather than converted to a very
+  large population, and a stale marker no longer carries the buckets its spans
+  describe, since a data point that records nothing cannot hold observations.
+  The sum is now left unset when the count is zero, which OpenTelemetry
+  requires.
 
 change_logs: [user]

--- a/.chloggen/50337-prw-histogram-mapping-conformance.yaml
+++ b/.chloggen/50337-prw-histogram-mapping-conformance.yaml
@@ -21,6 +21,10 @@ subtext: |
   running bucket count below zero are refused rather than converted to a very
   large population, and a stale marker no longer carries the buckets its spans
   describe, since a data point that records nothing cannot hold observations.
+  Spans and deltas that describe a different shape from the bounds are refused
+  the way Prometheus refuses them, rather than read as far as the shorter of the
+  two, which dropped observations while leaving a count that agreed with the
+  buckets it did emit.
   The sum is now left unset when the count is zero, which OpenTelemetry
   requires.
 

--- a/.chloggen/50340-prw-write-transaction.yaml
+++ b/.chloggen/50340-prw-write-transaction.yaml
@@ -1,0 +1,29 @@
+change_type: bug_fix
+
+component: receiver/prometheus_remote_write
+
+note: Answer with a non-2xx status when part of a remote write request could not be written, instead of acknowledging it as successful.
+
+issues: [50340]
+
+subtext: |
+  Series the receiver cannot translate, such as classic histograms, gauge and
+  float flavored native histograms, unsupported schemas and malformed bucket
+  spans, summary metrics, and custom bucket histograms that Prometheus itself
+  would reject, were dropped or silently truncated and the request was still
+  answered with 204. The Remote-Write 2.0 specification requires a non-2xx
+  response whenever data the receiver understood was not written. Such a request
+  is now rejected as a whole with 400, nothing is passed on, and the written
+  counts report zero. Those counts are also only reported after the next
+  consumer has accepted the batch, and resource attributes learned from
+  target_info are only remembered then, so a failed request no longer affects
+  later ones. A series carrying both samples and histograms, or histograms
+  attached to a metric type that does not have them, is rejected instead of
+  being half translated. Responses that could not be decoded now carry the
+  written counts too, and a request only replaces the cached resource attributes
+  of a target when it actually learned something from target_info. A native
+  histogram whose zero bucket carries a float count while the histogram itself
+  is integer flavored, or whose zero threshold is negative, is rejected rather
+  than losing those fields on the way through.
+
+change_logs: [user]

--- a/.chloggen/50340-prw-write-transaction.yaml
+++ b/.chloggen/50340-prw-write-transaction.yaml
@@ -23,7 +23,13 @@ subtext: |
   written counts too, and a request only replaces the cached resource attributes
   of a target when it actually learned something from target_info. A native
   histogram whose zero bucket carries a float count while the histogram itself
-  is integer flavored, or whose zero threshold is negative, is rejected rather
-  than losing those fields on the way through.
+  is integer flavored, or whose zero threshold is negative or not a number, is
+  rejected rather than losing those fields on the way through. A symbol
+  reference past the end of the table is refused whichever series carries it,
+  where target_info used to be handed on before the check. A request that
+  translates to no data point at all stops before the consumer rather than
+  handing it an empty batch, and translation stops at the first series it
+  cannot take, so a request full of invalid ones no longer answers with an
+  error larger than itself.
 
 change_logs: [user]

--- a/.chloggen/50340-prw-write-transaction.yaml
+++ b/.chloggen/50340-prw-write-transaction.yaml
@@ -30,6 +30,10 @@ subtext: |
   translates to no data point at all stops before the consumer rather than
   handing it an empty batch, and translation stops at the first series it
   cannot take, so a request full of invalid ones no longer answers with an
-  error larger than itself.
+  error larger than itself. A target_info series carrying a histogram or an
+  exemplar is refused rather than read for its labels alone, since the branch
+  that reads it has no data point for either, and an exemplar whose label
+  references cannot be resolved is refused rather than skipped, since nothing
+  downstream looks at it again.
 
 change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/README.md
+++ b/receiver/prometheusremotewritereceiver/README.md
@@ -99,6 +99,14 @@ As mentioned in [Histogram Atomicity](#histogram-atomicity), Prometheus Classic 
 
 Summaries suffer from the same problem, a working Summary is composed by several time series just like Classic Histograms. The only difference is that instead of bucket boundaries, these time series represent pre-calculated quantiles. Since the quantiles can be sent in separate Remote Write requests, it's impossible to determine if the amount of quantiles received are enough to generate a complete Summary.
 
+### Only integer, counter flavored Native Histograms are translated
+
+The Prometheus compatibility specification requires native histograms of the float or gauge flavors to be dropped, for both the standard schemas and custom buckets. A histogram whose reset hint is `GAUGE`, or whose counts arrive as floats, is therefore not translated. Float bucket populations can be fractional or non-finite and have no faithful representation in an OpenTelemetry histogram, whose bucket counts are unsigned integers.
+
+A custom bucket histogram that carries no bounds is translated rather than dropped. The bounds sit between buckets, so a histogram with none of them still has the bucket above the last one, which is the shape Prometheus produces for a classic histogram whose only bucket was `+Inf`.
+
+The data point count is rebuilt from what the translated histogram holds, rather than copied from the count Prometheus sent. For the exponential schemas that is the zero count plus the retained bucket populations, and for custom buckets it is the bucket counts. The two differ whenever an observation is not represented by a bucket, which happens for observations of NaN and for the overflow bucket. When nothing at all could be represented the count is zero, and the sum is then left unset, since OpenTelemetry requires the sum to be zero once the count is.
+
 ### Native Histogram expansion limits
 
 Prometheus sends Native Histogram buckets as spans of populated buckets separated by gaps, while OTLP wants one contiguous list, so a short list of spans can describe a very wide one. Two limits bound what that expansion is allowed to cost:

--- a/receiver/prometheusremotewritereceiver/README.md
+++ b/receiver/prometheusremotewritereceiver/README.md
@@ -99,6 +99,8 @@ The same applies once the data reaches the rest of the collector: the counts are
 
 The counts are reported on every response once the request has been recognised as Remote-Write 2.0, including the ones that could not be decoded. A sender reading no header at all cannot tell that apart from a receiver that does not report them.
 
+The body of a rejection describes the first series the receiver could not take, not every one of them. The whole request goes back either way, so the rest would tell a sender nothing it can act on separately, and a request made of thousands of invalid series would otherwise answer with an error larger than itself.
+
 ### What a series is allowed to carry
 
 Remote-Write 2.0 lets a series hold samples or histograms and never both, and the metric type decides which of the two the receiver goes looking for. A series that breaks either rule carries data the receiver would walk past without translating, so the request is rejected rather than half written.

--- a/receiver/prometheusremotewritereceiver/README.md
+++ b/receiver/prometheusremotewritereceiver/README.md
@@ -93,11 +93,13 @@ In Prometheus Remote Write v2, this problem is solved since the time series are 
 
 ## Rejected data is reported as rejected
 
-A remote write request is translated as a whole. If any part of it cannot be written, including the histograms this receiver does not support, the request is answered with a non-2xx status, nothing is handed to the pipeline, and the `X-Prometheus-Remote-Write-*-Written` headers report zero. That follows the Remote-Write 2.0 rule that a receiver must not answer 2xx when data it understood was not written, and that the headers carry the number actually written.
+A remote write request is translated as a whole. If any part of it cannot be translated, including the histograms this receiver does not support, the request is answered with a non-2xx status, nothing is handed to the pipeline, and the `X-Prometheus-Remote-Write-*-Written` headers report zero. That follows the Remote-Write 2.0 rule that a receiver must not answer 2xx when data it understood was not written, and that the headers carry the number actually written.
 
 The same applies once the data reaches the rest of the collector: the counts are only reported after the next consumer has accepted the batch, and the resource attributes a request carries in `target_info` are only remembered once that has happened. A request that fails therefore leaves no trace for later requests to pick up. A request that succeeds only replaces what the cache holds for a target when it actually learned something from `target_info`, so a slow request cannot undo attributes another one committed while it was waiting.
 
 The counts are reported on every response once the request has been recognised as Remote-Write 2.0, including the ones that could not be decoded. A sender reading no header at all cannot tell that apart from a receiver that does not report them.
+
+What a written count means here is that the next consumer in the pipeline accepted the batch, which is as far as a receiver can see. If that consumer is a queue or a batcher, acceptance is not yet a durable write at whatever the pipeline ends in, and a fanout consumer that accepted the batch for some of its branches and refused it for others reports a single error, so this receiver takes that as nothing written rather than guessing a partial count.
 
 The body of a rejection describes the first series the receiver could not take, not every one of them. The whole request goes back either way, so the rest would tell a sender nothing it can act on separately, and a request made of thousands of invalid series would otherwise answer with an error larger than itself.
 

--- a/receiver/prometheusremotewritereceiver/README.md
+++ b/receiver/prometheusremotewritereceiver/README.md
@@ -103,6 +103,8 @@ Summaries suffer from the same problem, a working Summary is composed by several
 
 The Prometheus compatibility specification requires native histograms of the float or gauge flavors to be dropped, for both the standard schemas and custom buckets. A histogram whose reset hint is `GAUGE`, or whose counts arrive as floats, is therefore not translated. Float bucket populations can be fractional or non-finite and have no faithful representation in an OpenTelemetry histogram, whose bucket counts are unsigned integers.
 
+Custom bucket histograms are checked with Prometheus' own `Validate`, which is what a Prometheus server runs on every histogram it accepts over remote write. Spans and deltas that describe a different shape from the bounds are dropped rather than read as far as the shorter of the two, since reading part of them loses observations while leaving a count that agrees with the buckets that were emitted.
+
 A custom bucket histogram that carries no bounds is translated rather than dropped. The bounds sit between buckets, so a histogram with none of them still has the bucket above the last one, which is the shape Prometheus produces for a classic histogram whose only bucket was `+Inf`.
 
 The data point count is rebuilt from what the translated histogram holds, rather than copied from the count Prometheus sent. For the exponential schemas that is the zero count plus the retained bucket populations, and for custom buckets it is the bucket counts. The two differ whenever an observation is not represented by a bucket, which happens for observations of NaN and for the overflow bucket. When nothing at all could be represented the count is zero, and the sum is then left unset, since OpenTelemetry requires the sum to be zero once the count is.

--- a/receiver/prometheusremotewritereceiver/README.md
+++ b/receiver/prometheusremotewritereceiver/README.md
@@ -91,6 +91,28 @@ In Prometheus Remote Write v2, this problem is solved since the time series are 
 
 `Created Timestamp` is a feature in Prometheus that works similarly and is translated to OTel's `StartTimeUnixNano`. Prometheus Remote Write v1 doesn't send Created Timestamps, so we can never populate the StartTimeUnixNano field from that protocol.
 
+## Rejected data is reported as rejected
+
+A remote write request is translated as a whole. If any part of it cannot be written, including the histograms this receiver does not support, the request is answered with a non-2xx status, nothing is handed to the pipeline, and the `X-Prometheus-Remote-Write-*-Written` headers report zero. That follows the Remote-Write 2.0 rule that a receiver must not answer 2xx when data it understood was not written, and that the headers carry the number actually written.
+
+The same applies once the data reaches the rest of the collector: the counts are only reported after the next consumer has accepted the batch, and the resource attributes a request carries in `target_info` are only remembered once that has happened. A request that fails therefore leaves no trace for later requests to pick up. A request that succeeds only replaces what the cache holds for a target when it actually learned something from `target_info`, so a slow request cannot undo attributes another one committed while it was waiting.
+
+The counts are reported on every response once the request has been recognised as Remote-Write 2.0, including the ones that could not be decoded. A sender reading no header at all cannot tell that apart from a receiver that does not report them.
+
+### What a series is allowed to carry
+
+Remote-Write 2.0 lets a series hold samples or histograms and never both, and the metric type decides which of the two the receiver goes looking for. A series that breaks either rule carries data the receiver would walk past without translating, so the request is rejected rather than half written.
+
+### Custom bucket histograms
+
+Native Histograms with custom buckets are checked with Prometheus' own `Validate`, which is what a Prometheus server runs on every histogram it accepts over remote write, and whose failures it answers with 400. It covers the bucket bounds being finite, distinct and in increasing order, the implicit `+Inf` bound not being sent explicitly, the spans matching the bounds and the values, and the count matching the buckets. The compatibility specification defines exactly this shape, and OTLP requires the count to equal the sum of the bucket counts, so a histogram that fails any of these has no valid translation and is rejected.
+
+A histogram whose bucket populations add up past what a count can hold is rejected as well. That is the one check `Validate` cannot make, because it adds them with wrapping arithmetic.
+
+### Fields that would be read past
+
+Two shapes are turned away because translating them would leave data behind without saying so. A histogram whose count is an integer but whose zero bucket carries a float loses those observations, since nothing reads the float side once the flavor is decided. And the Native Histograms specification defines the zero threshold as a `float64 >= 0`, so a negative one has no meaning to carry over.
+
 ## Known Limitations
 
 ### Summaries and Classic Histograms are unsupported
@@ -101,7 +123,7 @@ Summaries suffer from the same problem, a working Summary is composed by several
 
 ### Only integer, counter flavored Native Histograms are translated
 
-The Prometheus compatibility specification requires native histograms of the float or gauge flavors to be dropped, for both the standard schemas and custom buckets. A histogram whose reset hint is `GAUGE`, or whose counts arrive as floats, is therefore not translated. Float bucket populations can be fractional or non-finite and have no faithful representation in an OpenTelemetry histogram, whose bucket counts are unsigned integers.
+The Prometheus compatibility specification requires native histograms of the float or gauge flavors to be dropped, for both the standard schemas and custom buckets. A histogram whose reset hint is `GAUGE`, or whose counts arrive as floats, is not translated, and the request carrying it is rejected. Float bucket populations can be fractional or non-finite and have no faithful representation in an OpenTelemetry histogram, whose bucket counts are unsigned integers.
 
 Custom bucket histograms are checked with Prometheus' own `Validate`, which is what a Prometheus server runs on every histogram it accepts over remote write. Spans and deltas that describe a different shape from the bounds are dropped rather than read as far as the shorter of the two, since reading part of them loses observations while leaving a count that agrees with the buckets that were emitted.
 
@@ -116,7 +138,7 @@ Prometheus sends Native Histogram buckets as spans of populated buckets separate
     - A single histogram may expand to 16384 buckets, counting its positive and negative ranges together.
     - All histograms in one request share a budget of 4194304 expanded buckets.
 
-Histograms past either limit are dropped, are not counted in the `X-Prometheus-Remote-Write-Histograms-Written` response header, and are logged. Both limits are hardcoded and not configurable for now.
+A histogram past either limit rejects the request, so the outcome does not depend on the order the histograms arrived in. Both limits are hardcoded and not configurable for now.
 
 ### Resource Metrics Cache
 

--- a/receiver/prometheusremotewritereceiver/README.md
+++ b/receiver/prometheusremotewritereceiver/README.md
@@ -107,7 +107,7 @@ Remote-Write 2.0 lets a series hold samples or histograms and never both, and th
 
 ### Custom bucket histograms
 
-Native Histograms with custom buckets are checked with Prometheus' own `Validate`, which is what a Prometheus server runs on every histogram it accepts over remote write, and whose failures it answers with 400. It covers the bucket bounds being finite, distinct and in increasing order, the implicit `+Inf` bound not being sent explicitly, the spans matching the bounds and the values, and the count matching the buckets. The compatibility specification defines exactly this shape, and OTLP requires the count to equal the sum of the bucket counts, so a histogram that fails any of these has no valid translation and is rejected.
+Native Histograms with custom buckets are checked with Prometheus' own `Validate`, which is what a Prometheus server runs on every histogram it accepts over remote write, and whose failures it answers with 400. It covers the bucket bounds being numbers, distinct and in increasing order, the implicit `+Inf` bound not being sent explicitly, the spans matching the bounds and the values, and the count matching the buckets. The compatibility specification defines exactly this shape, and OTLP requires the count to equal the sum of the bucket counts, so a histogram that fails any of these has no valid translation and is rejected.
 
 A histogram whose bucket populations add up past what a count can hold is rejected as well. That is the one check `Validate` cannot make, because it adds them with wrapping arithmetic.
 

--- a/receiver/prometheusremotewritereceiver/exemplars.go
+++ b/receiver/prometheusremotewritereceiver/exemplars.go
@@ -5,6 +5,7 @@ package prometheusremotewritereceiver // import "github.com/open-telemetry/opent
 
 import (
 	"encoding/hex"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -39,7 +40,7 @@ func collectExemplars(
 	req *writev2.Request,
 	settings receiver.Settings,
 	stats *promremote.WriteResponseStats,
-) map[uint64]pmetric.ExemplarSlice {
+) (map[uint64]pmetric.ExemplarSlice, error) {
 	result := make(map[uint64]pmetric.ExemplarSlice)
 	builder := labels.NewScratchBuilder(0)
 	stats.Exemplars = 0
@@ -79,8 +80,9 @@ func collectExemplars(
 		for _, ex := range ts.Exemplars {
 			promExemplar, err := ex.ToExemplar(&builder, req.Symbols)
 			if err != nil {
-				settings.Logger.Warn("error converting exemplar label refs", zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: err})
-				continue
+				// Nothing looks at this exemplar again, so skipping it is the one drop that
+				// would still leave the request answered as written.
+				return nil, fmt.Errorf("exemplar of %q cannot be read: %w", metadata.Name, err)
 			}
 
 			exemplar := slice.AppendEmpty()
@@ -95,7 +97,7 @@ func collectExemplars(
 		result[key.hash()] = slice
 	}
 
-	return result
+	return result, nil
 }
 
 func extractScopeFromLabels(settings receiver.Settings, ls labels.Labels) (string, string) {

--- a/receiver/prometheusremotewritereceiver/exemplars_test.go
+++ b/receiver/prometheusremotewritereceiver/exemplars_test.go
@@ -30,9 +30,10 @@ func TestCollectExemplars_ErrorsAndEdgeCases(t *testing.T) {
 		expectedExemplars int
 		expectedGroups    int
 		expectedWarnMsgs  []string
+		expectedErr       string
 	}{
 		{
-			name: "invalid exemplar label refs logs warning",
+			name: "invalid exemplar label refs are refused",
 			req: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -54,11 +55,7 @@ func TestCollectExemplars_ErrorsAndEdgeCases(t *testing.T) {
 					},
 				},
 			},
-			expectedExemplars: 0,
-			expectedGroups:    1,
-			expectedWarnMsgs: []string{
-				"error converting exemplar label refs",
-			},
+			expectedErr: `exemplar of "request_duration_ms" cannot be read`,
 		},
 		{
 			name: "missing metric name logs warning",
@@ -138,7 +135,7 @@ func TestCollectExemplars_ErrorsAndEdgeCases(t *testing.T) {
 			expectedWarnMsgs:  nil,
 		},
 		{
-			name: "mixed valid and invalid exemplars logs once and keeps valid",
+			name: "one unreadable exemplar refuses the rest with it",
 			req: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -170,11 +167,7 @@ func TestCollectExemplars_ErrorsAndEdgeCases(t *testing.T) {
 					},
 				},
 			},
-			expectedExemplars: 1,
-			expectedGroups:    1,
-			expectedWarnMsgs: []string{
-				"error converting exemplar label refs",
-			},
+			expectedErr: `exemplar of "request_duration_ms" cannot be read`,
 		},
 	}
 
@@ -189,7 +182,13 @@ func TestCollectExemplars_ErrorsAndEdgeCases(t *testing.T) {
 				},
 			}
 
-			result := collectExemplars(tt.req, settings, stats)
+			result, err := collectExemplars(tt.req, settings, stats)
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				assert.Nil(t, result)
+				return
+			}
+			require.NoError(t, err)
 
 			assert.Equal(t, tt.expectedExemplars, stats.Exemplars)
 			assert.Len(t, result, tt.expectedGroups)

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -654,8 +654,8 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 		}
 		// The zero threshold is written to the data point whether or not the histogram carries a
 		// stale marker, and the Native Histograms specification defines it as a float64 >= 0.
-		if histogram.ZeroThreshold < 0 {
-			return fmt.Errorf("Native Histogram %q at timestamp %d has a negative zero threshold %v", metricName, histogram.Timestamp, histogram.ZeroThreshold)
+		if math.IsNaN(histogram.ZeroThreshold) || histogram.ZeroThreshold < 0 {
+			return fmt.Errorf("Native Histogram %q at timestamp %d has a zero threshold of %v, which is not a width", metricName, histogram.Timestamp, histogram.ZeroThreshold)
 		}
 
 		// Validate before any resource, scope or metric is built, so that a histogram which is

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -409,6 +409,16 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 			continue
 		}
 
+		if ts.Metadata.UnitRef >= uint32(len(req.Symbols)) {
+			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unit ref %d is out of bounds of symbolsTable", ts.Metadata.UnitRef))
+			continue
+		}
+
+		if ts.Metadata.HelpRef >= uint32(len(req.Symbols)) {
+			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("help ref %d is out of bounds of symbolsTable", ts.Metadata.HelpRef))
+			continue
+		}
+
 		// If the metric name is equal to target_info, we use its labels as attributes of the resource
 		// Ref: https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#resource-attributes-1
 		if metadata.Name == "target_info" {
@@ -433,16 +443,6 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 
 		si := prw.extractScopeInfo(ls)
 		metricName := metadata.Name
-		if ts.Metadata.UnitRef >= uint32(len(req.Symbols)) {
-			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unit ref %d is out of bounds of symbolsTable", ts.Metadata.UnitRef))
-			continue
-		}
-
-		if ts.Metadata.HelpRef >= uint32(len(req.Symbols)) {
-			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("help ref %d is out of bounds of symbolsTable", ts.Metadata.HelpRef))
-			continue
-		}
-
 		unit := req.Symbols[ts.Metadata.UnitRef]
 		description := req.Symbols[ts.Metadata.HelpRef]
 

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -238,8 +238,9 @@ func (prw *prometheusRemoteWriteReceiver) handlePRW(w http.ResponseWriter, req *
 	prw.obsrecv.EndMetricsOp(obsrecvCtx, "prometheusremotewritereceiver", m.DataPointCount(), err)
 	if err != nil {
 		prw.settings.Logger.Error("Error consuming metrics", zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: err})
-		// The consumer reports one error for the whole batch and no partial count, so the batch
-		// counts as unwritten and the resource cache is not updated either.
+		// One error covers the batch and carries no accepted count, so the receiver cannot confirm
+		// a write. It reports zero and drops its cache updates, while a fanout consumer may still
+		// have passed the batch to some of the consumers behind it.
 		promremote.WriteResponseStats{}.SetHeaders(w)
 		if consumererror.IsPermanent(err) {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -1103,14 +1103,18 @@ func applyScopeInfo(sm pmetric.ScopeMetrics, si scopeInfo) {
 func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram *writev2.Histogram, attrs pcommon.Map, ls labels.Labels, stats *promremote.WriteResponseStats) {
 	// Bounds sit between buckets, so a histogram carrying none still has the bucket above the
 	// last one, which is what a classic histogram with only a +Inf bucket becomes.
-	bucketCounts := convertNHCBBuckets(histogram)
+	bucketCounts, ok := convertNHCBBuckets(histogram)
+	if !ok {
+		prw.settings.Logger.Info("Dropping Native Histogram whose deltas take a bucket population below zero",
+			zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
+		return
+	}
 
 	// Counted first, so a population that cannot be represented is never half published. A stale
 	// marker has none to count.
 	var count uint64
 	stale := value.IsStaleNaN(histogram.Sum)
 	if !stale {
-		var ok bool
 		if count, ok = addPopulations(bucketCounts...); !ok {
 			prw.settings.Logger.Info("Dropping Native Histogram whose bucket population is too large to represent",
 				zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
@@ -1142,14 +1146,15 @@ func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.Hi
 	stats.Histograms++
 }
 
-// convertNHCBBuckets converts NHCB bucket data to OpenTelemetry bucket counts
-func convertNHCBBuckets(histogram *writev2.Histogram) []uint64 {
+// convertNHCBBuckets converts NHCB bucket data to OpenTelemetry bucket counts, reporting false
+// if the deltas take a running count below zero, which no bucket population can express.
+func convertNHCBBuckets(histogram *writev2.Histogram) ([]uint64, bool) {
 	// For NHCB, we need numExplicitBounds + 1 buckets (including the final +inf bucket)
 	bucketCounts := make([]uint64, len(histogram.CustomValues)+1)
 
 	// NHCB uses the positive bucket list and spans for all buckets
 	if len(histogram.PositiveSpans) == 0 {
-		return bucketCounts
+		return bucketCounts, true
 	}
 
 	// Values are deltas between buckets. Float flavored histograms are dropped earlier.
@@ -1166,6 +1171,9 @@ func convertNHCBBuckets(histogram *writev2.Histogram) []uint64 {
 			bucketCount += histogram.PositiveDeltas[deltaIdx]
 			deltaIdx++
 
+			if bucketCount < 0 {
+				return nil, false
+			}
 			if bucketIdx >= 0 && bucketIdx < len(bucketCounts) {
 				bucketCounts[bucketIdx] = uint64(bucketCount)
 			}
@@ -1173,5 +1181,5 @@ func convertNHCBBuckets(histogram *writev2.Histogram) []uint64 {
 		}
 	}
 
-	return bucketCounts
+	return bucketCounts, true
 }

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -564,9 +564,9 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 }
 
 // validateTimeSeriesPayload checks what a series carries against what the protocol allows it to.
-// A series holds samples or histograms and never both, and the metric type decides which of the
-// two the receiver goes looking for, so histograms attached to a sample type are data the
-// receiver would silently walk past.
+// Samples and histograms never travel together, and the metric type decides which of the two the
+// receiver goes looking for, so histograms attached to a sample type are data it would silently
+// walk past.
 func validateTimeSeriesPayload(ts *writev2.TimeSeries, name string) error {
 	hasSamples, hasHistograms := len(ts.Samples) > 0, len(ts.Histograms) > 0
 	if hasSamples && hasHistograms {

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -1101,9 +1101,8 @@ func applyScopeInfo(sm pmetric.ScopeMetrics, si scopeInfo) {
 
 // addNHCBDatapoint converts a single Native Histogram Custom Buckets (NHCB) to OpenTelemetry histogram datapoints
 func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram *writev2.Histogram, attrs pcommon.Map, ls labels.Labels, stats *promremote.WriteResponseStats) {
-	// A stale marker records that the series stopped. It carries no distribution, so the spans
-	// and deltas that would describe one are left unread and the buckets stay empty, which is
-	// what a count of zero says as well.
+	// A stale marker records that the series stopped, so it carries no distribution and the
+	// spans and deltas that would describe one are left unread.
 	if value.IsStaleNaN(histogram.Sum) {
 		dp := datapoints.AppendEmpty()
 		dp.SetStartTimestamp(pcommon.Timestamp(histogram.StartTimestamp * int64(time.Millisecond)))

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -361,7 +361,6 @@ func (prw *prometheusRemoteWriteReceiver) getOrCreateRM(ls labels.Labels, otelMe
 // translate is not feature complete.
 func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *writev2.Request) (pmetric.Metrics, promremote.WriteResponseStats, map[uint64]stagedResource, error) {
 	var (
-		badRequestErrors error
 		// otelMetrics represents the final metrics, after all the processing, that will be returned by the receiver.
 		otelMetrics   = pmetric.NewMetrics()
 		labelsBuilder = labels.NewScratchBuilder(0)
@@ -393,30 +392,24 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		ts := &req.Timeseries[i]
 		ls, err := ts.ToLabels(&labelsBuilder, req.Symbols)
 		if err != nil {
-			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("error converting timeseries to labels: %w", err))
-			continue
+			return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, fmt.Errorf("error converting timeseries to labels: %w", err)
 		}
 		metadata := schema.NewMetadataFromLabels(ls)
 		if metadata.Name == "" {
-			badRequestErrors = errors.Join(badRequestErrors, errors.New("missing metric name in labels"))
-			continue
+			return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, errors.New("missing metric name in labels")
 		} else if duplicateLabel, hasDuplicate := ls.HasDuplicateLabelNames(); hasDuplicate {
-			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("duplicate label %q in labels", duplicateLabel))
-			continue
+			return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, fmt.Errorf("duplicate label %q in labels", duplicateLabel)
 		}
 		if err := validateTimeSeriesPayload(ts, metadata.Name); err != nil {
-			badRequestErrors = errors.Join(badRequestErrors, err)
-			continue
+			return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, err
 		}
 
 		if ts.Metadata.UnitRef >= uint32(len(req.Symbols)) {
-			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unit ref %d is out of bounds of symbolsTable", ts.Metadata.UnitRef))
-			continue
+			return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, fmt.Errorf("unit ref %d is out of bounds of symbolsTable", ts.Metadata.UnitRef)
 		}
 
 		if ts.Metadata.HelpRef >= uint32(len(req.Symbols)) {
-			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("help ref %d is out of bounds of symbolsTable", ts.Metadata.HelpRef))
-			continue
+			return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, fmt.Errorf("help ref %d is out of bounds of symbolsTable", ts.Metadata.HelpRef)
 		}
 
 		// If the metric name is equal to target_info, we use its labels as attributes of the resource
@@ -515,8 +508,7 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 				return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil,
 					fmt.Errorf("summary metric %q is not supported by this receiver, its quantile series can arrive in separate requests and cannot be reassembled", metricName)
 			default:
-				badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, metricName))
-				continue
+				return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, metricName)
 			}
 			metricCache[metricKey] = metric
 		} else if len(metric.Description()) < len(description) {
@@ -552,16 +544,11 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 			return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil,
 				fmt.Errorf("summary metric %q is not supported by this receiver, its quantile series can arrive in separate requests and cannot be reassembled", metricName)
 		default:
-			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, metricName))
+			return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, metricName)
 		}
 	}
 
-	if badRequestErrors != nil {
-		// Nothing is published when any known data could not be written.
-		return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, badRequestErrors
-	}
-
-	return otelMetrics, stats, cacheUpdates, badRequestErrors
+	return otelMetrics, stats, cacheUpdates, nil
 }
 
 // validateTimeSeriesPayload checks what a series carries against what the protocol allows it to.

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -1101,6 +1101,21 @@ func applyScopeInfo(sm pmetric.ScopeMetrics, si scopeInfo) {
 
 // addNHCBDatapoint converts a single Native Histogram Custom Buckets (NHCB) to OpenTelemetry histogram datapoints
 func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram *writev2.Histogram, attrs pcommon.Map, ls labels.Labels, stats *promremote.WriteResponseStats) {
+	// A stale marker records that the series stopped. It carries no distribution, so the spans
+	// and deltas that would describe one are left unread and the buckets stay empty, which is
+	// what a count of zero says as well.
+	if value.IsStaleNaN(histogram.Sum) {
+		dp := datapoints.AppendEmpty()
+		dp.SetStartTimestamp(pcommon.Timestamp(histogram.StartTimestamp * int64(time.Millisecond)))
+		dp.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * int64(time.Millisecond)))
+		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
+		dp.ExplicitBounds().FromRaw(histogram.CustomValues)
+		dp.BucketCounts().FromRaw(make([]uint64, len(histogram.CustomValues)+1))
+		attrs.CopyTo(dp.Attributes())
+		stats.Histograms++
+		return
+	}
+
 	// Bounds sit between buckets, so a histogram carrying none still has the bucket above the
 	// last one, which is what a classic histogram with only a +Inf bucket becomes.
 	bucketCounts, ok := convertNHCBBuckets(histogram)
@@ -1110,33 +1125,25 @@ func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.Hi
 		return
 	}
 
-	// Counted first, so a population that cannot be represented is never half published. A stale
-	// marker has none to count.
-	var count uint64
-	stale := value.IsStaleNaN(histogram.Sum)
-	if !stale {
-		if count, ok = addPopulations(bucketCounts...); !ok {
-			prw.settings.Logger.Info("Dropping Native Histogram whose bucket population is too large to represent",
-				zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
-			return
-		}
+	// Counted first, so a population that cannot be represented is never half published.
+	count, ok := addPopulations(bucketCounts...)
+	if !ok {
+		prw.settings.Logger.Info("Dropping Native Histogram whose bucket population is too large to represent",
+			zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
+		return
 	}
 
 	dp := datapoints.AppendEmpty()
 	dp.SetStartTimestamp(pcommon.Timestamp(histogram.StartTimestamp * int64(time.Millisecond)))
 	dp.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * int64(time.Millisecond)))
 
-	if stale {
-		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
-	} else {
-		// OTLP wants the count to be the sum of the bucket counts. Prometheus counts an
-		// observation of NaN without putting it in any bucket, so the count it sends can be
-		// larger than the buckets account for.
-		dp.SetCount(count)
-		if count > 0 {
-			// OTLP requires the sum to be zero when the count is.
-			dp.SetSum(histogram.Sum)
-		}
+	// OTLP wants the count to be the sum of the bucket counts. Prometheus counts an observation
+	// of NaN without putting it in any bucket, so the count it sends can be larger than the
+	// buckets account for.
+	dp.SetCount(count)
+	if count > 0 {
+		// OTLP requires the sum to be zero when the count is.
+		dp.SetSum(histogram.Sum)
 	}
 
 	dp.ExplicitBounds().FromRaw(histogram.CustomValues)

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -568,6 +568,19 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 			continue
 		}
 
+		// The compatibility specification requires native histograms of the float flavor to be
+		// dropped; the gauge flavor is already rejected above. This has to come before the stale
+		// check, otherwise a stale float histogram would be accepted by accident.
+		if histogram.IsFloatHistogram() {
+			prw.settings.Logger.Debug(
+				"Dropping float flavored Native Histogram",
+				zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
+				zapcore.Field{Key: "job", Type: zapcore.StringType, String: ls.Get("job")},
+				zapcore.Field{Key: "instance", Type: zapcore.StringType, String: ls.Get("instance")},
+			)
+			continue
+		}
+
 		// Validate everything that can be checked without allocating, so that a histogram which
 		// is going to be dropped never reserves budget or leaves an empty metric behind. A stale
 		// marker is exempt because its remaining fields are ignored rather than translated.
@@ -656,7 +669,7 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 		exemplarSlice := pmetric.NewExemplarSlice()
 		// Process the individual histogram
 		if histogramType == "nhcb" {
-			prw.addNHCBDatapoint(histMetric.Histogram().DataPoints(), histogram, attrs, stats)
+			prw.addNHCBDatapoint(histMetric.Histogram().DataPoints(), histogram, attrs, ls, stats)
 			if histMetric.Histogram().DataPoints().Len() > 0 {
 				exemplarSlice = histMetric.Histogram().DataPoints().At(0).Exemplars()
 			}
@@ -741,90 +754,70 @@ func (prw *prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datap
 		return
 	}
 
-	dp := datapoints.AppendEmpty()
+	// Built aside from the slice so that a histogram whose population cannot be represented is
+	// never published as a half filled data point.
+	dp := pmetric.NewExponentialHistogramDataPoint()
 	dp.SetStartTimestamp(pcommon.Timestamp(histogram.StartTimestamp * int64(time.Millisecond)))
 	dp.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * int64(time.Millisecond)))
 	dp.SetScale(histogram.Schema)
 	dp.SetZeroThreshold(histogram.ZeroThreshold)
-	setCountAndSum(histogram, dp)
 
-	var droppedCount uint64
+	zeroCount := histogram.GetZeroCountInt()
+	dp.SetZeroCount(zeroCount)
 
-	// The difference between float and integer histograms is that float histograms are stored as absolute counts
-	// while integer histograms are stored as deltas.
-	if histogram.IsFloatHistogram() {
-		// Float histograms
-		zeroCountFloat := histogram.GetZeroCountFloat()
-		dp.SetZeroCount(uint64(zeroCountFloat))
+	positive, positiveOK := convertDeltaBuckets(histogram.PositiveSpans, histogram.PositiveDeltas, dp.Positive(), layout.positive)
+	negative, negativeOK := convertDeltaBuckets(histogram.NegativeSpans, histogram.NegativeDeltas, dp.Negative(), layout.negative)
 
-		droppedCount += convertAbsoluteBuckets(histogram.PositiveSpans, histogram.PositiveCounts, dp.Positive(), layout.positive)
-		droppedCount += convertAbsoluteBuckets(histogram.NegativeSpans, histogram.NegativeCounts, dp.Negative(), layout.negative)
-	} else {
-		// Integer histograms
-		zeroCountInt := histogram.GetZeroCountInt()
-		dp.SetZeroCount(zeroCountInt)
-
-		droppedCount += convertDeltaBuckets(histogram.PositiveSpans, histogram.PositiveDeltas, dp.Positive(), layout.positive)
-		droppedCount += convertDeltaBuckets(histogram.NegativeSpans, histogram.NegativeDeltas, dp.Negative(), layout.negative)
+	// The compatibility specification derives Count from what the data point actually holds,
+	// rather than from the count Prometheus sent. The two differ whenever observations are not
+	// represented by a bucket, which happens for NaN observations and for the overflow bucket.
+	count, ok := addPopulations(zeroCount, positive, negative)
+	if !positiveOK || !negativeOK || !ok {
+		prw.settings.Logger.Info("Dropping Native Histogram whose bucket population is too large to represent",
+			zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
+		return
 	}
-
-	if droppedCount > 0 {
-		count := dp.Count()
-		if droppedCount > count {
-			prw.settings.Logger.Info("Clamping Native Histogram count to zero due to inconsistent dropped overflow bucket count",
-				zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
-			dp.SetCount(0)
-		} else {
-			dp.SetCount(count - droppedCount)
-		}
+	dp.SetCount(count)
+	if count > 0 {
+		// OTLP wants the sum to be zero when the count is, so a histogram whose observations all
+		// landed outside the representable range carries neither.
+		dp.SetSum(histogram.Sum)
 	}
 
 	attrs.CopyTo(dp.Attributes())
+	dp.MoveTo(datapoints.AppendEmpty())
 	stats.Histograms++
 }
 
-// hasNegativeCounts checks if a histogram has any negative counts
+// addPopulations sums bucket populations, reporting false if the total cannot be represented.
+func addPopulations(values ...uint64) (uint64, bool) {
+	var total uint64
+	for _, v := range values {
+		sum := total + v
+		if sum < total {
+			return 0, false
+		}
+		total = sum
+	}
+	return total, true
+}
+
+// hasNegativeCounts reports whether any bucket of an integer histogram resolves to a negative
+// population. Float histograms are dropped before they reach this.
 func hasNegativeCounts(histogram *writev2.Histogram) bool {
-	if histogram.IsFloatHistogram() {
-		// Check overall count
-		if histogram.GetCountFloat() < 0 {
+	var absolute int64
+	for _, delta := range histogram.NegativeDeltas {
+		absolute += delta
+		if absolute < 0 {
 			return true
 		}
+	}
 
-		// Check zero count
-		if histogram.GetZeroCountFloat() < 0 {
+	absolute = 0
+	for _, delta := range histogram.PositiveDeltas {
+		absolute += delta
+		if absolute < 0 {
 			return true
-		}
-
-		// Check positive bucket counts
-		for _, count := range histogram.PositiveCounts {
-			if count < 0 {
-				return true
-			}
-		}
-
-		// Check negative bucket counts
-		for _, count := range histogram.NegativeCounts {
-			if count < 0 {
-				return true
-			}
-		}
-	} else {
-		// Integer histograms
-		var absolute int64
-		for _, delta := range histogram.NegativeDeltas {
-			absolute += delta
-			if absolute < 0 {
-				return true
-			}
-		}
-
-		absolute = 0
-		for _, delta := range histogram.PositiveDeltas {
-			absolute += delta
-			if absolute < 0 {
-				return true
-			}
 		}
 	}
 
@@ -901,9 +894,6 @@ func validateExponentialHistogram(histogram *writev2.Histogram) (exponentialHist
 	finiteLimit := exponentialHistogramFiniteLimit(histogram.Schema)
 
 	positiveValues, negativeValues := len(histogram.PositiveDeltas), len(histogram.NegativeDeltas)
-	if histogram.IsFloatHistogram() {
-		positiveValues, negativeValues = len(histogram.PositiveCounts), len(histogram.NegativeCounts)
-	}
 
 	positive, err := validateBucketSpanLayout(histogram.PositiveSpans, positiveValues, finiteLimit)
 	if err != nil {
@@ -994,17 +984,18 @@ func validateBucketSpanLayout(spans []writev2.BucketSpan, valueCount int, finite
 }
 
 // convertDeltaBuckets converts Prometheus spans and deltas to OTLP bucket counts, returning the
-// population of the overflow buckets it dropped. Deltas are cumulative: 1,2,-2 means counts of
-// 1,3,1. layout must come from validateBucketSpanLayout for the same spans.
-func convertDeltaBuckets(spans []writev2.BucketSpan, deltas []int64, dest pmetric.ExponentialHistogramDataPointBuckets, layout bucketSpanLayout) uint64 {
+// population it emitted, which leaves out the overflow bucket so the caller can rebuild Count from
+// what the data point holds. Deltas are cumulative: 1,2,-2 means 1,3,1. Reports false if that
+// population does not fit a uint64. layout comes from validateBucketSpanLayout for the same spans.
+func convertDeltaBuckets(spans []writev2.BucketSpan, deltas []int64, dest pmetric.ExponentialHistogramDataPointBuckets, layout bucketSpanLayout) (uint64, bool) {
 	buckets := prepareBuckets(dest, layout)
 
 	var (
-		bucketIdx    int
-		bucketCount  int64
-		droppedCount uint64
-		nextIndex    int64
-		nextAppend   = layout.firstIndex // no gap before the first bucket, the OTLP offset places it
+		bucketIdx     int
+		bucketCount   int64
+		retainedCount uint64
+		nextIndex     int64
+		nextAppend    = layout.firstIndex // no gap before the first bucket, the OTLP offset places it
 	)
 
 	for _, span := range spans {
@@ -1019,48 +1010,19 @@ func convertDeltaBuckets(spans []writev2.BucketSpan, deltas []int64, dest pmetri
 
 			index := start + int64(i)
 			if !layout.hasBuckets || index > layout.lastIndex {
-				droppedCount += uint64(bucketCount)
 				continue
 			}
 			nextAppend = appendGap(buckets, nextAppend, index)
 			buckets.Append(uint64(bucketCount))
-		}
-	}
-	return droppedCount
-}
 
-// convertAbsoluteBuckets converts Prometheus spans and float counts to OTLP bucket counts,
-// returning the population of the overflow buckets it dropped. Float bucket values are absolute.
-// layout must come from validateBucketSpanLayout for the same spans.
-func convertAbsoluteBuckets(spans []writev2.BucketSpan, counts []float64, dest pmetric.ExponentialHistogramDataPointBuckets, layout bucketSpanLayout) uint64 {
-	buckets := prepareBuckets(dest, layout)
-
-	var (
-		bucketIdx    int
-		droppedCount uint64
-		nextIndex    int64
-		nextAppend   = layout.firstIndex // no gap before the first bucket, the OTLP offset places it
-	)
-
-	for _, span := range spans {
-		start := nextIndex + int64(span.Offset)
-		// A zero length span appends nothing but still shifts the spans after it.
-		nextIndex = start + int64(span.Length)
-
-		for i := uint32(0); i < span.Length; i++ {
-			count := uint64(counts[bucketIdx])
-			bucketIdx++
-
-			index := start + int64(i)
-			if !layout.hasBuckets || index > layout.lastIndex {
-				droppedCount += count
-				continue
+			total, ok := addPopulations(retainedCount, uint64(bucketCount))
+			if !ok {
+				return 0, false
 			}
-			nextAppend = appendGap(buckets, nextAppend, index)
-			buckets.Append(count)
+			retainedCount = total
 		}
 	}
-	return droppedCount
+	return retainedCount, true
 }
 
 // prepareBuckets sets the OTLP offset and reserves exactly what the validated layout needs.
@@ -1138,23 +1100,42 @@ func applyScopeInfo(sm pmetric.ScopeMetrics, si scopeInfo) {
 }
 
 // addNHCBDatapoint converts a single Native Histogram Custom Buckets (NHCB) to OpenTelemetry histogram datapoints
-func (*prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram *writev2.Histogram, attrs pcommon.Map, stats *promremote.WriteResponseStats) {
-	if len(histogram.CustomValues) == 0 {
-		return
+func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram *writev2.Histogram, attrs pcommon.Map, ls labels.Labels, stats *promremote.WriteResponseStats) {
+	// Bounds sit between buckets, so a histogram carrying none still has the bucket above the
+	// last one, which is what a classic histogram with only a +Inf bucket becomes.
+	bucketCounts := convertNHCBBuckets(histogram)
+
+	// Counted first, so a population that cannot be represented is never half published. A stale
+	// marker has none to count.
+	var count uint64
+	stale := value.IsStaleNaN(histogram.Sum)
+	if !stale {
+		var ok bool
+		if count, ok = addPopulations(bucketCounts...); !ok {
+			prw.settings.Logger.Info("Dropping Native Histogram whose bucket population is too large to represent",
+				zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
+			return
+		}
 	}
 
 	dp := datapoints.AppendEmpty()
 	dp.SetStartTimestamp(pcommon.Timestamp(histogram.StartTimestamp * int64(time.Millisecond)))
 	dp.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * int64(time.Millisecond)))
 
-	if value.IsStaleNaN(histogram.Sum) {
+	if stale {
 		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 	} else {
-		setCountAndSum(histogram, dp)
+		// OTLP wants the count to be the sum of the bucket counts. Prometheus counts an
+		// observation of NaN without putting it in any bucket, so the count it sends can be
+		// larger than the buckets account for.
+		dp.SetCount(count)
+		if count > 0 {
+			// OTLP requires the sum to be zero when the count is.
+			dp.SetSum(histogram.Sum)
+		}
 	}
 
 	dp.ExplicitBounds().FromRaw(histogram.CustomValues)
-	bucketCounts := convertNHCBBuckets(histogram)
 	dp.BucketCounts().FromRaw(bucketCounts)
 
 	attrs.CopyTo(dp.Attributes())
@@ -1171,61 +1152,26 @@ func convertNHCBBuckets(histogram *writev2.Histogram) []uint64 {
 		return bucketCounts
 	}
 
-	if histogram.IsFloatHistogram() {
-		// Float histograms: values are absolute counts
-		bucketIdx := 0
-		for _, span := range histogram.PositiveSpans {
-			// Skip empty buckets based on offset
-			bucketIdx += int(span.Offset)
+	// Values are deltas between buckets. Float flavored histograms are dropped earlier.
+	bucketIdx := 0
+	bucketCount := int64(0)
+	deltaIdx := 0
 
-			// Fill buckets for this span
-			for i := uint32(0); i < span.Length && bucketIdx < len(bucketCounts) && i < uint32(len(histogram.PositiveCounts)); i++ {
-				if bucketIdx >= 0 && bucketIdx < len(bucketCounts) {
-					bucketCounts[bucketIdx] = uint64(histogram.PositiveCounts[i])
-				}
-				bucketIdx++
+	for _, span := range histogram.PositiveSpans {
+		// Skip empty buckets based on offset
+		bucketIdx += int(span.Offset)
+
+		// Fill buckets for this span
+		for i := uint32(0); i < span.Length && bucketIdx < len(bucketCounts) && deltaIdx < len(histogram.PositiveDeltas); i++ {
+			bucketCount += histogram.PositiveDeltas[deltaIdx]
+			deltaIdx++
+
+			if bucketIdx >= 0 && bucketIdx < len(bucketCounts) {
+				bucketCounts[bucketIdx] = uint64(bucketCount)
 			}
-		}
-	} else {
-		// Integer histograms: values are deltas between buckets
-		bucketIdx := 0
-		bucketCount := int64(0)
-		deltaIdx := 0
-
-		for _, span := range histogram.PositiveSpans {
-			// Skip empty buckets based on offset
-			bucketIdx += int(span.Offset)
-
-			// Fill buckets for this span
-			for i := uint32(0); i < span.Length && bucketIdx < len(bucketCounts) && deltaIdx < len(histogram.PositiveDeltas); i++ {
-				bucketCount += histogram.PositiveDeltas[deltaIdx]
-				deltaIdx++
-
-				if bucketIdx >= 0 && bucketIdx < len(bucketCounts) {
-					bucketCounts[bucketIdx] = uint64(bucketCount)
-				}
-				bucketIdx++
-			}
+			bucketIdx++
 		}
 	}
 
 	return bucketCounts
-}
-
-// setCountAndSum sets count and sum for histogram datapoints (common interface)
-type countSumSetter interface {
-	SetSum(float64)
-	SetCount(uint64)
-}
-
-func setCountAndSum(histogram *writev2.Histogram, dp countSumSetter) {
-	dp.SetSum(histogram.Sum)
-
-	if histogram.IsFloatHistogram() {
-		countFloat := histogram.GetCountFloat()
-		dp.SetCount(uint64(countFloat))
-	} else {
-		countInt := histogram.GetCountInt()
-		dp.SetCount(countInt)
-	}
 }

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -1198,7 +1198,7 @@ func applyScopeInfo(sm pmetric.ScopeMetrics, si scopeInfo) {
 // the buckets. The dense form is as long as the bounds, so unlike the exponential schemas it needs
 // no separate limit.
 func validateNHCB(histogram *writev2.Histogram) error {
-	// The float flavor is turned away before this, so the integer conversion always succeeds.
+	// Callers reject the float flavor, so the integer conversion always succeeds.
 	return histogram.ToIntHistogram().Validate()
 }
 

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -380,13 +380,16 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		// Published to the shared cache only once the request has been accepted.
 		cacheUpdates = make(map[uint64]stagedResource)
 
-		// exemplarMap keeps track of exemplars and key is composed by scope_name:scope_version:metric_name:type
-		exemplarMap = collectExemplars(req, prw.settings, &stats)
-
 		// bucketBudget bounds what every Native Histogram in this request may expand into
 		// together, since all of it stays in memory until the request has been translated.
 		bucketBudget = histogramBucketBudget{remaining: maxExponentialHistogramBucketsPerRequest}
 	)
+
+	// exemplarMap keeps track of exemplars and key is composed by scope_name:scope_version:metric_name:type
+	exemplarMap, err := collectExemplars(req, prw.settings, &stats)
+	if err != nil {
+		return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, err
+	}
 
 	for i := range req.Timeseries {
 		ts := &req.Timeseries[i]
@@ -567,6 +570,18 @@ func validateTimeSeriesPayload(ts *writev2.TimeSeries, name string) error {
 			return fmt.Errorf("timeseries %q is typed %s but carries histograms", name, ts.Metadata.Type)
 		}
 	}
+	if name == "target_info" {
+		// It is read for its labels and never becomes a metric, so the branch that reads it
+		// skips straight past whatever else it carries. A histogram there would be dropped
+		// without a word, and an exemplar would be counted as written with no data point to
+		// belong to. Carrying no sample is fine: the labels are the whole point of it.
+		if hasHistograms {
+			return fmt.Errorf("timeseries %q carries histograms, which it has no data point for", name)
+		}
+		if len(ts.Exemplars) > 0 {
+			return fmt.Errorf("timeseries %q carries exemplars, which it has no data point for", name)
+		}
+	}
 	return nil
 }
 
@@ -664,25 +679,6 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 					metricName, histogram.Timestamp, bucketBudget.remaining)
 			}
 		}
-		if histogramType == "nhcb" && !value.IsStaleNaN(histogram.Sum) {
-			// The dense form is as long as the bounds, so what has to be checked is that the
-			// spans and deltas describe that shape. Prometheus runs the same check on every
-			// histogram it accepts over remote write; without it the conversion below stops
-			// where the bounds or the deltas run out and reports what it managed to read.
-			// The float flavor is refused above, so the integer conversion always succeeds.
-			if err := histogram.ToIntHistogram().Validate(); err != nil {
-				prw.settings.Logger.Error(
-					"Dropping Native Histogram that cannot be converted",
-					zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
-					zapcore.Field{Key: "job", Type: zapcore.StringType, String: ls.Get("job")},
-					zapcore.Field{Key: "instance", Type: zapcore.StringType, String: ls.Get("instance")},
-					zapcore.Field{Key: "timestamp", Type: zapcore.Int64Type, Integer: histogram.Timestamp},
-					zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: err},
-				)
-				continue
-			}
-		}
-
 		if hashedLabels == 0 {
 			rm, hashedLabels = prw.getOrCreateRM(ls, otelMetrics, modifiedRM, cacheUpdates)
 			resourceID := identity.OfResource(rm.Resource())

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -614,8 +614,8 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 		case -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8:
 			histogramType = "exponential"
 		default:
-			// Kept from #48027: operators asked for the detail at debug level, and the error
-			// carries the same information back to the sender.
+			// The debug detail is what operators asked for in #48027, and the error carries
+			// the same information back to the sender.
 			prw.settings.Logger.Debug(
 				"Dropping histogram with invalid schema",
 				zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -604,6 +604,24 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 				continue
 			}
 		}
+		if histogramType == "nhcb" && !value.IsStaleNaN(histogram.Sum) {
+			// The dense form is as long as the bounds, so what has to be checked is that the
+			// spans and deltas describe that shape. Prometheus runs the same check on every
+			// histogram it accepts over remote write; without it the conversion below stops
+			// where the bounds or the deltas run out and reports what it managed to read.
+			// The float flavor is refused above, so the integer conversion always succeeds.
+			if err := histogram.ToIntHistogram().Validate(); err != nil {
+				prw.settings.Logger.Error(
+					"Dropping Native Histogram that cannot be converted",
+					zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
+					zapcore.Field{Key: "job", Type: zapcore.StringType, String: ls.Get("job")},
+					zapcore.Field{Key: "instance", Type: zapcore.StringType, String: ls.Get("instance")},
+					zapcore.Field{Key: "timestamp", Type: zapcore.Int64Type, Integer: histogram.Timestamp},
+					zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: err},
+				)
+				continue
+			}
+		}
 
 		if hashedLabels == 0 {
 			rm, hashedLabels = prw.getOrCreateRM(ls, otelMetrics, modifiedRM)

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -194,6 +194,10 @@ func (prw *prometheusRemoteWriteReceiver) handlePRW(w http.ResponseWriter, req *
 		return
 	}
 
+	// Content negotiation has succeeded, so every response from here owes the sender the written
+	// counts. A missing header does not tell it zero, only that the receiver does not report.
+	promremote.WriteResponseStats{}.SetHeaders(w)
+
 	// After parsing the content-type header, the next step would be to handle content-encoding.
 	// Luckly confighttp's Server has middleware that already decompress the request body for us.
 	buf := prw.bodyBufferPool.Get().(*bytes.Buffer)
@@ -212,15 +216,19 @@ func (prw *prometheusRemoteWriteReceiver) handlePRW(w http.ResponseWriter, req *
 		return
 	}
 
-	m, stats, err := prw.translateV2(req.Context(), &prw2Req)
-	stats.SetHeaders(w)
+	m, stats, cacheUpdates, err := prw.translateV2(req.Context(), &prw2Req)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest) // Following instructions at https://prometheus.io/docs/specs/remote_write_spec_2_0/#invalid-samples
+		// The consumer never saw this, so nothing was written.
+		// https://prometheus.io/docs/specs/remote_write_spec_2_0/#invalid-samples
+		promremote.WriteResponseStats{}.SetHeaders(w)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	// Return early if metric count is 0.
-	if m.MetricCount() == 0 {
+	// Return early if there is nothing to hand over.
+	if m.DataPointCount() == 0 {
+		stats.SetHeaders(w)
+		prw.commitResourceCache(cacheUpdates)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
@@ -230,6 +238,9 @@ func (prw *prometheusRemoteWriteReceiver) handlePRW(w http.ResponseWriter, req *
 	prw.obsrecv.EndMetricsOp(obsrecvCtx, "prometheusremotewritereceiver", m.DataPointCount(), err)
 	if err != nil {
 		prw.settings.Logger.Error("Error consuming metrics", zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: err})
+		// The consumer reports one error for the whole batch and no partial count, so the batch
+		// counts as unwritten and the resource cache is not updated either.
+		promremote.WriteResponseStats{}.SetHeaders(w)
 		if consumererror.IsPermanent(err) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		} else {
@@ -238,7 +249,29 @@ func (prw *prometheusRemoteWriteReceiver) handlePRW(w http.ResponseWriter, req *
 		return
 	}
 
+	stats.SetHeaders(w)
+	prw.commitResourceCache(cacheUpdates)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// stagedResource is a resource snapshot waiting for its request to be accepted.
+type stagedResource struct {
+	snapshot pmetric.ResourceMetrics
+	// learned marks attributes read from target_info, which replace what the cache holds. One
+	// derived from job and instance only fills a gap, since a concurrent request may hold more.
+	learned bool
+}
+
+// commitResourceCache publishes the snapshots a request staged, once it has been accepted. Staging
+// them keeps a rejected request from changing what later ones see.
+func (prw *prometheusRemoteWriteReceiver) commitResourceCache(updates map[uint64]stagedResource) {
+	for hashedLabels, staged := range updates {
+		if staged.learned {
+			prw.rmCache.Add(hashedLabels, staged.snapshot)
+			continue
+		}
+		prw.rmCache.ContainsOrAdd(hashedLabels, staged.snapshot)
+	}
 }
 
 // parseProto parses the content-type header and returns the version of the remote-write protocol.
@@ -284,7 +317,7 @@ func (*prometheusRemoteWriteReceiver) parseProto(contentType string) (remoteapi.
 // This function always creates new ResourceMetrics per request, only copying attributes
 // from the LRU cache when available. Never returns cached objects to avoid shared
 // mutation across concurrent requests.
-func (prw *prometheusRemoteWriteReceiver) getOrCreateRM(ls labels.Labels, otelMetrics pmetric.Metrics, reqRM map[uint64]pmetric.ResourceMetrics) (pmetric.ResourceMetrics, uint64) {
+func (prw *prometheusRemoteWriteReceiver) getOrCreateRM(ls labels.Labels, otelMetrics pmetric.Metrics, reqRM map[uint64]pmetric.ResourceMetrics, cacheUpdates map[uint64]stagedResource) (pmetric.ResourceMetrics, uint64) {
 	// Hash job+instance directly to avoid allocating a temporary pcommon.Resource
 	// on every call (which happens once per time series).
 	job := ls.Get("job")
@@ -300,7 +333,14 @@ func (prw *prometheusRemoteWriteReceiver) getOrCreateRM(ls labels.Labels, otelMe
 	}
 
 	rm := otelMetrics.ResourceMetrics().AppendEmpty()
-	if existingRM, ok := prw.rmCache.Get(hashedLabels); ok {
+	var existingRM pmetric.ResourceMetrics
+	staged, ok := cacheUpdates[hashedLabels]
+	if ok {
+		existingRM = staged.snapshot
+	} else {
+		existingRM, ok = prw.rmCache.Get(hashedLabels)
+	}
+	if ok {
 		// When the ResourceMetrics already exists in the global cache, we can reuse the previous snapshots and perpass the already seen attributes to the current request.
 		existingRM.Resource().Attributes().CopyTo(rm.Resource().Attributes())
 	} else {
@@ -309,7 +349,7 @@ func (prw *prometheusRemoteWriteReceiver) getOrCreateRM(ls labels.Labels, otelMe
 		parseJobAndInstance(rm.Resource().Attributes(), ls.Get("job"), ls.Get("instance"))
 		snapshot := pmetric.NewResourceMetrics()
 		rm.Resource().Attributes().CopyTo(snapshot.Resource().Attributes())
-		prw.rmCache.Add(hashedLabels, snapshot)
+		cacheUpdates[hashedLabels] = stagedResource{snapshot: snapshot}
 	}
 
 	reqRM[hashedLabels] = rm
@@ -318,7 +358,7 @@ func (prw *prometheusRemoteWriteReceiver) getOrCreateRM(ls labels.Labels, otelMe
 
 // translateV2 translates a v2 remote-write request into OTLP metrics.
 // translate is not feature complete.
-func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *writev2.Request) (pmetric.Metrics, promremote.WriteResponseStats, error) {
+func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *writev2.Request) (pmetric.Metrics, promremote.WriteResponseStats, map[uint64]stagedResource, error) {
 	var (
 		badRequestErrors error
 		// otelMetrics represents the final metrics, after all the processing, that will be returned by the receiver.
@@ -336,6 +376,9 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		// Once the request is fully processed, only the resource attributes contained in the request’s ResourceMetrics are snapshotted back into the LRU cache.
 		// This ensures that future requests start with the enriched resource attributes already applied.
 		modifiedResourceMetric = make(map[uint64]pmetric.ResourceMetrics)
+
+		// Published to the shared cache only once the request has been accepted.
+		cacheUpdates = make(map[uint64]stagedResource)
 
 		// exemplarMap keeps track of exemplars and key is composed by scope_name:scope_version:metric_name:type
 		exemplarMap = collectExemplars(req, prw.settings, &stats)
@@ -360,11 +403,15 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("duplicate label %q in labels", duplicateLabel))
 			continue
 		}
+		if err := validateTimeSeriesPayload(ts, metadata.Name); err != nil {
+			badRequestErrors = errors.Join(badRequestErrors, err)
+			continue
+		}
 
 		// If the metric name is equal to target_info, we use its labels as attributes of the resource
 		// Ref: https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#resource-attributes-1
 		if metadata.Name == "target_info" {
-			rm, hashed := prw.getOrCreateRM(ls, otelMetrics, modifiedResourceMetric)
+			rm, hashed := prw.getOrCreateRM(ls, otelMetrics, modifiedResourceMetric, cacheUpdates)
 			attrs := rm.Resource().Attributes()
 
 			// Add the remaining labels as resource attributes
@@ -376,7 +423,7 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 
 			snapshot := pmetric.NewResourceMetrics()
 			attrs.CopyTo(snapshot.Resource().Attributes())
-			prw.rmCache.Add(hashed, snapshot)
+			cacheUpdates[hashed] = stagedResource{snapshot: snapshot, learned: true}
 			// target_info is not stored as a metric but PRW requires the response
 			// to report all received samples, including target_info, to avoid a stats mismatch
 			stats.Samples += len(ts.Samples)
@@ -401,12 +448,17 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		// Handle histograms separately due to their complex mixed-schema processing
 		if ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_HISTOGRAM ||
 			ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_UNSPECIFIED && len(ts.Histograms) > 0 {
-			prw.processHistogramTimeSeries(otelMetrics, ls, ts, si, metricName, unit, description, metricCache, scopeCache, &stats, modifiedResourceMetric, exemplarMap, &bucketBudget)
+			if err := prw.processHistogramTimeSeries(otelMetrics, ls, ts, si, metricName, unit, description, metricCache, scopeCache, &stats, modifiedResourceMetric, exemplarMap, &bucketBudget, cacheUpdates); err != nil {
+				// The whole request is rejected either way, so there is nothing to gain from
+				// translating the rest of it, and collecting an error per histogram would let a
+				// request full of invalid ones inflate the response several times over.
+				return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, err
+			}
 			continue
 		}
 
 		// Handle regular metrics (gauge, counter, summary)
-		rm, _ := prw.getOrCreateRM(ls, otelMetrics, modifiedResourceMetric)
+		rm, _ := prw.getOrCreateRM(ls, otelMetrics, modifiedResourceMetric, cacheUpdates)
 
 		resourceID := identity.OfResource(rm.Resource())
 		metricID := createMetricIdentity(
@@ -459,8 +511,8 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 					metric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "stateset")
 				}
 			case writev2.Metadata_METRIC_TYPE_SUMMARY:
-				// Drop summary series as we will not handle them.
-				continue
+				return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil,
+					fmt.Errorf("summary metric %q is not supported by this receiver, its quantile series can arrive in separate requests and cannot be reassembled", metricName)
 			default:
 				badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, metricName))
 				continue
@@ -496,19 +548,38 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 			}
 
 		case writev2.Metadata_METRIC_TYPE_SUMMARY:
-			// Drop summary series as we will not handle them.
-			continue
+			return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil,
+				fmt.Errorf("summary metric %q is not supported by this receiver, its quantile series can arrive in separate requests and cannot be reassembled", metricName)
 		default:
 			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, metricName))
 		}
 	}
 
-	if bucketBudget.exhausted {
-		prw.settings.Logger.Warn("Dropped Native Histograms that did not fit the request bucket budget",
-			zapcore.Field{Key: "max_buckets", Type: zapcore.Int64Type, Integer: maxExponentialHistogramBucketsPerRequest})
+	if badRequestErrors != nil {
+		// Nothing is published when any known data could not be written.
+		return pmetric.NewMetrics(), promremote.WriteResponseStats{}, nil, badRequestErrors
 	}
 
-	return otelMetrics, stats, badRequestErrors
+	return otelMetrics, stats, cacheUpdates, badRequestErrors
+}
+
+// validateTimeSeriesPayload checks what a series carries against what the protocol allows it to.
+// A series holds samples or histograms and never both, and the metric type decides which of the
+// two the receiver goes looking for, so histograms attached to a sample type are data the
+// receiver would silently walk past.
+func validateTimeSeriesPayload(ts *writev2.TimeSeries, name string) error {
+	hasSamples, hasHistograms := len(ts.Samples) > 0, len(ts.Histograms) > 0
+	if hasSamples && hasHistograms {
+		return fmt.Errorf("timeseries %q carries both samples and histograms", name)
+	}
+	if hasHistograms {
+		switch ts.Metadata.Type {
+		case writev2.Metadata_METRIC_TYPE_HISTOGRAM, writev2.Metadata_METRIC_TYPE_GAUGEHISTOGRAM, writev2.Metadata_METRIC_TYPE_UNSPECIFIED:
+		default:
+			return fmt.Errorf("timeseries %q is typed %s but carries histograms", name, ts.Metadata.Type)
+		}
+	}
+	return nil
 }
 
 // processHistogramTimeSeries handles all histogram processing, including validation and mixed schemas.
@@ -524,12 +595,11 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 	modifiedRM map[uint64]pmetric.ResourceMetrics,
 	exemplarMap map[uint64]pmetric.ExemplarSlice,
 	bucketBudget *histogramBucketBudget,
-) {
+	cacheUpdates map[uint64]stagedResource,
+) error {
 	// Drop classic histogram series (those with samples)
 	if len(ts.Samples) != 0 {
-		prw.settings.Logger.Info("Dropping classic histogram series. Please configure Prometheus to convert classic histograms into Native Histograms Custom Buckets",
-			zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
-		return
+		return fmt.Errorf("classic histogram series %q is not supported, configure Prometheus to send Native Histograms with Custom Buckets", ls.Get("__name__"))
 	}
 	attrs := extractAttributes(ls)
 
@@ -543,7 +613,7 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 	for i := range ts.Histograms {
 		histogram := &ts.Histograms[i]
 		if histogram.ResetHint == writev2.Histogram_RESET_HINT_GAUGE {
-			continue
+			return fmt.Errorf("gauge flavored Native Histogram %q at timestamp %d is not supported", metricName, histogram.Timestamp)
 		}
 
 		var histogramType string
@@ -556,7 +626,8 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 		case -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8:
 			histogramType = "exponential"
 		default:
-			// Skip invalid schema - log at debug level for details
+			// Kept from #48027: operators asked for the detail at debug level, and the error
+			// carries the same information back to the sender.
 			prw.settings.Logger.Debug(
 				"Dropping histogram with invalid schema",
 				zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
@@ -565,43 +636,44 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 				zapcore.Field{Key: "instance", Type: zapcore.StringType, String: ls.Get("instance")},
 				zapcore.Field{Key: "timestamp", Type: zapcore.Int64Type, Integer: histogram.Timestamp},
 			)
-			continue
+			return fmt.Errorf("Native Histogram %q at timestamp %d has unsupported schema %d", metricName, histogram.Timestamp, histogram.Schema)
 		}
 
 		// The compatibility specification requires native histograms of the float flavor to be
 		// dropped; the gauge flavor is already rejected above. This has to come before the stale
 		// check, otherwise a stale float histogram would be accepted by accident.
 		if histogram.IsFloatHistogram() {
-			prw.settings.Logger.Debug(
-				"Dropping float flavored Native Histogram",
-				zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
-				zapcore.Field{Key: "job", Type: zapcore.StringType, String: ls.Get("job")},
-				zapcore.Field{Key: "instance", Type: zapcore.StringType, String: ls.Get("instance")},
-			)
-			continue
+			return fmt.Errorf("float flavored Native Histogram %q at timestamp %d is not supported", metricName, histogram.Timestamp)
+		}
+		// The zero bucket has to agree with the rest of the histogram. Anything the sender put in
+		// the float side of it is invisible to an integer histogram, which is the only flavor left
+		// by the time we get here, so those observations would go missing without a word.
+		if _, floatZero := histogram.GetZeroCount().(*writev2.Histogram_ZeroCountFloat); floatZero {
+			return fmt.Errorf("Native Histogram %q at timestamp %d carries a float zero count on an integer histogram", metricName, histogram.Timestamp)
+		}
+		// The zero threshold is written to the data point whether or not the histogram carries a
+		// stale marker, and the Native Histograms specification defines it as a float64 >= 0.
+		if histogram.ZeroThreshold < 0 {
+			return fmt.Errorf("Native Histogram %q at timestamp %d has a negative zero threshold %v", metricName, histogram.Timestamp, histogram.ZeroThreshold)
 		}
 
-		// Validate everything that can be checked without allocating, so that a histogram which
-		// is going to be dropped never reserves budget or leaves an empty metric behind. A stale
+		// Validate before any resource, scope or metric is built, so that a histogram which is
+		// going to be dropped never reserves budget or leaves an empty metric behind. A stale
 		// marker is exempt because its remaining fields are ignored rather than translated.
 		var expLayout exponentialHistogramLayout
-		if histogramType == "exponential" && !value.IsStaleNaN(histogram.Sum) {
+		if !value.IsStaleNaN(histogram.Sum) {
 			var err error
-			expLayout, err = validateExponentialHistogram(histogram)
-			if err != nil {
-				prw.settings.Logger.Error(
-					"Dropping Native Histogram that cannot be converted",
-					zapcore.Field{Key: "metric_name", Type: zapcore.StringType, String: metricName},
-					zapcore.Field{Key: "job", Type: zapcore.StringType, String: ls.Get("job")},
-					zapcore.Field{Key: "instance", Type: zapcore.StringType, String: ls.Get("instance")},
-					zapcore.Field{Key: "timestamp", Type: zapcore.Int64Type, Integer: histogram.Timestamp},
-					zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: err},
-				)
-				continue
+			if histogramType == "nhcb" {
+				err = validateNHCB(histogram)
+			} else {
+				expLayout, err = validateExponentialHistogram(histogram)
 			}
-			if !bucketBudget.reserve(expLayout) {
-				// Logged once for the request rather than once per histogram.
-				continue
+			if err != nil {
+				return fmt.Errorf("Native Histogram %q at timestamp %d cannot be converted: %w", metricName, histogram.Timestamp, err)
+			}
+			if histogramType == "exponential" && !bucketBudget.reserve(expLayout) {
+				return fmt.Errorf("Native Histogram %q at timestamp %d does not fit the remaining request budget of %d buckets",
+					metricName, histogram.Timestamp, bucketBudget.remaining)
 			}
 		}
 		if histogramType == "nhcb" && !value.IsStaleNaN(histogram.Sum) {
@@ -624,7 +696,7 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 		}
 
 		if hashedLabels == 0 {
-			rm, hashedLabels = prw.getOrCreateRM(ls, otelMetrics, modifiedRM)
+			rm, hashedLabels = prw.getOrCreateRM(ls, otelMetrics, modifiedRM, cacheUpdates)
 			resourceID := identity.OfResource(rm.Resource())
 			is := pcommon.NewInstrumentationScope()
 			is.SetName(si.Name)
@@ -687,12 +759,16 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 		exemplarSlice := pmetric.NewExemplarSlice()
 		// Process the individual histogram
 		if histogramType == "nhcb" {
-			prw.addNHCBDatapoint(histMetric.Histogram().DataPoints(), histogram, attrs, ls, stats)
+			if err := prw.addNHCBDatapoint(histMetric.Histogram().DataPoints(), histogram, attrs, stats); err != nil {
+				return fmt.Errorf("Native Histogram %q at timestamp %d cannot be converted: %w", metricName, histogram.Timestamp, err)
+			}
 			if histMetric.Histogram().DataPoints().Len() > 0 {
 				exemplarSlice = histMetric.Histogram().DataPoints().At(0).Exemplars()
 			}
 		} else {
-			prw.addExponentialHistogramDatapoint(histMetric.ExponentialHistogram().DataPoints(), histogram, expLayout, attrs, ls, stats)
+			if err := prw.addExponentialHistogramDatapoint(histMetric.ExponentialHistogram().DataPoints(), histogram, expLayout, attrs, stats); err != nil {
+				return fmt.Errorf("Native Histogram %q at timestamp %d cannot be converted: %w", metricName, histogram.Timestamp, err)
+			}
 			if histMetric.ExponentialHistogram().DataPoints().Len() > 0 {
 				exemplarSlice = histMetric.ExponentialHistogram().DataPoints().At(0).Exemplars()
 			}
@@ -709,6 +785,8 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 			ex.CopyTo(exemplarSlice)
 		}
 	}
+
+	return nil
 }
 
 // setMetric append a new empty metric and assign the name, unit and description to it.
@@ -757,7 +835,7 @@ func addNumberDatapoints(datapoints pmetric.NumberDataPointSlice, ls labels.Labe
 
 // addExponentialHistogramDatapoint converts one exponential Native Histogram to an OTLP data
 // point. layout must come from validateExponentialHistogram for the same histogram.
-func (prw *prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datapoints pmetric.ExponentialHistogramDataPointSlice, histogram *writev2.Histogram, layout exponentialHistogramLayout, attrs pcommon.Map, ls labels.Labels, stats *promremote.WriteResponseStats) {
+func (*prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datapoints pmetric.ExponentialHistogramDataPointSlice, histogram *writev2.Histogram, layout exponentialHistogramLayout, attrs pcommon.Map, stats *promremote.WriteResponseStats) error {
 	// A stale marker carries no distribution: the specification ignores the remaining fields when
 	// the sum is the stale NaN, so none of them are read.
 	if value.IsStaleNaN(histogram.Sum) {
@@ -769,7 +847,7 @@ func (prw *prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datap
 		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 		attrs.CopyTo(dp.Attributes())
 		stats.Histograms++
-		return
+		return nil
 	}
 
 	// Built aside from the slice so that a histogram whose population cannot be represented is
@@ -791,9 +869,7 @@ func (prw *prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datap
 	// represented by a bucket, which happens for NaN observations and for the overflow bucket.
 	count, ok := addPopulations(zeroCount, positive, negative)
 	if !positiveOK || !negativeOK || !ok {
-		prw.settings.Logger.Info("Dropping Native Histogram whose bucket population is too large to represent",
-			zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
-		return
+		return errors.New("bucket population is too large to represent")
 	}
 	dp.SetCount(count)
 	if count > 0 {
@@ -805,6 +881,7 @@ func (prw *prometheusRemoteWriteReceiver) addExponentialHistogramDatapoint(datap
 	attrs.CopyTo(dp.Attributes())
 	dp.MoveTo(datapoints.AppendEmpty())
 	stats.Histograms++
+	return nil
 }
 
 // addPopulations sums bucket populations, reporting false if the total cannot be represented.
@@ -859,14 +936,12 @@ const maxExponentialHistogramBucketsPerRequest = 4 * 1024 * 1024
 // histogramBucketBudget is the share of maxExponentialHistogramBucketsPerRequest left in a request.
 type histogramBucketBudget struct {
 	remaining int64
-	exhausted bool
 }
 
 // reserve claims the buckets one data point needs, reporting whether they were still available.
 func (b *histogramBucketBudget) reserve(layout exponentialHistogramLayout) bool {
 	needed := layout.positive.numBuckets + layout.negative.numBuckets
 	if needed > b.remaining {
-		b.exhausted = true
 		return false
 	}
 	b.remaining -= needed
@@ -1117,8 +1192,17 @@ func applyScopeInfo(sm pmetric.ScopeMetrics, si scopeInfo) {
 	}
 }
 
+// validateNHCB checks a custom bucket histogram the way Prometheus checks the ones it accepts over
+// remote write: the spans against the bounds, the bounds against each other, and the count against
+// the buckets. The dense form is as long as the bounds, so unlike the exponential schemas it needs
+// no separate limit.
+func validateNHCB(histogram *writev2.Histogram) error {
+	// The float flavor is turned away before this, so the integer conversion always succeeds.
+	return histogram.ToIntHistogram().Validate()
+}
+
 // addNHCBDatapoint converts a single Native Histogram Custom Buckets (NHCB) to OpenTelemetry histogram datapoints
-func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram *writev2.Histogram, attrs pcommon.Map, ls labels.Labels, stats *promremote.WriteResponseStats) {
+func (*prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram *writev2.Histogram, attrs pcommon.Map, stats *promremote.WriteResponseStats) error {
 	// A stale marker records that the series stopped, so it carries no distribution and the
 	// spans and deltas that would describe one are left unread.
 	if value.IsStaleNaN(histogram.Sum) {
@@ -1130,24 +1214,19 @@ func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.Hi
 		dp.BucketCounts().FromRaw(make([]uint64, len(histogram.CustomValues)+1))
 		attrs.CopyTo(dp.Attributes())
 		stats.Histograms++
-		return
+		return nil
 	}
-
 	// Bounds sit between buckets, so a histogram carrying none still has the bucket above the
 	// last one, which is what a classic histogram with only a +Inf bucket becomes.
 	bucketCounts, ok := convertNHCBBuckets(histogram)
 	if !ok {
-		prw.settings.Logger.Info("Dropping Native Histogram whose deltas take a bucket population below zero",
-			zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
-		return
+		return errors.New("bucket population goes below zero")
 	}
 
 	// Counted first, so a population that cannot be represented is never half published.
 	count, ok := addPopulations(bucketCounts...)
 	if !ok {
-		prw.settings.Logger.Info("Dropping Native Histogram whose bucket population is too large to represent",
-			zapcore.Field{Key: "timeseries", Type: zapcore.StringType, String: ls.Get("__name__")})
-		return
+		return errors.New("bucket population is too large to represent")
 	}
 
 	dp := datapoints.AppendEmpty()
@@ -1168,6 +1247,7 @@ func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.Hi
 
 	attrs.CopyTo(dp.Attributes())
 	stats.Histograms++
+	return nil
 }
 
 // convertNHCBBuckets converts NHCB bucket data to OpenTelemetry bucket counts, reporting false

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -229,6 +229,53 @@ func TestNHCBUnrepresentablePopulationIsDropped(t *testing.T) {
 	assert.Equal(t, 0, dps.Len(), "a population that cannot be represented is not published")
 }
 
+func TestNHCBNegativeBucketPopulationIsDropped(t *testing.T) {
+	// Deltas are cumulative, so a run of them can go below zero. A bucket holds a count of
+	// observations, which cannot, and the conversion to uint64 would turn it into a very large
+	// one. This PR derives the data point count from the buckets, so it would land there too.
+	for _, tc := range []struct {
+		name   string
+		deltas []int64
+	}{
+		{name: "first delta below zero", deltas: []int64{-1, 0}},
+		{name: "running count falls below zero", deltas: []int64{1, -5}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prwReceiver := setupMetricsReceiver(t)
+
+			metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+						Histograms: []writev2.Histogram{{
+							Count:          &writev2.Histogram_CountInt{CountInt: 1},
+							Sum:            1,
+							Timestamp:      1,
+							Schema:         -53,
+							CustomValues:   []float64{1.0},
+							PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+							PositiveDeltas: tc.deltas,
+						}},
+					},
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 0, stats.Histograms)
+
+			dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+				Histogram().DataPoints()
+			assert.Equal(t, 0, dps.Len(), "a negative bucket population is not published")
+		})
+	}
+}
+
 func TestNHCBWithoutBoundsIsKept(t *testing.T) {
 	// Bounds sit between buckets, so a histogram with none of them still has the bucket above the
 	// last one. Prometheus produces that shape for a classic histogram whose only bucket was +Inf.

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -191,6 +191,178 @@ func TestHandlePRWContentTypeNegotiation(t *testing.T) {
 	}
 }
 
+func TestNHCBUnrepresentablePopulationIsDropped(t *testing.T) {
+	// Five buckets of 2^62 sum past what a uint64 count can hold, so there is no data point that
+	// both keeps the buckets and carries a count OTLP accepts.
+	prwReceiver := setupMetricsReceiver(t)
+
+	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+		Symbols: []string{
+			"",
+			"__name__", "test_metric", // 1, 2
+			"job", "service-x/test", // 3, 4
+			"instance", "107cn001", // 5, 6
+		},
+		Timeseries: []writev2.TimeSeries{
+			{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Count:          &writev2.Histogram_CountInt{CountInt: 1},
+					Sum:            1,
+					Timestamp:      1,
+					Schema:         -53,
+					CustomValues:   []float64{1.0, 2.0, 3.0, 4.0},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 5}},
+					PositiveDeltas: []int64{1 << 62, 0, 0, 0, 0},
+				}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.Histograms)
+
+	// The metric container is created before the buckets are converted, so it is still there,
+	// empty. That shape is the same for every late rejection and is tracked in #50340.
+	dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+		Histogram().DataPoints()
+	assert.Equal(t, 0, dps.Len(), "a population that cannot be represented is not published")
+}
+
+func TestNHCBWithoutBoundsIsKept(t *testing.T) {
+	// Bounds sit between buckets, so a histogram with none of them still has the bucket above the
+	// last one. Prometheus produces that shape for a classic histogram whose only bucket was +Inf.
+	for _, tc := range []struct {
+		name     string
+		count    uint64
+		spans    []writev2.BucketSpan
+		deltas   []int64
+		expected []uint64
+	}{
+		{
+			name:     "one observation in the implicit bucket",
+			count:    1,
+			spans:    []writev2.BucketSpan{{Offset: 0, Length: 1}},
+			deltas:   []int64{1},
+			expected: []uint64{1},
+		},
+		{
+			name:     "no observations at all",
+			expected: []uint64{0},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prwReceiver := setupMetricsReceiver(t)
+
+			metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+						Histograms: []writev2.Histogram{{
+							Count:          &writev2.Histogram_CountInt{CountInt: tc.count},
+							Sum:            1,
+							Timestamp:      1,
+							Schema:         -53,
+							PositiveSpans:  tc.spans,
+							PositiveDeltas: tc.deltas,
+						}},
+					},
+				},
+			})
+			require.NoError(t, err)
+			require.Equal(t, 1, stats.Histograms)
+
+			dp := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+				Histogram().DataPoints().At(0)
+			assert.Empty(t, dp.ExplicitBounds().AsRaw())
+			assert.Equal(t, tc.expected, dp.BucketCounts().AsRaw())
+			assert.Equal(t, tc.count, dp.Count())
+		})
+	}
+}
+
+func TestStaleNHCBIsKeptWhateverItsBucketsSay(t *testing.T) {
+	// A stale marker has no population, so the buckets it carries are not summed and cannot take
+	// the marker down with them by overflowing.
+	prwReceiver := setupMetricsReceiver(t)
+
+	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+		Symbols: []string{
+			"",
+			"__name__", "test_metric", // 1, 2
+			"job", "service-x/test", // 3, 4
+			"instance", "107cn001", // 5, 6
+		},
+		Timeseries: []writev2.TimeSeries{
+			{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Count:          &writev2.Histogram_CountInt{CountInt: 0},
+					Sum:            math.Float64frombits(value.StaleNaN),
+					Timestamp:      1,
+					Schema:         -53,
+					CustomValues:   []float64{1, 2, 3, 4},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 5}},
+					PositiveDeltas: []int64{1 << 62, 0, 0, 0, 0},
+				}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Histograms)
+
+	dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Histogram().DataPoints()
+	require.Equal(t, 1, dps.Len(), "the stale marker is published")
+	assert.True(t, dps.At(0).Flags().NoRecordedValue())
+}
+
+func TestNHCBCountComesFromTheBuckets(t *testing.T) {
+	// An observation of NaN raises the Prometheus count without landing in a bucket, so the count
+	// that arrives can be larger than the buckets account for. OTLP requires the two to agree.
+	prwReceiver := setupMetricsReceiver(t)
+
+	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+		Symbols: []string{
+			"",
+			"__name__", "test_metric", // 1, 2
+			"job", "service-x/test", // 3, 4
+			"instance", "107cn001", // 5, 6
+		},
+		Timeseries: []writev2.TimeSeries{
+			{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					// Three observations landed in buckets and one was NaN.
+					Count:          &writev2.Histogram_CountInt{CountInt: 4},
+					Sum:            math.NaN(),
+					Timestamp:      1,
+					Schema:         -53,
+					CustomValues:   []float64{1.0},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+					PositiveDeltas: []int64{1, 1},
+				}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Histograms)
+
+	dp := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+		Histogram().DataPoints().At(0)
+	assert.Equal(t, []uint64{1, 2}, dp.BucketCounts().AsRaw())
+	assert.Equal(t, uint64(3), dp.Count(), "the count is the sum of the buckets, not the 4 that arrived")
+	assert.True(t, dp.HasSum() && math.IsNaN(dp.Sum()), "the NaN sum is carried through")
+}
+
 func TestTranslateV2(t *testing.T) {
 	prwReceiver := setupMetricsReceiver(t)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -512,7 +684,7 @@ func TestTranslateV2(t *testing.T) {
 				expDP := expHist.DataPoints().AppendEmpty()
 				expDP.SetStartTimestamp(pcommon.Timestamp(150 * int64(time.Millisecond)))
 				expDP.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				expDP.SetCount(6)
+				expDP.SetCount(7) // 1 zero + 6 across the buckets
 				expDP.SetSum(1)
 				expDP.SetScale(0)
 				expDP.SetZeroThreshold(1)
@@ -762,7 +934,7 @@ func TestTranslateV2(t *testing.T) {
 				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
 				dp.SetScale(-4)
 				dp.SetSum(30)
-				dp.SetCount(20)
+				dp.SetCount(1015) // 2 zero + 1009 positive + 4 negative
 				dp.SetZeroCount(2)
 				dp.SetZeroThreshold(1)
 				dp.Positive().SetOffset(0)
@@ -824,6 +996,145 @@ func TestTranslateV2(t *testing.T) {
 			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
+			name: "nhcb histogram - all observations outside the buckets leave no count or sum",
+			// A histogram whose only observation was NaN has nothing in any bucket. OTLP requires
+			// the sum to be zero when the count is, so it carries neither.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountInt{CountInt: 48},
+								Sum:            math.NaN(),
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         -53,
+								CustomValues:   []float64{1.0},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Histograms: 1,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.namespace", "service-x")
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "107cn001")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("scope1")
+				sm.Scope().SetVersion("v1")
+
+				m := sm.Metrics().AppendEmpty()
+				m.SetName("test_metric")
+				m.SetUnit("")
+				m.SetDescription("")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+
+				hist := m.SetEmptyHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp := hist.DataPoints().AppendEmpty()
+				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.ExplicitBounds().FromRaw([]float64{1.0})
+				dp.BucketCounts().FromRaw([]uint64{0, 0})
+
+				return metrics
+			}(),
+		},
+		{
+			name: "exponential histogram - float carrying a stale marker is dropped",
+			// A stale marker short circuits the rest of the histogram, so the flavor has to be
+			// checked before it. Otherwise a float histogram is admitted whenever it happens to
+			// be stale, and emits a data point the specification says to drop.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountFloat{CountFloat: 0},
+								Sum:            math.Float64frombits(value.StaleNaN),
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         0,
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed: true,
+			},
+			expectedMetrics: pmetric.NewMetrics(),
+		},
+		{
+			name: "nhcb histogram - float carrying a stale marker is dropped",
+			// The custom bucket schema reaches the stale short circuit through a different branch.
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count:          &writev2.Histogram_CountFloat{CountFloat: 0},
+								Sum:            math.Float64frombits(value.StaleNaN),
+								Timestamp:      1,
+								StartTimestamp: 1,
+								Schema:         -53,
+								CustomValues:   []float64{1.0},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed: true,
+			},
+			expectedMetrics: pmetric.NewMetrics(),
+		},
+		{
 			name: "exponential histogram - float",
 			request: &writev2.Request{
 				Symbols: []string{
@@ -863,48 +1174,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedMetrics: func() pmetric.Metrics {
-				metrics := pmetric.NewMetrics()
-				rm := metrics.ResourceMetrics().AppendEmpty()
-				attrs := rm.Resource().Attributes()
-				attrs.PutStr("service.namespace", "service-x")
-				attrs.PutStr("service.name", "test")
-				attrs.PutStr("service.instance.id", "107cn001")
-
-				sm := rm.ScopeMetrics().AppendEmpty()
-				sm.Scope().SetName("scope1")
-				sm.Scope().SetVersion("v1")
-
-				m := sm.Metrics().AppendEmpty()
-				m.SetName("test_metric")
-				m.SetUnit("")
-				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
-
-				hist := m.SetEmptyExponentialHistogram()
-				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-
-				dp := hist.DataPoints().AppendEmpty()
-				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				dp.SetScale(-4)
-				dp.SetSum(33.3)
-				dp.SetCount(20)
-				dp.SetZeroCount(2)
-				dp.SetZeroThreshold(1)
-				dp.Positive().SetOffset(0)
-				dp.Positive().BucketCounts().FromRaw([]uint64{33, 30, 0, 0, 0, 26, 0, 0, 0, 0, 0, 100})
-				dp.Negative().BucketCounts().FromRaw([]uint64{1})
-				dp.Negative().SetOffset(-1)
-				dp.Negative().BucketCounts().FromRaw([]uint64{1})
-				dp.Attributes().PutStr("attr1", "attr1")
-
-				return metrics
-			}(),
+			// The float flavor must be dropped, so nothing is emitted.
+			expectedMetrics: pmetric.NewMetrics(),
 			expectedStats: remote.WriteResponseStats{
-				Confirmed:  true,
-				Samples:    0,
-				Histograms: 1,
-				Exemplars:  0,
+				Confirmed: true,
 			},
 		},
 		{
@@ -1374,7 +1647,7 @@ func TestTranslateV2(t *testing.T) {
 				dp2.SetTimestamp(pcommon.Timestamp(123456790 * int64(time.Millisecond)))
 				dp2.SetScale(-4)
 				dp2.SetSum(200.0)
-				dp2.SetCount(100)
+				dp2.SetCount(105) // 5 zero + 100 across the buckets
 				dp2.SetZeroCount(5)
 				dp2.SetZeroThreshold(1.0)
 				dp2.Positive().SetOffset(0)
@@ -1453,7 +1726,7 @@ func TestTranslateV2(t *testing.T) {
 				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
 				dp.SetScale(-4)
 				dp.SetSum(30)
-				dp.SetCount(20)
+				dp.SetCount(1015) // 2 zero + 1009 positive + 4 negative
 				dp.SetZeroCount(2)
 				dp.SetZeroThreshold(1)
 				dp.Positive().SetOffset(0)
@@ -1848,7 +2121,7 @@ func TestTranslateV2(t *testing.T) {
 				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
 				dp.SetScale(0)
 				dp.SetSum(100)
-				dp.SetCount(20)
+				dp.SetCount(10) // recomputed from the one retained bucket
 
 				dp.Positive().SetOffset(1023)
 				dp.Positive().BucketCounts().FromRaw([]uint64{10})
@@ -1857,10 +2130,9 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
-			name: "exponential histogram - float overflow buckets dropped",
-			// The float twin of the case above. It walks a different converter, so the integer
-			// case does not cover it: bucket 1024 is kept, bucket 1025 is the overflow bucket and
-			// is dropped along with its 30 observations, leaving a count of 50 - 30.
+			name: "exponential histogram - float overflow buckets are dropped with the histogram",
+			// The integer twin of this case keeps bucket 1024 and drops the overflow bucket. The
+			// float flavor is turned away before any of that, so nothing is emitted at all.
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -1891,42 +2163,9 @@ func TestTranslateV2(t *testing.T) {
 				},
 			},
 			expectedStats: remote.WriteResponseStats{
-				Confirmed:  true,
-				Histograms: 1,
+				Confirmed: true,
 			},
-			expectedMetrics: func() pmetric.Metrics {
-				metrics := pmetric.NewMetrics()
-				rm := metrics.ResourceMetrics().AppendEmpty()
-				attrs := rm.Resource().Attributes()
-				attrs.PutStr("service.namespace", "service-x")
-				attrs.PutStr("service.name", "test")
-				attrs.PutStr("service.instance.id", "107cn001")
-
-				sm := rm.ScopeMetrics().AppendEmpty()
-				sm.Scope().SetName("scope1")
-				sm.Scope().SetVersion("v1")
-
-				m := sm.Metrics().AppendEmpty()
-				m.SetName("test_metric")
-				m.SetUnit("")
-				m.SetDescription("")
-				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
-
-				hist := m.SetEmptyExponentialHistogram()
-				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-
-				dp := hist.DataPoints().AppendEmpty()
-				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				dp.SetScale(0)
-				dp.SetSum(100)
-				dp.SetCount(20)
-
-				dp.Positive().SetOffset(1023)
-				dp.Positive().BucketCounts().FromRaw([]uint64{10})
-
-				return metrics
-			}(),
+			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
 			name: "exponential histogram - malformed negative spans drop the histogram",
@@ -2904,7 +3143,7 @@ func TestTranslateV2(t *testing.T) {
 						Histograms: []writev2.Histogram{
 							{
 								Schema:         -53,
-								Count:          &writev2.Histogram_CountInt{CountInt: 10},
+								Count:          &writev2.Histogram_CountInt{CountInt: 26},
 								Sum:            5.0,
 								Timestamp:      1,
 								StartTimestamp: 1,
@@ -2933,7 +3172,7 @@ func TestTranslateV2(t *testing.T) {
 				dp := hist.DataPoints().AppendEmpty()
 				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
 				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				dp.SetCount(10)
+				dp.SetCount(26)
 				dp.SetSum(5.0)
 				dp.ExplicitBounds().FromRaw([]float64{0.1, 0.5, 1.0})
 				dp.BucketCounts().FromRaw([]uint64{2, 5, 9, 10})
@@ -3370,7 +3609,7 @@ func TestTranslateV2(t *testing.T) {
 						Histograms: []writev2.Histogram{
 							{
 								Schema:         -53, // NHCB
-								Count:          &writev2.Histogram_CountInt{CountInt: 2},
+								Count:          &writev2.Histogram_CountInt{CountInt: 3},
 								Sum:            3.0,
 								Timestamp:      1000,
 								CustomValues:   []float64{1.0},
@@ -3402,7 +3641,7 @@ func TestTranslateV2(t *testing.T) {
 				dp := hist.DataPoints().AppendEmpty()
 				dp.SetTimestamp(pcommon.Timestamp(1000 * int64(time.Millisecond)))
 				dp.SetSum(3.0)
-				dp.SetCount(2)
+				dp.SetCount(3)
 				dp.ExplicitBounds().FromRaw([]float64{1.0})
 				dp.BucketCounts().FromRaw([]uint64{1, 2})
 				dp.Attributes().PutStr("dp_attr", "dp_value")
@@ -3514,6 +3753,7 @@ func TestTranslateV2(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.NoError(t, pmetrictest.CompareMetrics(tc.expectedMetrics, metrics))
+			assertExponentialHistogramInvariants(t, metrics)
 			assert.Equal(t, tc.expectedStats, stats)
 			assert.Equal(t, buildMetaDataMapByID(tc.expectedMetrics), buildMetaDataMapByID(metrics))
 		})
@@ -3818,9 +4058,11 @@ func TestConvertDeltaBucketsWhenEveryBucketOverflows(t *testing.T) {
 	require.False(t, layout.hasBuckets)
 
 	dp := pmetric.NewExponentialHistogramDataPoint()
-	dropped := convertDeltaBuckets(spans, deltas, dp.Positive(), layout)
+	retained, ok := convertDeltaBuckets(spans, deltas, dp.Positive(), layout)
+	require.True(t, ok)
 
-	assert.Equal(t, uint64(10), dropped)
+	// The overflow bucket is consumed but never emitted, so it contributes nothing to Count.
+	assert.Equal(t, uint64(0), retained)
 	assert.Empty(t, dp.Positive().BucketCounts().AsRaw())
 	assert.Equal(t, int32(0), dp.Positive().Offset())
 }
@@ -3840,16 +4082,172 @@ func TestExponentialHistogramSpanExpansionIsBounded(t *testing.T) {
 	runtime.ReadMemStats(&before)
 
 	dp := pmetric.NewExponentialHistogramDataPoint()
-	dropped := convertDeltaBuckets(spans, deltas, dp.Positive(), layout)
+	retained, ok := convertDeltaBuckets(spans, deltas, dp.Positive(), layout)
 
 	runtime.ReadMemStats(&after)
 
-	assert.Zero(t, dropped)
+	require.True(t, ok)
+
+	// Both buckets are emitted, holding 1 and 3.
+	assert.Equal(t, uint64(4), retained)
 	assert.Equal(t, int32(-1), dp.Positive().Offset())
 	assert.Equal(t, []uint64{1, 3}, dp.Positive().BucketCounts().AsRaw())
 	// Reserving one bucket per unit of offset would allocate 800MB here, so the budget only has
 	// to be far below that to catch it.
 	assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(8<<20))
+}
+
+// assertExponentialHistogramInvariants checks the two rules the OTLP data model states for an
+// exponential histogram data point: the count equals zero_count plus the bucket populations, and
+// the sum is absent when the count is zero.
+func TestFloatFlavorHistogramsAreDropped(t *testing.T) {
+	// The compatibility mapping requires float flavored native histograms to be dropped, for the
+	// custom bucket schema as well as the standard one.
+	for _, tc := range []struct {
+		name   string
+		schema int32
+		hist   writev2.Histogram
+	}{
+		{
+			name:   "standard schema",
+			schema: 0,
+			hist: writev2.Histogram{
+				Schema:         0,
+				Count:          &writev2.Histogram_CountFloat{CountFloat: 3},
+				Sum:            6,
+				Timestamp:      1,
+				PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+				PositiveCounts: []float64{1, 2},
+			},
+		},
+		{
+			name:   "custom buckets",
+			schema: -53,
+			hist: writev2.Histogram{
+				Schema:         -53,
+				Count:          &writev2.Histogram_CountFloat{CountFloat: 30},
+				Sum:            1,
+				Timestamp:      1,
+				CustomValues:   []float64{1, 2, 3},
+				PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 1, Length: 1}},
+				PositiveCounts: []float64{10, 20},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prwReceiver := setupMetricsReceiver(t)
+			metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+				Symbols: []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+						Histograms: []writev2.Histogram{tc.hist},
+					},
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 0, metrics.ResourceMetrics().Len(), "nothing should be emitted")
+			assert.Equal(t, 0, stats.Histograms, "a dropped histogram is not written")
+		})
+	}
+}
+
+func TestHistogramWithOnlyOverflowBucketHasNoSum(t *testing.T) {
+	// Every observation landed in the +Inf bucket, which cannot be represented, so the data point
+	// holds nothing. OTLP requires the sum to be absent once the count is zero.
+	prwReceiver := setupMetricsReceiver(t)
+
+	metrics, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+		Symbols: []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"},
+		Timeseries: []writev2.TimeSeries{
+			{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         0,
+					Count:          &writev2.Histogram_CountInt{CountInt: 5},
+					Sum:            100,
+					Timestamp:      1,
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 1025, Length: 1}},
+					PositiveDeltas: []int64{10},
+				}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	dp := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+		ExponentialHistogram().DataPoints().At(0)
+	assert.Equal(t, uint64(0), dp.Count())
+	assert.False(t, dp.HasSum(), "OTLP requires no sum once the count is zero")
+	assert.Empty(t, dp.Positive().BucketCounts().AsRaw())
+}
+
+func TestHistogramWithUnrepresentablePopulationIsDropped(t *testing.T) {
+	// Five buckets holding 2^62 each sum to more than a uint64 can hold, so no data point can
+	// satisfy the OTLP rule that the count equals the bucket populations. The histogram has to be
+	// dropped rather than emitted with a count that silently wrapped.
+	const huge = int64(1) << 62
+
+	prwReceiver := setupMetricsReceiver(t)
+	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+		Symbols: []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"},
+		Timeseries: []writev2.TimeSeries{
+			{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         0,
+					Count:          &writev2.Histogram_CountInt{CountInt: 5},
+					Sum:            1,
+					Timestamp:      1,
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 5}},
+					PositiveDeltas: []int64{huge, 0, 0, 0, 0},
+				}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// The metric container is created before the buckets are converted, so it is still there,
+	// empty. That shape is the same for every late rejection and is tracked in #50340.
+	dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+		ExponentialHistogram().DataPoints()
+	assert.Equal(t, 0, dps.Len(), "no data point can represent this population")
+	assert.Equal(t, 0, stats.Histograms, "a dropped histogram is not written")
+}
+
+func assertExponentialHistogramInvariants(t *testing.T, md pmetric.Metrics) {
+	t.Helper()
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		sms := md.ResourceMetrics().At(i).ScopeMetrics()
+		for j := 0; j < sms.Len(); j++ {
+			ms := sms.At(j).Metrics()
+			for k := 0; k < ms.Len(); k++ {
+				if ms.At(k).Type() != pmetric.MetricTypeExponentialHistogram {
+					continue
+				}
+				dps := ms.At(k).ExponentialHistogram().DataPoints()
+				for d := 0; d < dps.Len(); d++ {
+					dp := dps.At(d)
+					population := dp.ZeroCount()
+					for b := 0; b < dp.Positive().BucketCounts().Len(); b++ {
+						population += dp.Positive().BucketCounts().At(b)
+					}
+					for b := 0; b < dp.Negative().BucketCounts().Len(); b++ {
+						population += dp.Negative().BucketCounts().At(b)
+					}
+					assert.Equal(t, population, dp.Count(),
+						"metric %q: count must equal zero_count plus the bucket populations", ms.At(k).Name())
+					if dp.Count() == 0 {
+						assert.False(t, dp.HasSum(),
+							"metric %q: sum must not be set when count is zero", ms.At(k).Name())
+					}
+				}
+			}
+		}
+	}
 }
 
 type nonMutatingConsumer struct{}

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -276,6 +276,45 @@ func TestNHCBNegativeBucketPopulationIsDropped(t *testing.T) {
 	}
 }
 
+func TestStaleCustomBucketHistogramCarriesNoPopulation(t *testing.T) {
+	// The spans and deltas of a stale marker are not read, so the buckets stay empty and agree
+	// with the count of zero. Reading them would put a population on a data point that says
+	// nothing was recorded.
+	prwReceiver := setupMetricsReceiver(t)
+
+	metrics, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+		Symbols: []string{
+			"",
+			"__name__", "test_metric", // 1, 2
+			"job", "service-x/test", // 3, 4
+			"instance", "107cn001", // 5, 6
+		},
+		Timeseries: []writev2.TimeSeries{
+			{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Timestamp:      1,
+					Sum:            math.Float64frombits(value.StaleNaN),
+					Count:          &writev2.Histogram_CountInt{CountInt: 777},
+					CustomValues:   []float64{1.0, 2.0},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+					PositiveDeltas: []int64{9, 9},
+				}},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	dp := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
+		Histogram().DataPoints().At(0)
+	assert.True(t, dp.Flags().NoRecordedValue())
+	assert.Equal(t, uint64(0), dp.Count())
+	assert.Equal(t, []uint64{0, 0, 0}, dp.BucketCounts().AsRaw(), "the deltas are not read")
+	assert.Equal(t, []float64{1.0, 2.0}, dp.ExplicitBounds().AsRaw(), "the shape is still described")
+}
+
 func TestNHCBWithoutBoundsIsKept(t *testing.T) {
 	// Bounds sit between buckets, so a histogram with none of them still has the bucket above the
 	// last one. Prometheus produces that shape for a classic histogram whose only bucket was +Inf.

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -231,8 +231,8 @@ func TestNHCBUnrepresentablePopulationIsDropped(t *testing.T) {
 
 func TestNHCBNegativeBucketPopulationIsDropped(t *testing.T) {
 	// Deltas are cumulative, so a run of them can go below zero. A bucket holds a count of
-	// observations, which cannot, and the conversion to uint64 would turn it into a very large
-	// one. This PR derives the data point count from the buckets, so it would land there too.
+	// observations, which cannot, so the conversion to uint64 would turn one into a very large
+	// population, and the data point count comes from those buckets.
 	for _, tc := range []struct {
 		name   string
 		deltas []int64

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -191,195 +192,6 @@ func TestHandlePRWContentTypeNegotiation(t *testing.T) {
 	}
 }
 
-func TestNHCBUnrepresentablePopulationIsDropped(t *testing.T) {
-	// Five buckets of 2^62 sum past what a uint64 count can hold, so there is no data point that
-	// both keeps the buckets and carries a count OTLP accepts.
-	prwReceiver := setupMetricsReceiver(t)
-
-	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
-		Symbols: []string{
-			"",
-			"__name__", "test_metric", // 1, 2
-			"job", "service-x/test", // 3, 4
-			"instance", "107cn001", // 5, 6
-		},
-		Timeseries: []writev2.TimeSeries{
-			{
-				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
-				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
-				Histograms: []writev2.Histogram{{
-					Count:          &writev2.Histogram_CountInt{CountInt: 1},
-					Sum:            1,
-					Timestamp:      1,
-					Schema:         -53,
-					CustomValues:   []float64{1.0, 2.0, 3.0, 4.0},
-					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 5}},
-					PositiveDeltas: []int64{1 << 62, 0, 0, 0, 0},
-				}},
-			},
-		},
-	})
-	require.NoError(t, err)
-	assert.Equal(t, 0, stats.Histograms)
-
-	// The bucket populations are summed before anything is built, so the refusal leaves no
-	// resource, scope or metric behind either.
-	assert.Equal(t, 0, metrics.ResourceMetrics().Len(),
-		"a population that cannot be represented is not published")
-}
-
-func TestMalformedNHCBIsNotTruncated(t *testing.T) {
-	// The dense form is as long as the bounds, so spans and deltas that describe a different
-	// shape have no translation. Reading as far as the shorter of the two and reporting what
-	// that produced would drop observations the sender wrote, with a count that agrees with
-	// the buckets and says nothing about what went missing.
-	for _, tc := range []struct {
-		name   string
-		bounds []float64
-		spans  []writev2.BucketSpan
-		deltas []int64
-		count  uint64
-	}{
-		{
-			name:   "more buckets than the bounds allow",
-			bounds: []float64{1},
-			spans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
-			deltas: []int64{1, 1, 1},
-			count:  6,
-		},
-		{
-			name:   "fewer deltas than the span declares",
-			bounds: []float64{1, 2},
-			spans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
-			deltas: []int64{1},
-			count:  1,
-		},
-		{
-			name:   "offset past the last bucket",
-			bounds: []float64{1},
-			spans:  []writev2.BucketSpan{{Offset: 10, Length: 1}},
-			deltas: []int64{5},
-			count:  5,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			prwReceiver := setupMetricsReceiver(t)
-
-			metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
-				Symbols: []string{
-					"",
-					"__name__", "test_metric", // 1, 2
-					"job", "service-x/test", // 3, 4
-					"instance", "107cn001", // 5, 6
-				},
-				Timeseries: []writev2.TimeSeries{
-					{
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
-						Histograms: []writev2.Histogram{{
-							Schema:         -53,
-							Count:          &writev2.Histogram_CountInt{CountInt: tc.count},
-							Sum:            1,
-							Timestamp:      1,
-							CustomValues:   tc.bounds,
-							PositiveSpans:  tc.spans,
-							PositiveDeltas: tc.deltas,
-						}},
-					},
-				},
-			})
-			require.NoError(t, err)
-			assert.Equal(t, 0, stats.Histograms, "a histogram that was not translated is not written")
-			assert.Equal(t, 0, metrics.ResourceMetrics().Len(),
-				"a shape with no translation leaves nothing behind")
-		})
-	}
-}
-
-func TestNHCBNegativeBucketPopulationIsDropped(t *testing.T) {
-	// Deltas are cumulative, so a run of them can go below zero. A bucket holds a count of
-	// observations, which cannot, so the conversion to uint64 would turn one into a very large
-	// population, and the data point count comes from those buckets.
-	for _, tc := range []struct {
-		name   string
-		deltas []int64
-	}{
-		{name: "first delta below zero", deltas: []int64{-1, 0}},
-		{name: "running count falls below zero", deltas: []int64{1, -5}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			prwReceiver := setupMetricsReceiver(t)
-
-			metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
-				Symbols: []string{
-					"",
-					"__name__", "test_metric", // 1, 2
-					"job", "service-x/test", // 3, 4
-					"instance", "107cn001", // 5, 6
-				},
-				Timeseries: []writev2.TimeSeries{
-					{
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
-						Histograms: []writev2.Histogram{{
-							Count:          &writev2.Histogram_CountInt{CountInt: 1},
-							Sum:            1,
-							Timestamp:      1,
-							Schema:         -53,
-							CustomValues:   []float64{1.0},
-							PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
-							PositiveDeltas: tc.deltas,
-						}},
-					},
-				},
-			})
-			require.NoError(t, err)
-			assert.Equal(t, 0, stats.Histograms)
-			assert.Equal(t, 0, metrics.ResourceMetrics().Len(),
-				"a negative bucket population is not published")
-		})
-	}
-}
-
-func TestStaleCustomBucketHistogramCarriesNoPopulation(t *testing.T) {
-	// The spans and deltas of a stale marker are not read, so the buckets stay empty and agree
-	// with the count of zero. Reading them would put a population on a data point that says
-	// nothing was recorded.
-	prwReceiver := setupMetricsReceiver(t)
-
-	metrics, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
-		Symbols: []string{
-			"",
-			"__name__", "test_metric", // 1, 2
-			"job", "service-x/test", // 3, 4
-			"instance", "107cn001", // 5, 6
-		},
-		Timeseries: []writev2.TimeSeries{
-			{
-				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
-				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
-				Histograms: []writev2.Histogram{{
-					Schema:         -53,
-					Timestamp:      1,
-					Sum:            math.Float64frombits(value.StaleNaN),
-					Count:          &writev2.Histogram_CountInt{CountInt: 777},
-					CustomValues:   []float64{1.0, 2.0},
-					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
-					PositiveDeltas: []int64{9, 9},
-				}},
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	dp := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
-		Histogram().DataPoints().At(0)
-	assert.True(t, dp.Flags().NoRecordedValue())
-	assert.Equal(t, uint64(0), dp.Count())
-	assert.Equal(t, []uint64{0, 0, 0}, dp.BucketCounts().AsRaw(), "the deltas are not read")
-	assert.Equal(t, []float64{1.0, 2.0}, dp.ExplicitBounds().AsRaw(), "the shape is still described")
-}
-
 func TestNHCBWithoutBoundsIsKept(t *testing.T) {
 	// Bounds sit between buckets, so a histogram with none of them still has the bucket above the
 	// last one. Prometheus produces that shape for a classic histogram whose only bucket was +Inf.
@@ -405,7 +217,7 @@ func TestNHCBWithoutBoundsIsKept(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			prwReceiver := setupMetricsReceiver(t)
 
-			metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+			metrics, stats, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
 				Symbols: []string{
 					"",
 					"__name__", "test_metric", // 1, 2
@@ -444,7 +256,7 @@ func TestStaleNHCBIsKeptWhateverItsBucketsSay(t *testing.T) {
 	// the marker down with them by overflowing.
 	prwReceiver := setupMetricsReceiver(t)
 
-	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+	metrics, stats, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
 		Symbols: []string{
 			"",
 			"__name__", "test_metric", // 1, 2
@@ -480,7 +292,7 @@ func TestNHCBCountComesFromTheBuckets(t *testing.T) {
 	// that arrives can be larger than the buckets account for. OTLP requires the two to agree.
 	prwReceiver := setupMetricsReceiver(t)
 
-	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+	metrics, stats, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
 		Symbols: []string{
 			"",
 			"__name__", "test_metric", // 1, 2
@@ -733,11 +545,12 @@ func TestTranslateV2(t *testing.T) {
 						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16},
 						Histograms: []writev2.Histogram{
 							{
-								Schema:         -53,
-								Count:          &writev2.Histogram_CountInt{CountInt: 4},
-								Sum:            1,
-								Timestamp:      1,
-								CustomValues:   []float64{1.0},
+								Schema:       -53,
+								Count:        &writev2.Histogram_CountInt{CountInt: 4},
+								Sum:          1,
+								Timestamp:    1,
+								CustomValues: []float64{1.0},
+								// One bound means two buckets, and two deltas fill them.
 								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
 								PositiveDeltas: []int64{1, 2},
 							},
@@ -1098,7 +911,8 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
-			name: "exponential histogram - integer with negative counts",
+			name:        "exponential histogram - integer with negative counts",
+			expectError: "negative counts",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -1137,14 +951,6 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed:  true,
-				Samples:    0,
-				Histograms: 0,
-				Exemplars:  0,
-			},
-			// Rejected before the resource, scope and metric are built, so nothing is emitted.
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
 			name: "nhcb histogram - all observations outside the buckets leave no count or sum",
@@ -1213,7 +1019,8 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
-			name: "exponential histogram - float carrying a stale marker is dropped",
+			name:        "exponential histogram - float carrying a stale marker is rejected",
+			expectError: "float flavored",
 			// A stale marker short circuits the rest of the histogram, so the flavor has to be
 			// checked before it. Otherwise a float histogram is admitted whenever it happens to
 			// be stale, and emits a data point the specification says to drop.
@@ -1244,13 +1051,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
-			name: "nhcb histogram - float carrying a stale marker is dropped",
+			name:        "nhcb histogram - float carrying a stale marker is rejected",
+			expectError: "float flavored",
 			// The custom bucket schema reaches the stale short circuit through a different branch.
 			request: &writev2.Request{
 				Symbols: []string{
@@ -1280,13 +1084,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
-			name: "exponential histogram - float",
+			name:        "exponential histogram - float",
+			expectError: "float flavored",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -1325,14 +1126,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			// The float flavor must be dropped, so nothing is emitted.
-			expectedMetrics: pmetric.NewMetrics(),
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
 		},
 		{
-			name: "exponential histogram - float with negative counts",
+			name:        "exponential histogram - float with negative counts",
+			expectError: "float flavored",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -1371,17 +1168,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed:  true,
-				Samples:    0,
-				Histograms: 0,
-				Exemplars:  0,
-			},
-			// Rejected before the resource, scope and metric are built, so nothing is emitted.
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
-			name: "reset hint gauge should be dropped",
+			name:        "reset hint gauge should be dropped",
+			expectError: "gauge flavored",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -1418,17 +1208,11 @@ func TestTranslateV2(t *testing.T) {
 						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 					},
 				},
-			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed:  true,
-				Samples:    0,
-				Histograms: 0,
-				Exemplars:  0,
-			},
-			expectedMetrics: pmetric.NewMetrics(), // Reset hint gauge should be dropped completely, no resources should be created
+			}, // Reset hint gauge should be dropped completely, no resources should be created
 		},
 		{
-			name: "classic histogram - should be dropped",
+			name:        "classic histogram - should be dropped",
+			expectError: "classic histogram series",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -1455,17 +1239,11 @@ func TestTranslateV2(t *testing.T) {
 						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 					},
 				},
-			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed:  true,
-				Samples:    0,
-				Histograms: 0,
-				Exemplars:  0,
-			},
-			expectedMetrics: pmetric.NewMetrics(), // Classic histograms should be dropped completely, no resources should be created
+			}, // Classic histograms should be dropped completely, no resources should be created
 		},
 		{
-			name: "summary - should be dropped",
+			name:        "summary - should be rejected",
+			expectError: "summary metric \"test_metric\" is not supported",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -1490,26 +1268,6 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed:  true,
-				Samples:    0,
-				Histograms: 0,
-				Exemplars:  0,
-			},
-			expectedMetrics: func() pmetric.Metrics {
-				metrics := pmetric.NewMetrics()
-				rm := metrics.ResourceMetrics().AppendEmpty()
-				attrs := rm.Resource().Attributes()
-				attrs.PutStr("service.namespace", "service-x")
-				attrs.PutStr("service.name", "test")
-				attrs.PutStr("service.instance.id", "107cn001")
-
-				sm := rm.ScopeMetrics().AppendEmpty()
-				sm.Scope().SetName("scope1")
-				sm.Scope().SetVersion("v1")
-
-				return metrics
-			}(),
 		},
 		{
 			name: "NHCB translation",
@@ -1649,7 +1407,8 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
-			name: "invalid schema histogram dropped",
+			name:        "invalid schema histogram dropped",
+			expectError: "unsupported schema",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -1690,14 +1449,7 @@ func TestTranslateV2(t *testing.T) {
 						},
 					},
 				},
-			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed:  true,
-				Samples:    0,
-				Histograms: 0,
-				Exemplars:  0,
-			},
-			expectedMetrics: pmetric.NewMetrics(), // When all histograms have invalid schemas, no metrics should be created
+			}, // When all histograms have invalid schemas, no metrics should be created
 		},
 		{
 			name: "mixed schema histograms - NHCB and exponential",
@@ -1979,11 +1731,12 @@ func TestTranslateV2(t *testing.T) {
 						},
 						Histograms: []writev2.Histogram{
 							{
-								Schema:         -53,
-								Count:          &writev2.Histogram_CountInt{CountInt: 4},
-								Sum:            1,
-								Timestamp:      1,
-								CustomValues:   []float64{1.0},
+								Schema:       -53,
+								Count:        &writev2.Histogram_CountInt{CountInt: 4},
+								Sum:          1,
+								Timestamp:    1,
+								CustomValues: []float64{1.0},
+								// One bound means two buckets, and two deltas fill them.
 								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
 								PositiveDeltas: []int64{1, 2},
 							},
@@ -2281,7 +2034,8 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
-			name: "exponential histogram - float overflow buckets are dropped with the histogram",
+			name:        "exponential histogram - float overflow buckets are rejected with the histogram",
+			expectError: "float flavored",
 			// The integer twin of this case keeps bucket 1024 and drops the overflow bucket. The
 			// float flavor is turned away before any of that, so nothing is emitted at all.
 			request: &writev2.Request{
@@ -2313,13 +2067,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
-			name: "exponential histogram - malformed negative spans drop the histogram",
+			name:        "exponential histogram - malformed negative spans reject the request",
+			expectError: "negative spans",
 			// Both ranges are validated. The positive one is well formed here, so this is the
 			// only shape that reaches the negative range's error path.
 			request: &writev2.Request{
@@ -2354,10 +2105,6 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
 			name: "exponential histogram - trailing empty span is not materialized",
@@ -2502,7 +2249,8 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
-			name: "exponential histogram - bucket past the overflow bucket is dropped",
+			name:        "exponential histogram - bucket past the overflow bucket is dropped",
+			expectError: "past the overflow bucket",
 			// Only index 1025 is the +Inf overflow bucket at scale 0. Bucket 100000001 is past it,
 			// which the specification forbids, so the whole histogram is treated as malformed.
 			request: &writev2.Request{
@@ -2534,13 +2282,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
-			name: "exponential histogram - spans expanding past the bucket limit are dropped",
+			name:        "exponential histogram - spans expanding past the bucket limit are dropped",
+			expectError: "more than the maximum",
 			// Buckets 0 and 16384 are both within the schema 8 limit, but expanding them into a
 			// dense range needs 16385 buckets, one more than maxExponentialHistogramBuckets.
 			request: &writev2.Request{
@@ -2572,13 +2317,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
-			name: "exponential histogram - float spans expanding past the bucket limit are dropped",
+			name:        "exponential histogram - float spans expanding past the bucket limit are dropped",
+			expectError: "float flavored",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -2608,13 +2350,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
-			name: "exponential histogram - negative offset after the first span is dropped",
+			name:        "exponential histogram - negative offset after the first span is dropped",
+			expectError: "has negative offset",
 			// Prometheus only allows the first span of a list to move backwards.
 			request: &writev2.Request{
 				Symbols: []string{
@@ -2645,13 +2384,10 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
-			name: "exponential histogram - spans longer than the bucket values are dropped",
+			name:        "exponential histogram - spans longer than the bucket values are rejected",
+			expectError: "spans define more buckets than",
 			// The span promises three buckets and the histogram carries two deltas, so the
 			// third bucket has no value to read.
 			request: &writev2.Request{
@@ -2683,10 +2419,6 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			expectedStats: remote.WriteResponseStats{
-				Confirmed: true,
-			},
-			expectedMetrics: pmetric.NewMetrics(),
 		},
 		{
 			name: "multiple histogram metrics with exemplars",
@@ -2713,11 +2445,12 @@ func TestTranslateV2(t *testing.T) {
 						},
 						Histograms: []writev2.Histogram{
 							{
-								Schema:         -53,
-								Count:          &writev2.Histogram_CountInt{CountInt: 4},
-								Sum:            1,
-								Timestamp:      1,
-								CustomValues:   []float64{1.0},
+								Schema:       -53,
+								Count:        &writev2.Histogram_CountInt{CountInt: 4},
+								Sum:          1,
+								Timestamp:    1,
+								CustomValues: []float64{1.0},
+								// One bound means two buckets, and two deltas fill them.
 								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
 								PositiveDeltas: []int64{1, 2},
 							},
@@ -2734,11 +2467,12 @@ func TestTranslateV2(t *testing.T) {
 						},
 						Histograms: []writev2.Histogram{
 							{
-								Schema:         -53,
-								Count:          &writev2.Histogram_CountInt{CountInt: 4},
-								Sum:            1,
-								Timestamp:      1,
-								CustomValues:   []float64{1.0},
+								Schema:       -53,
+								Count:        &writev2.Histogram_CountInt{CountInt: 4},
+								Sum:          1,
+								Timestamp:    1,
+								CustomValues: []float64{1.0},
+								// One bound means two buckets, and two deltas fill them.
 								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
 								PositiveDeltas: []int64{1, 2},
 							},
@@ -3896,7 +3630,7 @@ func TestTranslateV2(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// since we are using the rmCache to store values across requests, we need to clear it after each test, otherwise it will affect the next test
 			prwReceiver.rmCache.Purge()
-			metrics, stats, err := prwReceiver.translateV2(ctx, tc.request)
+			metrics, stats, _, err := prwReceiver.translateV2(ctx, tc.request)
 			if tc.expectError != "" {
 				assert.ErrorContains(t, err, tc.expectError)
 				return
@@ -4055,6 +3789,15 @@ func TestValidateBucketSpanLayout(t *testing.T) {
 			expected:      bucketSpanLayout{hasBuckets: true, firstIndex: 0, lastIndex: 0, numBuckets: 1},
 		},
 		{
+			// 1024 is the last finite bucket and 1025 is the overflow bucket, so 1026 is the
+			// first index the specification forbids. Exactly one past the boundary.
+			name:          "bucket one past the overflow bucket",
+			spans:         []writev2.BucketSpan{{Offset: 1026, Length: 1}},
+			valueCount:    1,
+			overflowLimit: schema0Limit,
+			expectError:   "bucket index 1026 is past the overflow bucket at 1025",
+		},
+		{
 			name:          "bucket index past the end of int32",
 			spans:         []writev2.BucketSpan{{Offset: 2_000_000_000, Length: 1}, {Offset: 2_000_000_000, Length: 1}},
 			valueCount:    2,
@@ -4144,7 +3887,6 @@ func TestHistogramBucketBudgetReserve(t *testing.T) {
 	}
 	require.True(t, budget.reserve(fits))
 	assert.Equal(t, int64(2), budget.remaining)
-	assert.False(t, budget.exhausted)
 
 	// Positive and negative are charged together, so 3 does not fit in the remaining 2.
 	tooBig := exponentialHistogramLayout{
@@ -4153,7 +3895,6 @@ func TestHistogramBucketBudgetReserve(t *testing.T) {
 	}
 	assert.False(t, budget.reserve(tooBig))
 	assert.Equal(t, int64(2), budget.remaining, "a rejected reservation must not consume budget")
-	assert.True(t, budget.exhausted)
 
 	// A later, smaller histogram can still be admitted.
 	assert.True(t, budget.reserve(exponentialHistogramLayout{positive: bucketSpanLayout{numBuckets: 2}}))
@@ -4180,7 +3921,7 @@ func TestRequestBucketBudgetLimitsHistogramExpansion(t *testing.T) {
 	}
 
 	prwReceiver := setupMetricsReceiver(t)
-	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+	metrics, stats, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
 		Symbols: []string{"", "__name__", "test_metric", "job", "service-x/test", "instance", "107cn001"},
 		Timeseries: []writev2.TimeSeries{
 			{
@@ -4190,12 +3931,11 @@ func TestRequestBucketBudgetLimitsHistogramExpansion(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-
-	dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).ExponentialHistogram().DataPoints()
-	assert.Equal(t, perRequest, dps.Len(), "the histogram past the request budget must not be translated")
-	assert.Equal(t, perRequest, stats.Histograms, "rejected histograms must not be reported as written")
-	assert.Equal(t, maxExponentialHistogramBuckets, dps.At(0).Positive().BucketCounts().Len())
+	// One histogram more than the budget allows makes the whole request invalid, rather than
+	// silently translating the first 256 and acknowledging the rest as written.
+	require.ErrorContains(t, err, "does not fit the remaining request budget")
+	assert.Equal(t, 0, metrics.DataPointCount(), "nothing is published from a rejected request")
+	assert.Equal(t, 0, stats.Histograms)
 }
 
 func TestConvertDeltaBucketsWhenEveryBucketOverflows(t *testing.T) {
@@ -4284,7 +4024,7 @@ func TestFloatFlavorHistogramsAreDropped(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			prwReceiver := setupMetricsReceiver(t)
-			metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+			metrics, stats, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
 				Symbols: []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"},
 				Timeseries: []writev2.TimeSeries{
 					{
@@ -4294,9 +4034,9 @@ func TestFloatFlavorHistogramsAreDropped(t *testing.T) {
 					},
 				},
 			})
-			require.NoError(t, err)
-			assert.Equal(t, 0, metrics.ResourceMetrics().Len(), "nothing should be emitted")
-			assert.Equal(t, 0, stats.Histograms, "a dropped histogram is not written")
+			require.ErrorContains(t, err, "float flavored")
+			assert.Equal(t, 0, metrics.DataPointCount(), "nothing should be emitted")
+			assert.Equal(t, 0, stats.Histograms, "a rejected histogram is not written")
 		})
 	}
 }
@@ -4306,7 +4046,7 @@ func TestHistogramWithOnlyOverflowBucketHasNoSum(t *testing.T) {
 	// holds nothing. OTLP requires the sum to be absent once the count is zero.
 	prwReceiver := setupMetricsReceiver(t)
 
-	metrics, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+	metrics, _, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
 		Symbols: []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"},
 		Timeseries: []writev2.TimeSeries{
 			{
@@ -4339,7 +4079,7 @@ func TestHistogramWithUnrepresentablePopulationIsDropped(t *testing.T) {
 	const huge = int64(1) << 62
 
 	prwReceiver := setupMetricsReceiver(t)
-	metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+	metrics, stats, _, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
 		Symbols: []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"},
 		Timeseries: []writev2.TimeSeries{
 			{
@@ -4356,14 +4096,752 @@ func TestHistogramWithUnrepresentablePopulationIsDropped(t *testing.T) {
 			},
 		},
 	})
+	require.ErrorContains(t, err, "too large to represent")
+	assert.Equal(t, 0, metrics.DataPointCount(), "no data point can represent this population")
+	assert.Equal(t, 0, stats.Histograms, "a rejected histogram is not written")
+}
+
+// writeRequest marshals a request the way the confighttp middleware hands it to the handler.
+func writeRequest(t *testing.T, req *writev2.Request) *http.Request {
+	t.Helper()
+	pBuf := proto.NewBuffer(nil)
+	require.NoError(t, pBuf.Marshal(req))
+	httpReq := httptest.NewRequest(http.MethodPost, "/api/v1/write", bytes.NewBuffer(pBuf.Bytes()))
+	httpReq.Header.Set("Content-Type", fmt.Sprintf("application/x-protobuf;proto=%s", remoteapi.WriteV2MessageType))
+	return httpReq
+}
+
+func writtenHeaders(t *testing.T, resp *http.Response) (samples, histograms, exemplars string) {
+	t.Helper()
+	h := resp.Header
+	return h.Get("X-Prometheus-Remote-Write-Samples-Written"),
+		h.Get("X-Prometheus-Remote-Write-Histograms-Written"),
+		h.Get("X-Prometheus-Remote-Write-Exemplars-Written")
+}
+
+func validHistogramSeries(timestamp int64) writev2.TimeSeries {
+	return writev2.TimeSeries{
+		Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+		LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+		Histograms: []writev2.Histogram{{
+			Schema:         0,
+			Count:          &writev2.Histogram_CountInt{CountInt: 3},
+			Sum:            6,
+			Timestamp:      timestamp,
+			PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+			PositiveDeltas: []int64{1, 1},
+		}},
+	}
+}
+
+func invalidHistogramSeries(timestamp int64) writev2.TimeSeries {
+	ts := validHistogramSeries(timestamp)
+	// Three buckets promised, two values sent.
+	ts.Histograms[0].PositiveSpans = []writev2.BucketSpan{{Offset: 0, Length: 3}}
+	return ts
+}
+
+// TestRequestIsAllOrNothing covers the Remote-Write 2.0 rule that a receiver must not answer 2xx
+// when any data it understood was not written, and that the Written headers carry what was
+// actually written.
+func TestRequestIsAllOrNothing(t *testing.T) {
+	symbols := []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"}
+
+	for _, tc := range []struct {
+		name           string
+		series         []writev2.TimeSeries
+		expectStatus   int
+		expectConsumed bool
+	}{
+		{
+			name:           "only invalid histograms",
+			series:         []writev2.TimeSeries{invalidHistogramSeries(1)},
+			expectStatus:   http.StatusBadRequest,
+			expectConsumed: false,
+		},
+		{
+			name:           "valid histogram before an invalid one",
+			series:         []writev2.TimeSeries{validHistogramSeries(1), invalidHistogramSeries(2)},
+			expectStatus:   http.StatusBadRequest,
+			expectConsumed: false,
+		},
+		{
+			name:           "invalid histogram before a valid one",
+			series:         []writev2.TimeSeries{invalidHistogramSeries(1), validHistogramSeries(2)},
+			expectStatus:   http.StatusBadRequest,
+			expectConsumed: false,
+		},
+		{
+			name:           "only valid histograms",
+			series:         []writev2.TimeSeries{validHistogramSeries(1)},
+			expectStatus:   http.StatusNoContent,
+			expectConsumed: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &consumertest.MetricsSink{}
+			prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+			w := httptest.NewRecorder()
+			prwReceiver.handlePRW(w, writeRequest(t, &writev2.Request{Symbols: symbols, Timeseries: tc.series}))
+			resp := w.Result()
+
+			assert.Equal(t, tc.expectStatus, resp.StatusCode)
+			samples, histograms, exemplars := writtenHeaders(t, resp)
+
+			if tc.expectConsumed {
+				assert.Len(t, sink.AllMetrics(), 1)
+				assert.Equal(t, "1", histograms, "one histogram was written")
+			} else {
+				assert.Empty(t, sink.AllMetrics(), "a rejected request must not reach the consumer")
+				assert.Equal(t, "0", samples)
+				assert.Equal(t, "0", histograms)
+				assert.Equal(t, "0", exemplars)
+			}
+		})
+	}
+}
+
+func TestUnsupportedShapesAreRejected(t *testing.T) {
+	// Each shape here is one the receiver cannot translate, so it rejects the whole request
+	// rather than passing on a subset and answering 204.
+	symbols := []string{
+		"", "__name__", "test_metric", "job", "service-x/test", "instance", "107cn001",
+	}
+
+	for _, tc := range []struct {
+		name   string
+		series writev2.TimeSeries
+		expect string
+	}{
+		{
+			name: "summary",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_SUMMARY},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+			},
+			expect: "summary metric",
+		},
+		{
+			name: "custom bucket spans reaching past the bounds",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 10},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1, 2, 3}, // four buckets
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 6}},
+					PositiveDeltas: []int64{1, 1, 1, 1, 1, 1},
+				}},
+			},
+			expect: "insufficient to cover total span length of 6",
+		},
+		{
+			name: "custom bucket spans and values disagreeing",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 10},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1, 2, 3},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 4}},
+					PositiveDeltas: []int64{1, 1}, // four promised, two sent
+				}},
+			},
+			expect: "spans need 4 buckets, have 2 buckets",
+		},
+		{
+			// Three bounds mean four buckets, so reaching bucket five is exactly one too far.
+			name: "custom bucket spans one past the last bucket",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 5},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1, 2, 3},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 5}},
+					PositiveDeltas: []int64{1, 1, 1, 1, 1},
+				}},
+			},
+			expect: "insufficient to cover total span length of 5",
+		},
+		{
+			name: "negative zero threshold",
+			// The Native Histograms specification defines the zero threshold as a float64 >= 0,
+			// and the value is written to the data point either way.
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         0,
+					Count:          &writev2.Histogram_CountInt{CountInt: 2},
+					Sum:            2,
+					Timestamp:      1,
+					ZeroThreshold:  -5,
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+					PositiveDeltas: []int64{1, 0},
+				}},
+			},
+			expect: "negative zero threshold",
+		},
+		{
+			name: "float zero count on an integer histogram",
+			// Nothing reads the float side of the zero bucket once the histogram is integer
+			// flavored, so those observations would disappear without a trace.
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         0,
+					Count:          &writev2.Histogram_CountInt{CountInt: 3},
+					Sum:            3,
+					Timestamp:      1,
+					ZeroCount:      &writev2.Histogram_ZeroCountFloat{ZeroCountFloat: 7},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+					PositiveDeltas: []int64{1, 1},
+				}},
+			},
+			expect: "float zero count on an integer histogram",
+		},
+		{
+			name: "custom bucket population too large to represent",
+			// Five buckets of 2^62 sum past what a uint64 count can hold. Prometheus' own check
+			// adds them with wrapping arithmetic, so this shape gets past it.
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 1 << 62},
+					Sum:            math.NaN(),
+					Timestamp:      1,
+					CustomValues:   []float64{1, 2, 3, 4},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 5}},
+					PositiveDeltas: []int64{1 << 62, 0, 0, 0, 0},
+				}},
+			},
+			expect: "bucket population is too large to represent",
+		},
+		{
+			name: "custom bucket histogram whose deltas go below zero",
+			// Deltas are cumulative, and a bucket holds a count of observations, which cannot be
+			// negative. Validate reaches this before the conversion does, and the conversion
+			// refuses it too, so neither can turn it into a very large population.
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Count:          &writev2.Histogram_CountInt{CountInt: 1},
+					Sum:            1,
+					Timestamp:      1,
+					Schema:         -53,
+					CustomValues:   []float64{1.0},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+					PositiveDeltas: []int64{1, -5},
+				}},
+			},
+			expect: "observation count is negative",
+		},
+		{
+			name: "a series carrying both samples and histograms",
+			// The protocol lets a series hold one or the other. Translating the samples and
+			// walking past the histograms would write half of what arrived.
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_COUNTER},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+				Histograms: []writev2.Histogram{{
+					Schema:         0,
+					Count:          &writev2.Histogram_CountInt{CountInt: 3},
+					Sum:            6,
+					Timestamp:      1,
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+					PositiveDeltas: []int64{1, 1},
+				}},
+			},
+			expect: "carries both samples and histograms",
+		},
+		{
+			name: "histograms attached to a sample type",
+			// Nothing goes looking for histograms on a gauge, so they would be dropped in silence.
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         0,
+					Count:          &writev2.Histogram_CountInt{CountInt: 3},
+					Sum:            6,
+					Timestamp:      1,
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+					PositiveDeltas: []int64{1, 1},
+				}},
+			},
+			expect: "carries histograms",
+		},
+		{
+			name: "custom bucket bounds out of order",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 6},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{5, 1},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+					PositiveDeltas: []int64{1, 1, 1},
+				}},
+			},
+			expect: "strictly increasing order",
+		},
+		{
+			name: "custom bucket bounds repeating",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 6},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1, 1},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+					PositiveDeltas: []int64{1, 1, 1},
+				}},
+			},
+			expect: "strictly increasing order",
+		},
+		{
+			name: "custom bucket bound that is not a number",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 6},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1, math.NaN()},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+					PositiveDeltas: []int64{1, 1, 1},
+				}},
+			},
+			expect: "must not be NaN",
+		},
+		{
+			name: "custom bucket bounds ending at infinity",
+			// The bucket past the last bound already covers everything above it, so an explicit
+			// +Inf bound would describe a bucket that cannot hold anything.
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 6},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1, math.Inf(1)},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+					PositiveDeltas: []int64{1, 1, 1},
+				}},
+			},
+			expect: "last +Inf bound must not be explicitly defined",
+		},
+		{
+			name: "custom bucket count disagreeing with the buckets",
+			// OTLP requires the count to equal the sum of the bucket counts, and the
+			// compatibility specification copies the count rather than deriving it, so a count
+			// that contradicts the buckets cannot be translated into a valid data point.
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 3},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1, 2},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+					PositiveDeltas: []int64{1, 1, 1},
+				}},
+			},
+			expect: "6 observations found in buckets, but the Count field is 3",
+		},
+		{
+			name: "custom bucket spans moving backwards",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 2},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1, 2, 3},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: -1, Length: 1}},
+					PositiveDeltas: []int64{1, 1},
+				}},
+			},
+			expect: "span number 2 with offset -1",
+		},
+		{
+			name: "custom bucket spans starting before the first bucket",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 1},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1, 2, 3},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: -2, Length: 1}},
+					PositiveDeltas: []int64{1},
+				}},
+			},
+			expect: "span number 1 with offset -2",
+		},
+		{
+			name: "negative range spans disagreeing with their values",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         0,
+					Count:          &writev2.Histogram_CountInt{CountInt: 3},
+					Sum:            6,
+					Timestamp:      1,
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}},
+					PositiveDeltas: []int64{1},
+					NegativeSpans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+					NegativeDeltas: []int64{1, 1},
+				}},
+			},
+			expect: "negative spans: spans define more buckets than the 2 bucket values provided",
+		},
+		{
+			name: "negative range buckets resolving to a negative population",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         0,
+					Count:          &writev2.Histogram_CountInt{CountInt: 3},
+					Sum:            6,
+					Timestamp:      1,
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}},
+					PositiveDeltas: []int64{1},
+					NegativeSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+					NegativeDeltas: []int64{1, -5},
+				}},
+			},
+			expect: "negative counts",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &consumertest.MetricsSink{}
+			prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+			w := httptest.NewRecorder()
+			prwReceiver.handlePRW(w, writeRequest(t, &writev2.Request{
+				Symbols:    symbols,
+				Timeseries: []writev2.TimeSeries{tc.series},
+			}))
+
+			assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+			assert.Contains(t, w.Body.String(), tc.expect)
+			assert.Empty(t, sink.AllMetrics(), "nothing may reach the consumer")
+			_, histograms, _ := writtenHeaders(t, w.Result())
+			assert.Equal(t, "0", histograms)
+		})
+	}
+}
+
+func TestRejectionDoesNotInflateTheResponse(t *testing.T) {
+	// The request is rejected as a whole, so translation stops at the first histogram it cannot
+	// convert. Reporting one error per histogram would let a request full of invalid ones turn a
+	// small body into a much larger response.
+	symbols := []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"}
+
+	bodyFor := func(count int) int {
+		series := make([]writev2.TimeSeries, 0, count)
+		for i := range count {
+			series = append(series, invalidHistogramSeries(int64(i+1)))
+		}
+		prwReceiver := setupMetricsReceiverWithConsumer(t, &consumertest.MetricsSink{})
+		w := httptest.NewRecorder()
+		prwReceiver.handlePRW(w, writeRequest(t, &writev2.Request{Symbols: symbols, Timeseries: series}))
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		return w.Body.Len()
+	}
+
+	one, many := bodyFor(1), bodyFor(500)
+	assert.Equal(t, one, many, "the response must not grow with the number of invalid histograms")
+}
+
+// TestWrittenHeadersFollowTheConsumer covers the rule that the Written headers report what the
+// downstream consumer accepted, not what translation happened to produce.
+func TestWrittenHeadersFollowTheConsumer(t *testing.T) {
+	symbols := []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"}
+	request := &writev2.Request{Symbols: symbols, Timeseries: []writev2.TimeSeries{validHistogramSeries(1)}}
+
+	for _, tc := range []struct {
+		name          string
+		consumer      consumer.Metrics
+		expectStatus  int
+		expectWritten string
+	}{
+		{
+			name:          "permanent error reports nothing written",
+			consumer:      consumertest.NewErr(consumererror.NewPermanent(errors.New("permanent failure"))),
+			expectStatus:  http.StatusBadRequest,
+			expectWritten: "0",
+		},
+		{
+			name:          "transient error reports nothing written",
+			consumer:      consumertest.NewErr(errors.New("temporary failure")),
+			expectStatus:  http.StatusInternalServerError,
+			expectWritten: "0",
+		},
+		{
+			name:          "success reports what was written",
+			consumer:      &consumertest.MetricsSink{},
+			expectStatus:  http.StatusNoContent,
+			expectWritten: "1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prwReceiver := setupMetricsReceiverWithConsumer(t, tc.consumer)
+
+			w := httptest.NewRecorder()
+			prwReceiver.handlePRW(w, writeRequest(t, request))
+			resp := w.Result()
+
+			assert.Equal(t, tc.expectStatus, resp.StatusCode)
+			_, histograms, _ := writtenHeaders(t, resp)
+			assert.Equal(t, tc.expectWritten, histograms)
+		})
+	}
+}
+
+func TestPartialWriteIsRejectedWholesale(t *testing.T) {
+	// A histogram the converter can only refuse after conversion used to be dropped while the
+	// rest of the request went through, which is the partial write the specification forbids.
+	sink := &consumertest.MetricsSink{}
+	prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+	w := httptest.NewRecorder()
+	prwReceiver.handlePRW(w, writeRequest(t, &writev2.Request{
+		Symbols: []string{
+			"", "__name__", "test_metric", "job", "service-x/test", "instance", "107cn001",
+		},
+		Timeseries: []writev2.TimeSeries{
+			{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+			},
+			{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 1 << 62},
+					Sum:            math.NaN(),
+					Timestamp:      2,
+					CustomValues:   []float64{1, 2, 3, 4},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 5}},
+					PositiveDeltas: []int64{1 << 62, 0, 0, 0, 0},
+				}},
+			},
+		},
+	}))
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Empty(t, sink.AllMetrics(), "the valid gauge must not be written on its own")
+	samples, histograms, exemplars := writtenHeaders(t, resp)
+	assert.Equal(t, "0", samples)
+	assert.Equal(t, "0", histograms)
+	assert.Equal(t, "0", exemplars)
+}
+
+func TestUndecodableRequestStillReportsWrittenCounts(t *testing.T) {
+	// Content negotiation has already succeeded here, so the response owes the sender the three
+	// written counts. Without them the sender cannot tell "nothing was written" apart from a
+	// receiver that does not report at all.
+	for _, tc := range []struct {
+		name string
+		body io.Reader
+	}{
+		{name: "truncated protobuf", body: bytes.NewBuffer([]byte{0x0a, 0xff, 0xff})},
+		{name: "unreadable body", body: iotest.ErrReader(errors.New("connection reset"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &consumertest.MetricsSink{}
+			prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+			httpReq := httptest.NewRequest(http.MethodPost, "/api/v1/write", tc.body)
+			httpReq.Header.Set("Content-Type", fmt.Sprintf("application/x-protobuf;proto=%s", remoteapi.WriteV2MessageType))
+			w := httptest.NewRecorder()
+			prwReceiver.handlePRW(w, httpReq)
+
+			resp := w.Result()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			samples, histograms, exemplars := writtenHeaders(t, resp)
+			assert.Equal(t, "0", samples)
+			assert.Equal(t, "0", histograms)
+			assert.Equal(t, "0", exemplars)
+			assert.Empty(t, sink.AllMetrics())
+		})
+	}
+}
+
+func TestTargetInfoReplacesWhatTheCacheHolds(t *testing.T) {
+	// target_info is the only thing that teaches the receiver about a target, so a later one has
+	// to replace the entry rather than leave the first set of attributes in place.
+	symbols := []string{
+		"", "__name__", "test_metric", "job", "service-x/test", "instance", "107cn001",
+		"target_info", "region", "us-east", "us-west",
+	}
+	targetInfo := func(regionRef uint32) *writev2.Request {
+		return &writev2.Request{Symbols: symbols, Timeseries: []writev2.TimeSeries{{
+			Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+			LabelsRefs: []uint32{1, 7, 3, 4, 5, 6, 8, regionRef},
+			Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+		}}}
+	}
+
+	sink := &consumertest.MetricsSink{}
+	prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+	for _, ref := range []uint32{9, 10} {
+		w := httptest.NewRecorder()
+		prwReceiver.handlePRW(w, writeRequest(t, targetInfo(ref)))
+		require.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+	}
+
+	require.Equal(t, 1, prwReceiver.rmCache.Len())
+	cached, ok := prwReceiver.rmCache.Get(prwReceiver.rmCache.Keys()[0])
+	require.True(t, ok)
+	region, found := cached.Resource().Attributes().Get("region")
+	require.True(t, found)
+	assert.Equal(t, "us-west", region.Str(), "the second target_info replaced the first")
+}
+
+func TestSlowRequestDoesNotUndoALearnedResource(t *testing.T) {
+	// A request that staged its resource before a target_info arrived must not put the older
+	// snapshot back when it finally commits, or the attributes target_info taught are lost for
+	// every request after it.
+	symbols := []string{
+		"", "__name__", "test_metric", "job", "service-x/test", "instance", "107cn001",
+		"target_info", "region", "us-east",
+	}
+	ordinary := &writev2.Request{Symbols: symbols, Timeseries: []writev2.TimeSeries{{
+		Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+		LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+		Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+	}}}
+	targetInfo := &writev2.Request{Symbols: symbols, Timeseries: []writev2.TimeSeries{{
+		Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+		LabelsRefs: []uint32{1, 7, 3, 4, 5, 6, 8, 9},
+		Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+	}}}
+
+	sink := &consumertest.MetricsSink{}
+	prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+	// Stand in for the slow request by holding its staged updates while another request commits.
+	_, _, staged, err := prwReceiver.translateV2(t.Context(), ordinary)
 	require.NoError(t, err)
 
-	// The metric container is created before the buckets are converted, so it is still there,
-	// empty. That shape is the same for every late rejection and is tracked in #50340.
-	dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
-		ExponentialHistogram().DataPoints()
-	assert.Equal(t, 0, dps.Len(), "no data point can represent this population")
-	assert.Equal(t, 0, stats.Histograms, "a dropped histogram is not written")
+	w := httptest.NewRecorder()
+	prwReceiver.handlePRW(w, writeRequest(t, targetInfo))
+	require.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+
+	prwReceiver.commitResourceCache(staged)
+
+	require.Equal(t, 1, prwReceiver.rmCache.Len())
+	cached, ok := prwReceiver.rmCache.Get(prwReceiver.rmCache.Keys()[0])
+	require.True(t, ok)
+	region, found := cached.Resource().Attributes().Get("region")
+	require.True(t, found, "the attribute target_info taught is still there")
+	assert.Equal(t, "us-east", region.Str())
+}
+
+// TestRejectedRequestDoesNotUpdateResourceCache covers the resource cache being part of the
+// transaction: a request that is rejected, or that the consumer refuses, must not leave its
+// target_info attributes behind for later requests to pick up.
+func TestRejectedRequestDoesNotUpdateResourceCache(t *testing.T) {
+	targetInfoAndHistogram := func(series ...writev2.TimeSeries) *writev2.Request {
+		return &writev2.Request{
+			Symbols: []string{
+				"", "__name__", "target_info", "job", "service-x/test", "instance", "107cn001",
+				"region", "poisoned", "test_hist",
+			},
+			Timeseries: append([]writev2.TimeSeries{
+				{
+					Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+					LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8},
+					Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+				},
+			}, series...),
+		}
+	}
+
+	t.Run("translation failure", func(t *testing.T) {
+		sink := &consumertest.MetricsSink{}
+		prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+		bad := invalidHistogramSeries(1)
+		bad.LabelsRefs = []uint32{1, 9, 3, 4, 5, 6}
+
+		w := httptest.NewRecorder()
+		prwReceiver.handlePRW(w, writeRequest(t, targetInfoAndHistogram(bad)))
+
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Empty(t, sink.AllMetrics())
+		assert.Equal(t, 0, prwReceiver.rmCache.Len(), "a rejected request must not update the cache")
+	})
+
+	t.Run("consumer failure", func(t *testing.T) {
+		prwReceiver := setupMetricsReceiverWithConsumer(t, consumertest.NewErr(errors.New("downstream is down")))
+
+		good := validHistogramSeries(1)
+		good.LabelsRefs = []uint32{1, 9, 3, 4, 5, 6}
+
+		w := httptest.NewRecorder()
+		prwReceiver.handlePRW(w, writeRequest(t, targetInfoAndHistogram(good)))
+
+		assert.Equal(t, http.StatusInternalServerError, w.Result().StatusCode)
+		assert.Equal(t, 0, prwReceiver.rmCache.Len(), "an unaccepted batch must not update the cache")
+	})
+
+	t.Run("accepted request does update the cache", func(t *testing.T) {
+		sink := &consumertest.MetricsSink{}
+		prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+		good := validHistogramSeries(1)
+		good.LabelsRefs = []uint32{1, 9, 3, 4, 5, 6}
+
+		w := httptest.NewRecorder()
+		prwReceiver.handlePRW(w, writeRequest(t, targetInfoAndHistogram(good)))
+
+		assert.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+		assert.Len(t, sink.AllMetrics(), 1)
+		assert.Positive(t, prwReceiver.rmCache.Len(), "an accepted request publishes its resource attributes")
+	})
 }
 
 // assertExponentialHistogramInvariants checks the two rules the OTLP data model states for an
@@ -5110,9 +5588,9 @@ func TestInvalidSchemaLogging(t *testing.T) {
 		},
 	}
 
-	metrics, stats, err := writeReceiver.translateV2(t.Context(), request)
-	require.NoError(t, err)
-	assert.Equal(t, 0, metrics.MetricCount())
+	metrics, stats, _, err := writeReceiver.translateV2(t.Context(), request)
+	require.ErrorContains(t, err, "unsupported schema")
+	assert.Equal(t, 0, metrics.DataPointCount())
 	assert.Equal(t, 0, stats.Histograms)
 
 	// Verify that debug log was emitted for the invalid schema

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -4277,8 +4277,8 @@ func TestUnsupportedShapesAreRejected(t *testing.T) {
 		},
 		{
 			name: "negative zero threshold",
-			// The Native Histograms specification defines the zero threshold as a float64 >= 0,
-			// and the value is written to the data point either way.
+			// The Native Histograms specification defines the zero threshold as a float64 at or
+			// above zero, and the value is written to the data point either way.
 			series: writev2.TimeSeries{
 				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
 				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
@@ -4292,7 +4292,25 @@ func TestUnsupportedShapesAreRejected(t *testing.T) {
 					PositiveDeltas: []int64{1, 0},
 				}},
 			},
-			expect: "negative zero threshold",
+			expect: "zero threshold",
+		},
+		{
+			name: "zero threshold that is not a number",
+			// No comparison against zero rejects NaN, so it needs naming.
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Histograms: []writev2.Histogram{{
+					Schema:         0,
+					Count:          &writev2.Histogram_CountInt{CountInt: 2},
+					Sum:            2,
+					Timestamp:      1,
+					ZeroThreshold:  math.NaN(),
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+					PositiveDeltas: []int64{1, 0},
+				}},
+			},
+			expect: "zero threshold",
 		},
 		{
 			name: "float zero count on an integer histogram",

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -4183,9 +4183,6 @@ func TestExponentialHistogramSpanExpansionIsBounded(t *testing.T) {
 	assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(8<<20))
 }
 
-// assertExponentialHistogramInvariants checks the two rules the OTLP data model states for an
-// exponential histogram data point: the count equals zero_count plus the bucket populations, and
-// the sum is absent when the count is zero.
 func TestFloatFlavorHistogramsAreDropped(t *testing.T) {
 	// The compatibility mapping requires float flavored native histograms to be dropped, for the
 	// custom bucket schema as well as the standard one.
@@ -4304,6 +4301,9 @@ func TestHistogramWithUnrepresentablePopulationIsDropped(t *testing.T) {
 	assert.Equal(t, 0, stats.Histograms, "a dropped histogram is not written")
 }
 
+// assertExponentialHistogramInvariants checks the two rules the OTLP data model states for an
+// exponential histogram data point: the count equals zero_count plus the bucket populations, and
+// the sum is absent when the count is zero.
 func assertExponentialHistogramInvariants(t *testing.T, md pmetric.Metrics) {
 	t.Helper()
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -222,11 +222,78 @@ func TestNHCBUnrepresentablePopulationIsDropped(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, stats.Histograms)
 
-	// The metric container is created before the buckets are converted, so it is still there,
-	// empty. That shape is the same for every late rejection and is tracked in #50340.
-	dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
-		Histogram().DataPoints()
-	assert.Equal(t, 0, dps.Len(), "a population that cannot be represented is not published")
+	// The bucket populations are summed before anything is built, so the refusal leaves no
+	// resource, scope or metric behind either.
+	assert.Equal(t, 0, metrics.ResourceMetrics().Len(),
+		"a population that cannot be represented is not published")
+}
+
+func TestMalformedNHCBIsNotTruncated(t *testing.T) {
+	// The dense form is as long as the bounds, so spans and deltas that describe a different
+	// shape have no translation. Reading as far as the shorter of the two and reporting what
+	// that produced would drop observations the sender wrote, with a count that agrees with
+	// the buckets and says nothing about what went missing.
+	for _, tc := range []struct {
+		name   string
+		bounds []float64
+		spans  []writev2.BucketSpan
+		deltas []int64
+		count  uint64
+	}{
+		{
+			name:   "more buckets than the bounds allow",
+			bounds: []float64{1},
+			spans:  []writev2.BucketSpan{{Offset: 0, Length: 3}},
+			deltas: []int64{1, 1, 1},
+			count:  6,
+		},
+		{
+			name:   "fewer deltas than the span declares",
+			bounds: []float64{1, 2},
+			spans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+			deltas: []int64{1},
+			count:  1,
+		},
+		{
+			name:   "offset past the last bucket",
+			bounds: []float64{1},
+			spans:  []writev2.BucketSpan{{Offset: 10, Length: 1}},
+			deltas: []int64{5},
+			count:  5,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prwReceiver := setupMetricsReceiver(t)
+
+			metrics, stats, err := prwReceiver.translateV2(t.Context(), &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+						Histograms: []writev2.Histogram{{
+							Schema:         -53,
+							Count:          &writev2.Histogram_CountInt{CountInt: tc.count},
+							Sum:            1,
+							Timestamp:      1,
+							CustomValues:   tc.bounds,
+							PositiveSpans:  tc.spans,
+							PositiveDeltas: tc.deltas,
+						}},
+					},
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 0, stats.Histograms, "a histogram that was not translated is not written")
+			assert.Equal(t, 0, metrics.ResourceMetrics().Len(),
+				"a shape with no translation leaves nothing behind")
+		})
+	}
 }
 
 func TestNHCBNegativeBucketPopulationIsDropped(t *testing.T) {
@@ -268,10 +335,8 @@ func TestNHCBNegativeBucketPopulationIsDropped(t *testing.T) {
 			})
 			require.NoError(t, err)
 			assert.Equal(t, 0, stats.Histograms)
-
-			dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).
-				Histogram().DataPoints()
-			assert.Equal(t, 0, dps.Len(), "a negative bucket population is not published")
+			assert.Equal(t, 0, metrics.ResourceMetrics().Len(),
+				"a negative bucket population is not published")
 		})
 	}
 }
@@ -673,7 +738,7 @@ func TestTranslateV2(t *testing.T) {
 								Sum:            1,
 								Timestamp:      1,
 								CustomValues:   []float64{1.0},
-								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 4}},
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
 								PositiveDeltas: []int64{1, 2},
 							},
 						},
@@ -1919,7 +1984,7 @@ func TestTranslateV2(t *testing.T) {
 								Sum:            1,
 								Timestamp:      1,
 								CustomValues:   []float64{1.0},
-								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 4}},
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
 								PositiveDeltas: []int64{1, 2},
 							},
 						},
@@ -2653,7 +2718,7 @@ func TestTranslateV2(t *testing.T) {
 								Sum:            1,
 								Timestamp:      1,
 								CustomValues:   []float64{1.0},
-								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 4}},
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
 								PositiveDeltas: []int64{1, 2},
 							},
 						},
@@ -2674,7 +2739,7 @@ func TestTranslateV2(t *testing.T) {
 								Sum:            1,
 								Timestamp:      1,
 								CustomValues:   []float64{1.0},
-								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 4}},
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
 								PositiveDeltas: []int64{1, 2},
 							},
 						},

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -4144,6 +4144,86 @@ func invalidHistogramSeries(timestamp int64) writev2.TimeSeries {
 // TestRequestIsAllOrNothing covers the Remote-Write 2.0 rule that a receiver must not answer 2xx
 // when any data it understood was not written, and that the Written headers carry what was
 // actually written.
+func TestPayloadWithNothingToCarryItIsRejected(t *testing.T) {
+	// target_info is read for its labels and never becomes a metric, and an exemplar whose
+	// references cannot be read is looked at nowhere else. Both are shapes the receiver used to
+	// walk past, answering 204 while the data went missing and, for target_info, while its
+	// labels still reached the shared cache.
+	symbols := []string{
+		"", "__name__", "target_info", // 0, 1, 2
+		"job", "api", // 3, 4
+		"instance", "node-1", // 5, 6
+		"region", "us-east", // 7, 8
+		"trace_id", "4bf92f3577b34da6a3ce929d0e0e4736", // 9, 10
+		"test_metric", // 11
+	}
+	targetInfoRefs := []uint32{1, 2, 3, 4, 5, 6, 7, 8}
+
+	for _, tc := range []struct {
+		name   string
+		series writev2.TimeSeries
+		expect string
+	}{
+		{
+			name: "target_info carrying a histogram",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+				LabelsRefs: targetInfoRefs,
+				Histograms: []writev2.Histogram{{
+					Schema:         -53,
+					Count:          &writev2.Histogram_CountInt{CountInt: 1},
+					Sum:            1,
+					Timestamp:      1,
+					CustomValues:   []float64{1},
+					PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}},
+					PositiveDeltas: []int64{1},
+				}},
+			},
+			expect: "carries histograms, which it has no data point for",
+		},
+		{
+			name: "target_info carrying an exemplar",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+				LabelsRefs: targetInfoRefs,
+				Exemplars:  []writev2.Exemplar{{LabelsRefs: []uint32{9, 10}, Value: 1, Timestamp: 1}},
+			},
+			expect: "carries exemplars, which it has no data point for",
+		},
+		{
+			name: "an exemplar reference past the symbol table",
+			series: writev2.TimeSeries{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_COUNTER},
+				LabelsRefs: []uint32{1, 11, 3, 4, 5, 6},
+				Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+				Exemplars:  []writev2.Exemplar{{LabelsRefs: []uint32{9, 9999}, Value: 1, Timestamp: 1}},
+			},
+			expect: `exemplar of "test_metric" cannot be read`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &consumertest.MetricsSink{}
+			prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+			w := httptest.NewRecorder()
+			prwReceiver.handlePRW(w, writeRequest(t, &writev2.Request{
+				Symbols:    symbols,
+				Timeseries: []writev2.TimeSeries{tc.series},
+			}))
+
+			resp := w.Result()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			assert.Contains(t, w.Body.String(), tc.expect)
+			assert.Empty(t, sink.AllMetrics(), "nothing may reach the consumer")
+			assert.Equal(t, 0, prwReceiver.rmCache.Len(), "a rejected request teaches the cache nothing")
+			samples, histograms, exemplars := writtenHeaders(t, resp)
+			assert.Equal(t, "0", samples)
+			assert.Equal(t, "0", histograms)
+			assert.Equal(t, "0", exemplars)
+		})
+	}
+}
+
 func TestTargetInfoIsNotExemptFromRefValidation(t *testing.T) {
 	// A symbol reference is wire data whichever series carries it, so target_info is checked
 	// before it is read for resource attributes rather than after.

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -4631,25 +4631,63 @@ func TestUnsupportedShapesAreRejected(t *testing.T) {
 }
 
 func TestRejectionDoesNotInflateTheResponse(t *testing.T) {
-	// The request is rejected as a whole, so translation stops at the first histogram it cannot
-	// convert. Reporting one error per histogram would let a request full of invalid ones turn a
-	// small body into a much larger response.
-	symbols := []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"}
-
-	bodyFor := func(count int) int {
-		series := make([]writev2.TimeSeries, 0, count)
-		for i := range count {
-			series = append(series, invalidHistogramSeries(int64(i+1)))
-		}
-		prwReceiver := setupMetricsReceiverWithConsumer(t, &consumertest.MetricsSink{})
-		w := httptest.NewRecorder()
-		prwReceiver.handlePRW(w, writeRequest(t, &writev2.Request{Symbols: symbols, Timeseries: series}))
-		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
-		return w.Body.Len()
+	// The request is rejected as a whole, so translation stops at the first series it cannot
+	// take. Reporting one error per series would let a request full of invalid ones turn a small
+	// body into a much larger response, and joining thousands of errors costs more to render
+	// than to build.
+	symbols := []string{
+		"",
+		"__name__", "test_hist", // 1, 2
+		"job", "service-x/test", // 3, 4
+		"instance", "107cn001", // 5, 6
 	}
 
-	one, many := bodyFor(1), bodyFor(500)
-	assert.Equal(t, one, many, "the response must not grow with the number of invalid histograms")
+	for _, tc := range []struct {
+		name   string
+		series func(int64) writev2.TimeSeries
+	}{
+		{
+			name:   "histogram the converter refuses",
+			series: invalidHistogramSeries,
+		},
+		{
+			name: "series with no metric name",
+			series: func(ts int64) writev2.TimeSeries {
+				return writev2.TimeSeries{
+					Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+					LabelsRefs: []uint32{3, 4, 5, 6},
+					Samples:    []writev2.Sample{{Value: 1, Timestamp: ts}},
+				}
+			},
+		},
+		{
+			name: "reference past the symbol table",
+			series: func(ts int64) writev2.TimeSeries {
+				return writev2.TimeSeries{
+					Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE, UnitRef: 9999},
+					LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+					Samples:    []writev2.Sample{{Value: 1, Timestamp: ts}},
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bodyFor := func(count int) int {
+				series := make([]writev2.TimeSeries, 0, count)
+				for i := range count {
+					series = append(series, tc.series(int64(i+1)))
+				}
+				prwReceiver := setupMetricsReceiverWithConsumer(t, &consumertest.MetricsSink{})
+				w := httptest.NewRecorder()
+				prwReceiver.handlePRW(w, writeRequest(t, &writev2.Request{Symbols: symbols, Timeseries: series}))
+				require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+				return w.Body.Len()
+			}
+
+			one, many := bodyFor(1), bodyFor(500)
+			assert.Equal(t, one, many, "the response must not grow with the number of invalid series")
+		})
+	}
 }
 
 // TestWrittenHeadersFollowTheConsumer covers the rule that the Written headers report what the

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -4740,6 +4740,67 @@ func TestTargetInfoReplacesWhatTheCacheHolds(t *testing.T) {
 	assert.Equal(t, "us-west", region.Str(), "the second target_info replaced the first")
 }
 
+func TestRequestWithNothingToPublishDoesNotReachTheConsumer(t *testing.T) {
+	// Nothing to hand over means the consumer is not called at all, since an empty batch would
+	// count as a delivery it never made. What target_info taught the receiver is committed anyway.
+	symbols := []string{
+		"",                        // 0
+		"__name__", "test_metric", // 1, 2
+		"job", "service-x/test", // 3, 4
+		"instance", "107cn001", // 5, 6
+		"target_info",       // 7
+		"region", "us-east", // 8, 9
+		"trace_id", "4bf92f3577b34da6a3ce929d0e0e4736", // 10, 11
+	}
+
+	for _, tc := range []struct {
+		name       string
+		series     []writev2.TimeSeries
+		wantRegion string
+	}{
+		{
+			name: "target_info on its own",
+			series: []writev2.TimeSeries{{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+				LabelsRefs: []uint32{1, 7, 3, 4, 5, 6, 8, 9},
+				Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+			}},
+			wantRegion: "us-east",
+		},
+		{
+			// Prometheus sends exemplars in a TimeSeries of their own, so a request can arrive
+			// carrying nothing this receiver can turn into a data point.
+			name: "a series carrying only exemplars",
+			series: []writev2.TimeSeries{{
+				Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_COUNTER},
+				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+				Exemplars:  []writev2.Exemplar{{LabelsRefs: []uint32{10, 11}, Value: 1.5, Timestamp: 1}},
+			}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &consumertest.MetricsSink{}
+			prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+			w := httptest.NewRecorder()
+			prwReceiver.handlePRW(w, writeRequest(t, &writev2.Request{Symbols: symbols, Timeseries: tc.series}))
+
+			require.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+			assert.Empty(t, sink.AllMetrics(), "an empty batch is not a delivery")
+
+			if tc.wantRegion == "" {
+				return
+			}
+			require.Equal(t, 1, prwReceiver.rmCache.Len(), "target_info still taught the receiver a target")
+			cached, ok := prwReceiver.rmCache.Get(prwReceiver.rmCache.Keys()[0])
+			require.True(t, ok)
+			region, found := cached.Resource().Attributes().Get("region")
+			require.True(t, found)
+			assert.Equal(t, tc.wantRegion, region.Str())
+		})
+	}
+}
+
 func TestSlowRequestDoesNotUndoALearnedResource(t *testing.T) {
 	// A request that staged its resource before a target_info arrived must not put the older
 	// snapshot back when it finally commits, or the attributes target_info taught are lost for

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -4144,6 +4144,50 @@ func invalidHistogramSeries(timestamp int64) writev2.TimeSeries {
 // TestRequestIsAllOrNothing covers the Remote-Write 2.0 rule that a receiver must not answer 2xx
 // when any data it understood was not written, and that the Written headers carry what was
 // actually written.
+func TestTargetInfoIsNotExemptFromRefValidation(t *testing.T) {
+	// A symbol reference is wire data whichever series carries it, so target_info is checked
+	// before it is read for resource attributes rather than after.
+	symbols := []string{
+		"",                        // 0
+		"__name__", "target_info", // 1, 2
+		"job", "service-x/test", // 3, 4
+		"instance", "107cn001", // 5, 6
+	}
+
+	for _, tc := range []struct {
+		name   string
+		unit   uint32
+		help   uint32
+		expect string
+	}{
+		{name: "unit ref past the table", unit: 9999, expect: "unit ref"},
+		{name: "help ref past the table", help: 9999, expect: "help ref"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &consumertest.MetricsSink{}
+			prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
+
+			w := httptest.NewRecorder()
+			prwReceiver.handlePRW(w, writeRequest(t, &writev2.Request{
+				Symbols: symbols,
+				Timeseries: []writev2.TimeSeries{{
+					Metadata: writev2.Metadata{
+						Type:    writev2.Metadata_METRIC_TYPE_GAUGE,
+						UnitRef: tc.unit,
+						HelpRef: tc.help,
+					},
+					LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+					Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+				}},
+			}))
+
+			require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+			assert.Contains(t, w.Body.String(), tc.expect)
+			assert.Empty(t, sink.AllMetrics())
+		})
+	}
+}
+
 func TestRequestIsAllOrNothing(t *testing.T) {
 	symbols := []string{"", "__name__", "test_hist", "job", "service-x/test", "instance", "107cn001"}
 

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -4654,8 +4654,9 @@ func TestWrittenHeadersFollowTheConsumer(t *testing.T) {
 }
 
 func TestPartialWriteIsRejectedWholesale(t *testing.T) {
-	// A histogram the converter can only refuse after conversion used to be dropped while the
-	// rest of the request went through, which is the partial write the specification forbids.
+	// A histogram the converter can only refuse once it has started takes the rest of the
+	// request with it, since writing the rest would be the partial write the specification
+	// forbids.
 	sink := &consumertest.MetricsSink{}
 	prwReceiver := setupMetricsReceiverWithConsumer(t, sink)
 


### PR DESCRIPTION
#### Description

> **This is waiting on a decision, not on review of the code.** #50340 asks which response model the receiver should use and it has had no answer. This PR implements request level all or nothing, and one series it cannot translate takes the rest of the request with it: 50 valid gauges plus a single classic histogram answer `400` with nothing delivered, where today the 50 are written and the request answers `204`. Both that and partial acceptance conform to the specification, so this is a policy call, not a reading of it. The table is under "The decision this is waiting on" below, and if the code owners want partial acceptance I will rewrite this rather than argue for what is here.
>
> Its own change is **182 added and 116 removed lines** of `receiver.go` and `exemplars.go`. The rest of the diff is tests. It sits on #50343, whose eight commits come first here, so that one wants reading first.

This implements the request transaction and the synchronous response accounting of #50340. #50292, which used to be the bottom of this stack, has merged.

The receiver drops anything it cannot translate and still answers `204`. Measured on `main` by driving `handlePRW` with a recorder and a counting consumer:

| request | status | Histograms-Written | consumer called |
| --- | --- | --- | --- |
| one histogram whose spans do not match its deltas | `204` | 0 | no |
| one valid histogram and one invalid one | `204` | 1 | yes, with the valid one |

The specification does not leave room for either:

> Receivers MUST NOT return a 2xx HTTP status code if any of the pieces of sent data known to the Receiver (e.g. Samples, Histograms, Exemplars) were NOT written successfully (both partial write or full write rejection).

> Receivers MAY write valid samples within a write request that also contains some invalid or otherwise unwritten samples, which represents a partial write case. In such a case, the Receiver MUST return non-2xx status code.

It also says it is up to the receiver what it treats as invalid, and that samples it deliberately does not support fall under the same rules. So the drops this receiver does on purpose, classic histograms and the gauge flavor among them, are covered too.

##### Rejections become errors

`processHistogramTimeSeries` returns an error for every case it used to drop in silence: classic histogram series, the gauge and float flavors, unsupported schemas, malformed bucket spans, a histogram that does not fit the request bucket budget, and a population too large to represent.

Three more silent exits turned up when I went looking for the rest of them rather than assuming the histogram paths were all of it. Summary metrics were dropped with a bare `continue` in two places. Custom bucket histograms had no validation at all, which is its own section below. And the warning about histograms that did not fit the request budget had become dead code once exceeding the budget started rejecting the request, so it is gone along with the field it read. `translateV2` stops there, publishes nothing, and the handler answers 400 with zero written counts. It sits alongside the `badRequestErrors` it already builds for labels and metric types, which keep their existing behaviour.

##### Custom bucket histograms are checked the way Prometheus checks them

My first version of this hand wrote the span checks. That was wrong twice over: it duplicated `checkHistogramCustomBounds` from `prometheus/model/histogram`, and it was a weaker copy of it. Everything it checked, Prometheus checks, plus four things it did not. Driving the receiver with a recorder on `main`:

| custom bounds | translated to | should be |
| --- | --- | --- |
| `[5, 1]` | `ExplicitBounds=[5 1]` | rejected, bounds must increase |
| `[1, 1]` | `ExplicitBounds=[1 1]` | rejected, bounds must be distinct |
| `[1, NaN]` | `ExplicitBounds=[1 NaN]` | rejected |
| `[1, +Inf]` | `ExplicitBounds=[1 +Inf]` | rejected, the bound above the last one is implicit |

The count is not checked against the buckets either. #50343 handles the case where they legitimately disagree, which is an observation of NaN, by deriving the count; what is left here is the case where they disagree for no reason, which is malformed input. OTLP is explicit about the requirement:

> count is the number of values in the population. Must be non-negative. This value must be equal to the sum of the "count" fields in buckets if a histogram is provided.

None of this is our own rule to invent. The compatibility specification defines the shape a custom bucket histogram has: the bounds are written "in ascending order", the implicit `+Inf` bound "MUST NOT be written into CustomValues", the count "is equal to the sum of all bucket counts", and every field not mentioned "MUST be set to their zero value, such as zero threshold, zero count, negative spans, negative deltas". `Histogram.Validate` enforces exactly that set, so the hand written checks are gone and it is called instead.

It is also what a Prometheus server does with the same request. `storage/remote/write_handler.go` appends every histogram it receives, `tsdb/head_append.go` and `head_append_v2.go` call `Validate` before storing one, and the handler maps a validation failure to 400 through `isHistogramValidationError`. A request this receiver accepted was one Prometheus would have rejected. The receiver has no TSDB behind it, so nothing else was going to make that check.

What it costs, on a request of 20 custom bucket histograms, paired runs alternating between the two binaries so machine drift cancels out:

| | before | after |
| --- | --- | --- |
| ns/op | 48583 | 54763 |
| B/op | 12345 | 15715 |
| allocs/op | 318 | 358 |

That is 12.7% slower, 95% CI 8.2% to 17.2% over 8 pairs. Two allocations per histogram, both from `ToIntHistogram` copying the spans; `Validate` itself allocates nothing. Exponential histograms do not go through this and are unchanged. I did measure this the lazy way first and got a 92% regression, which turned out to be noise: a microbenchmark puts the conversion at 185ns and the validation at 30ns, so 20 histograms cannot cost 44µs.

`Validate` does not bound the dense expansion at all, since `checkHistogramSpans` sums span lengths and never looks at offsets. The `2147483647` offset from #50292 passes it. So it replaces the custom bucket checks and nothing else; the exponential preflight stays.

400 rather than 5xx or 429 because these are deterministic: resending the same bytes will never succeed.

Rejecting the whole request also removes a wart in the bucket budget from #50292. It used to admit histograms first come first served, so the same set of histograms could produce different output depending on the order they arrived in. Now any histogram that does not fit rejects the request, and order stops mattering.

##### Written counts follow the consumer

`stats.SetHeaders(w)` ran immediately after translation, before the error check and before `ConsumeMetrics`. A response could therefore be 400 or 500 while claiming data had been written, even though the consumer was never called or had refused the batch. `consumer.Metrics` returns one error for the whole batch and no accepted count, so on error the receiver cannot confirm a write and reports zero. The fanout consumer calls every consumer behind it and joins their errors, so some of them may still have taken the batch. That is a limit of the API rather than something this receiver can see, and the counts it reports are what it can vouch for.

##### An empty batch is not a delivery

The early return read `MetricCount()`, and a series can produce a metric with no data point on it. A `TimeSeries` carrying only exemplars is that shape, and Prometheus sends exemplars in a `TimeSeries` of their own, so a request made of those was handed to the consumer as a batch with nothing in it. It reads `DataPointCount()` now, so that request stops here instead, and what `target_info` taught the receiver is still committed on the way out.

This only covers the request that produces nothing at all. A metric with no data point still travels alongside real ones when the same request carries both, which is the same accounting gap as the exemplar counts below.

##### The resource cache joins the transaction

Snapshots taken from `target_info` were written straight into the shared LRU while translating, and survived a later rejection. A request that ended in 400 could still change the resource attributes attached to later requests. They are staged per request now and published only once the batch has been accepted. Within a request a later series still sees what an earlier `target_info` staged, so nothing else changes.

##### The decision this is waiting on

All or nothing means one series the receiver cannot translate takes the rest of the request with it. Measured here: a batch of 50 perfectly good gauges plus a single classic histogram now answers 400 and hands the consumer nothing, where before the 50 gauges were written and the request answered 204.

I want to be careful about what the specification does and does not settle here. It settles the status code: a receiver must not answer 2xx when data it knew about was not written, and that rules out both of the shapes at the top of this description. It does not settle what happens to the rest of the request. The second rule quoted at the top of this description is the one that matters here: a receiver MAY write the valid samples of a request that also carries invalid ones, and MUST answer non-2xx when it does. So both models conform, and picking between them is a receiver policy rather than a reading of the specification. Earlier revisions of this description, of the README and of the changelog entry said this followed from the specification. That was wrong of me and all three are corrected.

| | refuse the whole request | accept the valid part |
| --- | --- | --- |
| valid series in a mixed request | not written | written |
| status for a mixed request | non-2xx | non-2xx |
| written counts | zero, nothing was delivered | the subset the consumer took |
| what the receiver has to track | one refusal per request | accepted counts per data kind, through translation |
| cost to whoever runs it | one unsupported series holds up the batch it arrived in | delivery of the supported part is unchanged |

What is in this PR is the first column. I reached for it because it is less machinery: the receiver refuses once and reports zero, with no per-kind accounting of what survived, while partial acceptance has to carry that count through translation and publish it only once the consumer has taken the batch. That is an argument about effort, not an argument that the other column is wrong. Anyone still scraping classic histograms feels the last row, so I would rather the code owners chose than have me choose by writing it.

Rejecting early also matters for the response itself. Collecting one error per histogram let a request full of invalid ones inflate the reply: 2000 invalid histograms in a 75916 byte body produced a 250893 byte error, 3.3 times the input. Since the whole request is rejected regardless, translation now stops at the first series it cannot take, whichever check refuses it, which holds the error body flat no matter how many follow. Joining is not free either: rendering a tree of 8000 joined errors took 416ms against 2ms to build it, and a 250 KB request of nameless series spent 666ms producing a 300 KB reply. There is a test pinning the flat body for a refused histogram, a series with no metric name, and a reference past the symbol table.

##### Everything else that was quietly half written

Driving the handler with a recorder and looking at what came back turned up five more shapes that answered `204` while losing data. All of them are the same defect as the one above, so they are fixed here rather than filed separately.

| request | before | now |
| --- | --- | --- |
| a counter carrying both samples and histograms | `204`, samples written, histograms ignored | `400` |
| a gauge carrying only histograms | `204`, nothing written | `400` |
| `target_info` carrying both | `204`, `Samples-Written: 1`, histograms ignored | `400` |
| a custom bucket histogram with no bounds | `400` | translated |
| a custom bucket histogram whose populations overflow, next to a valid gauge | `204`, the gauge written on its own | `400` |

The protocol is explicit that a series carries one or the other: "Timeseries messages can either specify samples or (native) histogram samples (histogram field), but not both." The metric type decides which of the two the receiver goes looking for, so histograms attached to a gauge are data it walks straight past. `validateTimeSeriesPayload` rejects both shapes before `target_info` is handled, since that path skipped the check too.

The bucketless one is the opposite mistake, and it was mine. My first version rejected a custom bucket histogram with no bounds. Bounds sit between buckets, so a histogram with none of them still has the bucket above the last one, and that is what Prometheus produces for a classic histogram whose only bucket was `+Inf`. #49892 fixed exactly this in `prometheusreceiver`. The check is gone and there is a case for the one-bucket and no-observation shapes.

Two more fields were read past rather than translated. A histogram whose count is an integer but whose zero bucket carries a float loses those observations, because nothing looks at the float side once the flavor is decided, and `IsFloatHistogram` only reads the count. And the Native Histograms specification defines the zero threshold as a `float64 >= 0`, while a negative one was copied into the data point as is. Both are rejected now.

##### The staged resource cache could undo itself

Staging the cache turned out to introduce a lost update, which I found by holding one request's staged snapshot while another committed:

```
ordinary request stages {service.name, service.instance.id} and blocks in the consumer
target_info request commits {service.name, service.instance.id, region=us-east}
ordinary request returns and commits its older snapshot
    -> region is gone, for every later request
```

Only `target_info` teaches the receiver anything about a target. The snapshot an ordinary metric stages is derived from job and instance and is the same every time, so it is committed with `ContainsOrAdd` and never replaces an entry, while `target_info` still commits with `Add`. `TestSlowRequestDoesNotUndoALearnedResource` reproduces the interleaving and `TestTargetInfoReplacesWhatTheCacheHolds` pins the other half.

##### Responses that could not be decoded

A body read error or a malformed protobuf answered `400` with no `Written` headers at all. The specification asks for them "upon a successful content negotiation ... once completed (with success or failure)", and a sender reading no header cannot tell that apart from a receiver that does not report them: `ParseWriteResponseStats` only sets `Confirmed` when it sees at least one. They are installed as zeroes right after the content type is accepted and overwritten after a successful consume.

##### One wording fix

The summary rejection said summaries "cannot be represented in OTLP". They can, OTLP has a Summary type and the compatibility specification maps to it. The limit is the same atomicity problem classic histograms have, so the message now says so.

##### What target_info and exemplars may carry

`target_info` is read for its labels and never becomes a metric, so the branch that reads it walked past whatever else the series carried. Measured on the parent commit: a `target_info` carrying a histogram answers `204` with `Histograms-Written: 0` and the histogram gone, and one carrying an exemplar answers `204` with `Exemplars-Written: 1` and nothing to attach it to. Both still committed the resource attributes to the shared cache. Both are rejected now, and the cache is left alone. Carrying no sample stays valid, since the labels are what the receiver reads it for.

An exemplar whose label references cannot be resolved was skipped with a warning. Nothing looks at it again, so that was the one drop a request could still be answered as written; it is a rejection now.

##### Still open here

`stats.Exemplars` is incremented while the request is parsed, not when an exemplar is attached to a data point. Rejections no longer reach the headers at all, so what is left is the `TimeSeries` that carries only exemplars: with no sample of its series in the request there is nothing to attach them to, and the response is `204` with `X-Prometheus-Remote-Write-Exemplars-Written` counting them anyway. That request also leaves a metric with no data point in the batch when it is not the whole request.

Taking the count where the exemplar is attached reaches into the paths #50341 changes, so this PR stays out of them and #50341 leaves the case out for the same reason. Measured here on this branch: a request whose only content is an exemplar for a series it does not carry answers `204` with `X-Prometheus-Remote-Write-Exemplars-Written: 1`, nothing attached and nothing consumed. That is the same shape #50340 opens with, so this is `Part of` rather than `Fixes` until the counting moves.

Two more shapes stay open here.

Staging the resource cache moves the write from translation time to commit time, so two `target_info` requests for one target now settle in the order their consumers finish rather than the order they were translated. Measured here: translate an older one, then a newer one, commit the newer first, and the older overwrites it. Getting that order right needs a version alongside the cached snapshot, which changes the cache value rather than the transaction, so it is not in this PR.

`validateTimeSeriesPayload` does not look at `Exemplars`, so a `TimeSeries` with no samples, no histograms and no exemplars is accepted and answers `204` with zero counts. The rc.5 wording proposed in prometheus/prometheus#19530 says a TimeSeries must specify at least one of the three, which would make the payload invalid rather than unusual. What is left to decide is the response: rejecting it under the all-or-nothing rule takes a whole request down over a payload that loses no data.

##### Where this meets #50341

The two touch the same lines of `processHistogramTimeSeries` and do not merge cleanly. Resolved locally, `receiver.go` wants both the error returns here and the appended data point #50341 selects, and the fourth return this PR adds to `translateV2` reaches four call sites in its tests. One of its tests then fails, because it builds a histogram the converter used to drop without a word and this PR rejects the request instead, and its `!appended` guard becomes unreachable once every path that returns nil from the converters appends first. Whichever of the two lands second carries that work.

#### Link to tracking issue
Part of #50340

#### Testing

Eleven handler level tests, run through `handlePRW` rather than `translateV2`, so the status code and the headers are what is actually asserted.

Ran against the parent commit in a separate worktree to check they fail for the right reason. Ten of them compile there, nine of those fail, and 35 of their 39 subtests fail with them. The four subtests that pass are the controls, one per property: a request of only valid histograms, a successful consume, `target_info` on its own, and an accepted request that does update the cache. The eleventh does not compile against the parent at all, since `commitResourceCache` is added here.

| test | covers |
| --- | --- |
| `TestRequestIsAllOrNothing` | invalid only, valid before invalid, invalid before valid, valid only. Status, all three Written headers, and whether the consumer saw anything |
| `TestUnsupportedShapesAreRejected` | twenty shapes the receiver refuses, from a series carrying both samples and histograms to custom buckets whose bounds repeat, run backwards, or are not numbers |
| `TestWrittenHeadersFollowTheConsumer` | permanent error, transient error, success |
| `TestRejectedRequestDoesNotUpdateResourceCache` | translation failure, consumer failure, and an accepted request that does update it |
| `TestRejectionDoesNotInflateTheResponse` | the error body stays flat for a refused histogram, a series with no metric name, and a reference past the symbol table |
| `TestRequestWithNothingToPublishDoesNotReachTheConsumer` | `target_info` on its own, and a series carrying only exemplars |
| `TestTargetInfoIsNotExemptFromRefValidation` | unit and help references past the symbol table, on the one metric name that used to skip the check |
| `TestPartialWriteIsRejectedWholesale` | a histogram the converter can only refuse once it has started takes the rest of the request with it |
| `TestUndecodableRequestStillReportsWrittenCounts` | body read error and malformed protobuf both answer with zeroes rather than no headers |
| `TestTargetInfoReplacesWhatTheCacheHolds` | a later `target_info` replaces what an earlier one taught |
| `TestSlowRequestDoesNotUndoALearnedResource` | an ordinary request that staged before `target_info` arrived does not put the older snapshot back |

Sixteen cases that asserted a silent drop are gone from `TestTranslateV2`, and the twenty in `TestUnsupportedShapesAreRejected` cover that ground instead. `TestRequestBucketBudgetLimitsHistogramExpansion` no longer expects 256 of 257 histograms to be quietly accepted.

`TestInvalidSchemaLogging` caught something worth keeping: my first version replaced the debug log from #48027 with the error. The log is back, and the error carries the same detail to the sender.

#### Documentation

Added a "Rejected data is reported as rejected" section to the receiver README covering the response, the written counts and the cache.

#### Authorship

- [x] I, a human, wrote this pull request description myself.



















