### PR TITLE
[receiver/libhoney] Use documented field names in the msgpack batch response

### DIFF
--- a/.chloggen/libhoneyreceiver-msgpack-response-fields.yaml
+++ b/.chloggen/libhoneyreceiver-msgpack-response-fields.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+component: receiver/libhoney
+note: Use the documented field names in the msgpack batch response so clients can read the per-event status
+issues: [50378]
+subtext: |
+  ResponseInBatch carried only json tags, so the msgpack encoder fell back to the
+  Go field names (Status, ErrorStr). libhoney decodes the response into a struct
+  tagged msgpack:"status"/"error", read a zero status, and reported every event
+  in the batch as failed even though the receiver had accepted it - one
+  client-side error per event, with no data loss and no retries.
+change_logs: [user]

--- a/receiver/libhoneyreceiver/internal/codec/codec_test.go
+++ b/receiver/libhoneyreceiver/internal/codec/codec_test.go
@@ -782,3 +782,34 @@ func TestBuildLibhoneyEventFromMap_NativeTimeValue(t *testing.T) {
 			"span 1 and 2 should have different timestamps")
 	})
 }
+
+// The msgpack response has to carry the same field names as the JSON one.
+// libhoney decodes it into a struct tagged msgpack:"status"/"error"; without
+// the tags msgpack falls back to the Go field names, libhoney reads a zero
+// status and reports every event in the batch as failed even though the
+// receiver accepted it.
+func TestMarshalResponse_FieldNamesMatchAcrossEncodings(t *testing.T) {
+	batch := []response.ResponseInBatch{{Status: 202}}
+
+	mpBody, err := MpEncoder.MarshalResponse(batch)
+	require.NoError(t, err)
+
+	var mpDecoded []struct {
+		Error  string `msgpack:"error"`
+		Status int    `msgpack:"status"`
+	}
+	require.NoError(t, msgpack.Unmarshal(mpBody, &mpDecoded))
+	require.Len(t, mpDecoded, 1)
+	assert.Equal(t, 202, mpDecoded[0].Status)
+
+	jsonBody, err := JsEncoder.MarshalResponse(batch)
+	require.NoError(t, err)
+
+	var jsonDecoded []struct {
+		Error  string `json:"error"`
+		Status int    `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(jsonBody, &jsonDecoded))
+	require.Len(t, jsonDecoded, 1)
+	assert.Equal(t, 202, jsonDecoded[0].Status)
+}

--- a/receiver/libhoneyreceiver/internal/response/response.go
+++ b/receiver/libhoneyreceiver/internal/response/response.go
@@ -6,8 +6,8 @@ package response // import "github.com/open-telemetry/opentelemetry-collector-co
 import "net/http"
 
 type ResponseInBatch struct {
-	ErrorStr string `json:"error,omitempty"`
-	Status   int    `json:"status,omitempty"`
+	ErrorStr string `json:"error,omitempty" msgpack:"error,omitempty"`
+	Status   int    `json:"status,omitempty" msgpack:"status,omitempty"`
 }
 
 func MakeResponse(eventErrs []int) []ResponseInBatch {


### PR DESCRIPTION
#### Description

`ResponseInBatch` carried only `json` tags, so `msgpack.Marshal` fell back to the Go field names and put `Status` / `ErrorStr` on the wire. libhoney decodes the batch response into a struct tagged `msgpack:"status"` / `msgpack:"error"` and so finds neither, ending up with `StatusCode: 0`:

```go
// honeycombio/libhoney-go, transmission/response.go
func (r *Response) UnmarshalMsgpack(b []byte) error {
	aux := struct {
		Error  string `msgpack:"error"`
		Status int    `msgpack:"status"`
	}{}
```

The effect is that any msgpack client — which libhoney-go is by default, see `transmission.go` setting `contentType = "application/msgpack"` — reports **every event of every batch as failed** while the receiver has in fact accepted and forwarded them. No data is lost and nothing is retried; only the status the client reads back is wrong. In our deployment that produced ~20k client-side error lines per minute per pod against 0 recorded successes, which is how it was found.

Same payload, same receiver, both encodings:

```
JSON     [{"status":202}]
msgpack  [{'ErrorStr': '', 'Status': 202}]
```

The names this PR uses are the ones the JSON encoder here already emits, and the ones Honeycomb documents for the batch endpoint (`[{"status":202},{"status":400,"error":"..."}]`). Worth noting for reviewers: Honeycomb's public docs describe JSON only, so the msgpack shape is a de-facto contract between libhoney and the API rather than a documented one — libhoney's `UnmarshalMsgpack` above is the authority for it.

#### Link to tracking issue

Fixes #50378

#### Testing

Added `TestMarshalResponse_FieldNamesMatchAcrossEncodings`, which decodes both encodings into libhoney's struct shape rather than back into `ResponseInBatch`. The existing `TestMarshalResponse_Msgpack` round-trips through `ResponseInBatch` itself, which is why the names on the wire were never checked.

Without the tags the new test fails with the production symptom:

```
expected: 202
actual  : 0
```

#### Documentation

None — the wire format is unchanged from what the JSON encoder already produces.
