### PR TITLE
[exporter/kafka] Remove deprecated config options

### DIFF
--- a/.chloggen/remove-deprecated-kafka-configs.yaml
+++ b/.chloggen/remove-deprecated-kafka-configs.yaml
@@ -10,7 +10,7 @@ component: pkg/kafka/configkafka
 note: Remove all previously deprecated Kafka client configuration options.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [48260, 48658]
+issues: [50381]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/remove-deprecated-kafka-configs.yaml
+++ b/.chloggen/remove-deprecated-kafka-configs.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/kafka/configkafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove all previously deprecated Kafka client configuration options.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48260, 48658]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The following deprecated options are no longer accepted:
+  - `resolve_canonical_bootstrap_servers_only` (no-op since franz-go migration)
+  - `auth.sasl.version` (no-op since franz-go migration)
+  - `group_rebalance_strategy` (use `group_rebalance_strategies` instead)
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -164,12 +164,7 @@ func NewFranzConsumerGroup(
 		opts = append(opts, kgo.InstanceID(consumerCfg.GroupInstanceID))
 	}
 
-	// Configure rebalance strategy
-	if consumerCfg.GroupRebalanceStrategy != "" {
-		logger.Warn("group_rebalance_strategy is deprecated, use group_rebalance_strategies instead")
-	}
 	balancerOpt, err := balancerOptFromStrategies(
-		consumerCfg.GroupRebalanceStrategy,
 		consumerCfg.GroupRebalanceStrategies,
 		host,
 	)
@@ -217,19 +212,11 @@ func NewFranzClusterAdminClient(
 // singular strategy and the strategies list are mutually exclusive (enforced by
 // ConsumerConfig.Validate).
 func balancerOptFromStrategies(
-	strategy configkafka.GroupRebalanceStrategy,
 	strategies []configkafka.GroupRebalanceStrategy,
 	host component.Host,
 ) (kgo.Opt, error) {
-	if strategy == "" && len(strategies) == 0 {
-		return nil, nil
-	}
 	if len(strategies) == 0 {
-		balancer, err := balancerFromStrategy(strategy, "group_rebalance_strategy", host)
-		if err != nil {
-			return nil, err
-		}
-		return kgo.Balancers(balancer), nil
+		return nil, nil
 	}
 
 	balancers, err := balancersFromStrategies(strategies, host)

--- a/internal/kafka/franz_client_test.go
+++ b/internal/kafka/franz_client_test.go
@@ -752,11 +752,6 @@ func (m *mockHost) GetExtensions() map[component.ID]component.Component {
 	return m.extensions
 }
 
-// nopComponent is a component.Component that does not implement GroupBalancer.
-type nopComponent struct {
-	extension.Extension
-}
-
 // mockTokenSource is a contextTokenSource extension used to test OAUTHBEARER.
 type mockTokenSource struct {
 	extension.Extension

--- a/internal/kafka/franz_client_test.go
+++ b/internal/kafka/franz_client_test.go
@@ -48,7 +48,6 @@ func TestNewFranzSyncProducer_SASL(t *testing.T) {
 			Mechanism: mechanism,
 			Username:  username,
 			Password:  password,
-			Version:   1, // kfake only supports version 1
 		}
 		tl := zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
 		client, err := NewFranzSyncProducer(
@@ -404,36 +403,13 @@ func TestNewFranzKafkaConsumer_InitialOffset(t *testing.T) {
 }
 
 func TestBalancerOptFromStrategies(t *testing.T) {
-	balancerExtID := component.MustNewID("my_balancer")
 	type testcase struct {
-		strategy   configkafka.GroupRebalanceStrategy
 		strategies []configkafka.GroupRebalanceStrategy
 		host       component.Host
 		wantNil    bool
 		wantErr    string
 	}
 	for name, tc := range map[string]testcase{
-		"empty": {
-			strategy: "",
-			host:     componenttest.NewNopHost(),
-			wantNil:  true,
-		},
-		"range": {
-			strategy: configkafka.RangeBalanceStrategy,
-			host:     componenttest.NewNopHost(),
-		},
-		"roundrobin": {
-			strategy: configkafka.RoundRobinBalanceStrategy,
-			host:     componenttest.NewNopHost(),
-		},
-		"sticky": {
-			strategy: configkafka.StickyBalanceStrategy,
-			host:     componenttest.NewNopHost(),
-		},
-		"cooperative-sticky": {
-			strategy: configkafka.CooperativeStickyBalanceStrategy,
-			host:     componenttest.NewNopHost(),
-		},
 		"strategies_only": {
 			strategies: []configkafka.GroupRebalanceStrategy{
 				configkafka.CooperativeStickyBalanceStrategy,
@@ -453,33 +429,10 @@ func TestBalancerOptFromStrategies(t *testing.T) {
 			host:    componenttest.NewNopHost(),
 			wantErr: `group_rebalance_strategies[1] extension "my_balancer" not found`,
 		},
-		"extension_not_found": {
-			strategy: "my_balancer",
-			host:     componenttest.NewNopHost(),
-			wantErr:  `group_rebalance_strategy extension "my_balancer" not found`,
-		},
-		"extension_wrong_type": {
-			strategy: "my_balancer",
-			host: &mockHost{extensions: map[component.ID]component.Component{
-				balancerExtID: &nopComponent{},
-			}},
-			wantErr: `group_rebalance_strategy extension "my_balancer" does not implement kgo.GroupBalancer`,
-		},
-		"extension_ok": {
-			strategy: "my_balancer",
-			host: &mockHost{extensions: map[component.ID]component.Component{
-				balancerExtID: &mockGroupBalancer{},
-			}},
-		},
-		"invalid_id": {
-			strategy: "!!!invalid!!!",
-			host:     componenttest.NewNopHost(),
-			wantErr:  `group_rebalance_strategy "!!!invalid!!!" is not a built-in strategy or a valid extension ID`,
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			opt, err := balancerOptFromStrategies(tc.strategy, tc.strategies, tc.host)
+			opt, err := balancerOptFromStrategies(tc.strategies, tc.host)
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
 				return

--- a/pkg/kafka/configkafka/config.go
+++ b/pkg/kafka/configkafka/config.go
@@ -40,14 +40,6 @@ type ClientConfig struct {
 	// Brokers holds the list of Kafka bootstrap servers (default localhost:9092).
 	Brokers []string `mapstructure:"brokers"`
 
-	// ResolveCanonicalBootstrapServersOnly is ignored, and exists for
-	// backwards compatibility in config parsing.
-	//
-	// Deprecated [v0.153.0]: this field is a no-op since the migration to franz-go,
-	// which has no direct equivalent to the associated Sarama config. This config
-	// will be removed in a future release.
-	ResolveCanonicalBootstrapServersOnly bool `mapstructure:"resolve_canonical_bootstrap_servers_only"`
-
 	// ProtocolVersion defines the Kafka protocol version that the client will
 	// assume it is running against.
 	ProtocolVersion string `mapstructure:"protocol_version"`
@@ -156,14 +148,6 @@ type ConsumerConfig struct {
 	// GroupRebalanceStrategy.
 	GroupRebalanceStrategies []GroupRebalanceStrategy `mapstructure:"group_rebalance_strategies"`
 
-	// GroupRebalanceStrategy specifies the strategy to use for partition
-	// assignment. Accepts the same values as GroupRebalanceStrategies.
-	//
-	// Defaults to "cooperative-sticky".
-	//
-	// Deprecated [v0.154.0]: use GroupRebalanceStrategies instead.
-	GroupRebalanceStrategy GroupRebalanceStrategy `mapstructure:"group_rebalance_strategy"`
-
 	// GroupInstanceID specifies the ID of the consumer
 	GroupInstanceID string `mapstructure:"group_instance_id,omitempty"`
 }
@@ -196,13 +180,6 @@ func (c ConsumerConfig) Validate() error {
 		)
 	}
 
-	if c.GroupRebalanceStrategy != "" && len(c.GroupRebalanceStrategies) > 0 {
-		return errors.New("group_rebalance_strategy and group_rebalance_strategies are mutually exclusive; group_rebalance_strategy is deprecated, prefer group_rebalance_strategies")
-	}
-
-	if err := validateGroupRebalanceStrategy(c.GroupRebalanceStrategy); err != nil {
-		return err
-	}
 	for _, strategy := range c.GroupRebalanceStrategies {
 		if strings.TrimSpace(string(strategy)) == "" {
 			return errors.New("group_rebalance_strategies entries cannot be empty")
@@ -234,12 +211,6 @@ func (c ConsumerConfig) Validate() error {
 }
 
 func validateGroupRebalanceStrategy(strategy GroupRebalanceStrategy) error {
-	// An empty value means the deprecated group_rebalance_strategy field is
-	// unset. Treat it as valid so the default ConsumerConfig passes validation.
-	// Empty entries inside group_rebalance_strategies are rejected by the caller.
-	if strategy == "" {
-		return nil
-	}
 	switch strategy {
 	case RangeBalanceStrategy, RoundRobinBalanceStrategy, StickyBalanceStrategy, CooperativeStickyBalanceStrategy:
 		// Built-in strategy, valid.
@@ -485,12 +456,6 @@ type SASLConfig struct {
 	// SASL Mechanism to be used, possible values are: (PLAIN, AWS_MSK_IAM_OAUTHBEARER, OAUTHBEARER,
 	// SCRAM-SHA-256 or SCRAM-SHA-512).
 	Mechanism string `mapstructure:"mechanism"`
-	// Version is ignored, and exists for backwards compatibility in config parsing.
-	//
-	// Deprecated [v0.153.0]: this field is a no-op since the migration to franz-go,
-	// which negotiates the SASL handshake version automatically. This config will be
-	// removed in a future release.
-	Version int `mapstructure:"version"`
 	// AWSMSK holds configuration specific to AWS MSK.
 	AWSMSK AWSMSKConfig `mapstructure:"aws_msk"`
 	// ID of type "extension" providing a TokenSource for OAUTHBEARER Mechanism,
@@ -519,9 +484,6 @@ func (c SASLConfig) Validate() error {
 			"mechanism should be one of 'PLAIN', 'AWS_MSK_IAM_OAUTHBEARER', 'SCRAM-SHA-256' or 'SCRAM-SHA-512'. configured value %v",
 			c.Mechanism,
 		)
-	}
-	if c.Version < 0 || c.Version > 1 {
-		return fmt.Errorf("version has to be either 0 or 1. configured value %v", c.Version)
 	}
 	return nil
 }

--- a/pkg/kafka/configkafka/config.schema.yaml
+++ b/pkg/kafka/configkafka/config.schema.yaml
@@ -55,9 +55,6 @@ $defs:
       rack_id:
         description: RackID provides the rack identifier for this client to enable rack-aware replica selection when supported by the brokers. This maps to Kafka's standard "client.rack" setting. By default, this is empty.
         type: string
-      resolve_canonical_bootstrap_servers_only:
-        description: 'ResolveCanonicalBootstrapServersOnly is ignored, and exists for backwards compatibility in config parsing. Deprecated [v0.153.0]: this field is a no-op since the migration to franz-go, which has no direct equivalent to the associated Sarama config. This config will be removed in a future release.'
-        type: boolean
       tls:
         description: TLS holds TLS-related configuration for connecting to Kafka brokers. By default the client will use an insecure connection unless SASL/AWS_MSK_IAM_OAUTHBEARER auth is configured.
         x-pointer: true
@@ -82,9 +79,6 @@ $defs:
         type: array
         items:
           $ref: group_rebalance_strategy
-      group_rebalance_strategy:
-        description: 'GroupRebalanceStrategy specifies the strategy to use for partition assignment. Accepts the same values as GroupRebalanceStrategies. Defaults to "cooperative-sticky". Deprecated [v0.154.0]: use GroupRebalanceStrategies instead.'
-        $ref: group_rebalance_strategy
       heartbeat_interval:
         description: HeartbeatInterval controls the Kafka consumer group coordination heartbeat interval. Heartbeats ensure the consumer's session remains active.
         type: string
@@ -218,6 +212,3 @@ $defs:
       username:
         description: Username to be used on authentication
         type: string
-      version:
-        description: 'Version is ignored, and exists for backwards compatibility in config parsing. Deprecated [v0.153.0]: this field is a no-op since the migration to franz-go, which negotiates the SASL handshake version automatically. This config will be removed in a future release.'
-        type: integer

--- a/pkg/kafka/configkafka/config_test.go
+++ b/pkg/kafka/configkafka/config_test.go
@@ -28,10 +28,9 @@ func TestClientConfig(t *testing.T) {
 		},
 		"full": {
 			expected: ClientConfig{
-				Brokers:                              []string{"foo:123", "bar:456"},
-				ResolveCanonicalBootstrapServersOnly: true,
-				ClientID:                             "vip",
-				ProtocolVersion:                      "3.1.2",
+				Brokers:         []string{"foo:123", "bar:456"},
+				ClientID:        "vip",
+				ProtocolVersion: "3.1.2",
 				TLS: &configtls.ClientConfig{
 					Config: configtls.Config{
 						CAFile:   "ca.pem",
@@ -87,7 +86,6 @@ func TestClientConfig(t *testing.T) {
 					Mechanism: "PLAIN",
 					Username:  "abc",
 					Password:  "def",
-					Version:   1,
 				}
 				return cfg
 			}(),
@@ -117,9 +115,6 @@ func TestClientConfig(t *testing.T) {
 		"sasl_invalid_mechanism": {
 			expectedErr: "auth::sasl: mechanism should be one of 'PLAIN', 'AWS_MSK_IAM_OAUTHBEARER', 'SCRAM-SHA-256' or 'SCRAM-SHA-512'. configured value FANCY",
 		},
-		"sasl_invalid_version": {
-			expectedErr: "auth::sasl: version has to be either 0 or 1. configured value -1",
-		},
 		"sasl_plain_username_required": {
 			expectedErr: "auth::sasl: username is required",
 		},
@@ -139,11 +134,10 @@ func TestConsumerConfig(t *testing.T) {
 		},
 		"full": {
 			expected: ConsumerConfig{
-				SessionTimeout:         5 * time.Second,
-				HeartbeatInterval:      2 * time.Second,
-				GroupID:                "throng",
-				GroupRebalanceStrategy: "cooperative-sticky",
-				InitialOffset:          "earliest",
+				SessionTimeout:    5 * time.Second,
+				HeartbeatInterval: 2 * time.Second,
+				GroupID:           "throng",
+				InitialOffset:     "earliest",
 				AutoCommit: AutoCommitConfig{
 					Enable:   false,
 					Interval: 10 * time.Minute,
@@ -190,9 +184,6 @@ func TestConsumerConfig(t *testing.T) {
 		},
 		"negative_min_fetch_size": {
 			expectedErr: "min_fetch_size (-100) must be non-negative",
-		},
-		"conflicting_group_rebalance_strategies": {
-			expectedErr: "group_rebalance_strategy and group_rebalance_strategies are mutually exclusive; group_rebalance_strategy is deprecated, prefer group_rebalance_strategies",
 		},
 		"empty_group_rebalance_strategies_entry": {
 			expectedErr: "group_rebalance_strategies entries cannot be empty",

--- a/pkg/kafka/configkafka/testdata/client_config.yaml
+++ b/pkg/kafka/configkafka/testdata/client_config.yaml
@@ -1,7 +1,6 @@
 kafka: {}
 kafka/full:
   brokers: ["foo:123", "bar:456"]
-  resolve_canonical_bootstrap_servers_only: true
   client_id: vip
   protocol_version: 3.1.2
   rack_id: rack1
@@ -36,7 +35,6 @@ kafka/sasl_plain:
       mechanism: PLAIN
       username: abc
       password: def
-      version: 1
 kafka/legacy_auth_tls:
   auth:
     tls:
@@ -61,14 +59,6 @@ kafka/sasl_invalid_mechanism:
     sasl:
       mechanism: FANCY
 
-kafka/sasl_invalid_version:
-  auth:
-    sasl:
-      mechanism: PLAIN
-      username: abc
-      password: def
-      version: -1
-
 kafka/sasl_plain_username_required:
   auth:
     sasl:
@@ -85,7 +75,6 @@ kafka/foo:
   brokers:
     - "foo:123"
     - "bar:456"
-  resolve_canonical_bootstrap_servers_only: true
   client_id: otel-collector
   auth:
     tls:

--- a/pkg/kafka/configkafka/testdata/consumer_config.yaml
+++ b/pkg/kafka/configkafka/testdata/consumer_config.yaml
@@ -11,7 +11,7 @@ kafka/full:
   max_fetch_size: 4096
   max_fetch_wait: 1s
   max_partition_fetch_size: 4096
-  group_rebalance_strategy: cooperative-sticky
+
 kafka/group_rebalance_strategies:
   group_rebalance_strategies:
     - cooperative-sticky
@@ -30,7 +30,6 @@ kafka/negative_min_fetch_size:
   min_fetch_size: -100
   max_fetch_size: 1048576
 kafka/conflicting_group_rebalance_strategies:
-  group_rebalance_strategy: cooperative-sticky
   group_rebalance_strategies:
     - my_balancer
 kafka/empty_group_rebalance_strategies_entry:

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -74,15 +74,6 @@ func TestLoadConfig(t *testing.T) {
 			}(),
 		},
 		{
-			name: "kafka/rebalance_strategy",
-			expected: func() *Config {
-				cfg := NewFactory().CreateDefaultConfig().(*Config)
-				cfg.ConsumerConfig.GroupRebalanceStrategy = configkafka.StickyBalanceStrategy
-				cfg.ConsumerConfig.GroupInstanceID = "test-instance"
-				return cfg
-			}(),
-		},
-		{
 			name: "kafka/rebalance_strategies",
 			expected: func() *Config {
 				cfg := NewFactory().CreateDefaultConfig().(*Config)

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -45,10 +45,6 @@ kafka/logs:
     max_elapsed_time: 1m
     multiplier: 1.5
 
-kafka/rebalance_strategy:
-  group_rebalance_strategy: sticky
-  group_instance_id: test-instance
-
 kafka/rebalance_strategies:
   group_rebalance_strategies:
     - cooperative-sticky


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
  The following deprecated options are no longer accepted:
  - `resolve_canonical_bootstrap_servers_only` (no-op since franz-go migration)
  - `auth.sasl.version` (no-op since franz-go migration)
  - `group_rebalance_strategy` (use `group_rebalance_strategies` instead)

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
