### PR TITLE
[cmd/opampsupervisor] Open agent logfile with `O_APPEND`

### DIFF
--- a/.chloggen/50376-agent-log-o-append.yaml
+++ b/.chloggen/50376-agent-log-o-append.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Open agent.log with O_APPEND so external copytruncate-style log rotation (e.g. logrotate) works correctly instead of the file's size reverting on the next write.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50376]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/supervisor/commander/commander.go
+++ b/cmd/opampsupervisor/supervisor/commander/commander.go
@@ -129,7 +129,10 @@ func (c *Commander) ValidateConfig(ctx context.Context, configPath string, addit
 }
 
 func (c *Commander) startNormal() error {
-	stdoutFile, err := os.Create(c.logFilePath)
+	// O_APPEND ensures every write lands at the file's current end-of-file, so
+	// external copytruncate-style log rotation (logrotate et al.) works correctly
+	// instead of the file's size reverting on the next write.
+	stdoutFile, err := os.OpenFile(c.logFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|os.O_APPEND, 0o644)
 	if err != nil {
 		return fmt.Errorf("cannot create %s: %w", c.logFilePath, err)
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is mostly reopening the work from #50377, as requested by the original PR's author. Thank you for reporting the issue and coming up with the fix, @weili-broadcom.

`Commander.startNormal()` opened agent.log via os.Create, which doesn't set O_APPEND. This breaks copytruncate-based external log rotation (e.g. the default policy on BOSH stemcells): after an external tool truncates the file, the supervisor's next write still lands at its old, stale offset instead of the new end-of-file, so the file's size snaps right back up instead of staying rotated.

Adding `O_APPEND` makes every write atomically target the current end-of-file, which is exactly what copytruncate-style rotation requires from a writer it can't signal to reopen its file.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50376

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Ran a local smoke test and confirmed it works as expected.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
