### PR TITLE
[chore]: Promote braydonk to maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 - [Andrzej Stencel](https://github.com/andrzej-stencel), Elastic
 - [Antoine Toulme](https://github.com/atoulme), Splunk
 - [Bogdan Drutu](https://github.com/bogdandrutu), Snowflake
+- [Braydon Kains](https://github.com/braydonk), Google
 - [Christos Markou](https://github.com/ChrsMark), Elastic
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
 - [Edmo Vamerlatti Costa](https://github.com/edmocosta), Elastic
@@ -83,7 +84,6 @@ For more information about the maintainer role, see the [community repository](h
 ### Approvers
 
 - [Arthur Silva Sens](https://github.com/ArthurSens), Grafana Labs
-- [Braydon Kains](https://github.com/braydonk), Google
 - [Curtis Robert](https://github.com/crobert-1), Splunk
 - [David Ashpole](https://github.com/dashpole), Google
 - [Israel Blancas](https://github.com/iblancasa), Coralogix


### PR DESCRIPTION
@braydonk has been in the Collector SIG for a long time helping mature several components, especially the hostmetricsreceiver. He has consistently shown great judgement, commitment to the SIG, and great communication skills.

- PRs reviewed: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+reviewed-by%3Abraydonk+
- PRs authored: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+author%3Abraydonk+
- Issues commented: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue%20commenter%3Abraydonk
- Issues opened: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue%20author%3Abraydonk
- Commits: https://github.com/open-telemetry/opentelemetry-collector-contrib/commits?since=2021-05-31&until=now&author=braydonk

For these reasons we'd like to promote @braydonk to Maintainer.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
