### PR TITLE
[chore][ci] pin govulncheck to oldstable while cockroachdb/swiss lacks Go 1.27 support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -223,7 +223,11 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-go-tools
         with:
-          go-version: stable
+          # Pinned to oldstable while github.com/cockroachdb/swiss does not
+          # build with Go 1.27; revert once
+          # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50382
+          # is resolved.
+          go-version: oldstable
       - name: Run `govulncheck`
         run: make gogovulncheck GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh


### PR DESCRIPTION
#### Description

Pins the govulncheck job's toolchain to `oldstable`. Go 1.27.0 released and `stable` now resolves to it, but `github.com/cockroachdb/swiss` (an indirect dependency of `extension/tailstorage/pebbletailstorageextension` via pebble) does not build with Go 1.27, so the `govulncheck (extension)` shard fails on every PR. govulncheck sweeps all modules regardless of ci-scope, which is why every PR is hit.

A comment marks the pin as temporary, to revert once swiss supports Go 1.27 (upstream fix is open at cockroachdb/swiss#52) and the dependency is bumped.

#### Link to tracking issue

Closes #50382

#### Testing

- CI on this PR, the govulncheck shards should pass again under oldstable (1.26), which was green until yesterday

#### Documentation

Not applicable, CI-only change.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
