### PR TITLE
[chore] [pkg/stanza] Use math/rand/v2.ChaCha8.Read in fingerprint test

### DIFF
--- a/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
@@ -5,7 +5,6 @@ package fingerprint
 
 import (
 	"compress/gzip"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -228,22 +227,13 @@ func TestStartsWith(t *testing.T) {
 // the file, while each iteration of the growing file represents
 // a possible state of the same file at a previous time.
 func TestStartsWith_FromFile(t *testing.T) {
-	r := rand.New(rand.NewPCG(112, 358))
+	// Use a fixed seed so that the generated content is the same on every run.
+	r := rand.NewChaCha8([32]byte{112})
 	fingerprintSize := 10
 	fileLength := 12 * fingerprintSize
 	fillRandomBytes := func(buf []byte) {
-		// TODO: when we upgrade to go1.23,
-		// use rand.ChaCha8.Read.
-		//
-		// NOTE: we can cheat here since know the
-		// buffer length is a multiple of 4, due to
-		// fileLength being a multiple of 12.
-		for i := range len(buf) / 4 {
-			binary.BigEndian.PutUint32(
-				buf[i*4:(i+1)*4],
-				r.Uint32(),
-			)
-		}
+		_, err := r.Read(buf)
+		require.NoError(t, err)
 	}
 
 	tempDir := t.TempDir()


### PR DESCRIPTION
#### Description
This PR replaces the hand-rolled random buffer fill in `TestStartsWith_FromFile` with a single `ChaCha8.Read` call. The original loop over `binary.BigEndian.PutUint32` existed only because `ChaCha8.Read` was not available before go1.23, and since `pkg/stanza` now requires go1.25 that workaround is no longer needed. This simplifies the test helper and, as a side benefit, drops the previous constraint that the buffer length be a multiple of 4.

#### Authorship

- [x] I, a human, wrote this pull request description myself.