### PR TITLE
[exporter/awsemf] Detect cumulative counter resets when converting to delta

### DIFF
--- a/.chloggen/48556-awsemf-counter-reset.yaml
+++ b/.chloggen/48556-awsemf-counter-reset.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/awsemf
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Detect cumulative counter resets when converting to delta
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48556]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The cumulative to delta conversion keyed only on the metric metadata and attributes, so a
+  counter that restarted was diffed against the value from before the restart. A short lived
+  producer such as a cron job or a Lambda that reports the same cumulative value on every run
+  therefore emitted a delta of 0 and its runs were invisible. The data point start timestamp,
+  which is how OTLP signals a reset, is now part of the key so a restarted counter starts a
+  new series.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -77,6 +77,16 @@ type deltaMetricMetadata struct {
 	logStream                  string
 }
 
+// deltaMetricKey identifies the series a data point belongs to for rate/delta
+// calculation. The start timestamp is part of the identity because OTLP signals
+// a counter reset by reporting a new start timestamp: a restarted counter must
+// begin a new series rather than be diffed against the value from before the
+// restart, which would report no change at all.
+type deltaMetricKey struct {
+	deltaMetricMetadata
+	startTimestamp pcommon.Timestamp
+}
+
 // numberDataPointSlice is a wrapper for pmetric.NumberDataPointSlice
 type numberDataPointSlice struct {
 	deltaMetricMetadata
@@ -154,7 +164,7 @@ func (dps numberDataPointSlice) CalculateDeltaDatapoints(i int, instrumentationS
 
 	if dps.adjustToDelta {
 		var deltaVal any
-		mKey := aws.NewKey(dps.deltaMetricMetadata, labels)
+		mKey := aws.NewKey(deltaMetricKey{dps.deltaMetricMetadata, metric.StartTimestamp()}, labels)
 		deltaVal, retained = calculators.delta.Calculate(mKey, metricVal, metric.Timestamp().AsTime())
 
 		// If a delta to the previous data point could not be computed use the current metric value instead
@@ -442,7 +452,7 @@ func (dps summaryDataPointSlice) CalculateDeltaDatapoints(i int, instrumentation
 
 	if dps.adjustToDelta {
 		var delta any
-		mKey := aws.NewKey(dps.deltaMetricMetadata, labels)
+		mKey := aws.NewKey(deltaMetricKey{dps.deltaMetricMetadata, metric.StartTimestamp()}, labels)
 		delta, retained = calculators.summary.Calculate(mKey, summaryMetricEntry{sum, count}, metric.Timestamp().AsTime())
 
 		// If a delta to the previous data point could not be computed use the current metric value instead

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -2165,3 +2165,90 @@ func BenchmarkGetAndCalculateDeltaDataPointsInclude300Buckets(b *testing.B) {
 func BenchmarkGetAndCalculateDeltaDataPointsInclude500Buckets(b *testing.B) {
 	benchmarkGetAndCalculateDeltaDataPoints(b, 500)
 }
+
+func TestCalculateDeltaDatapoints_NumberDataPointSliceCounterReset(t *testing.T) {
+	// A cumulative counter signals a reset by reporting a new start timestamp.
+	// Short-lived producers (a cron job, a Lambda) restart the counter on every
+	// run, so the raw value repeats while the start timestamp moves forward.
+	// Each run must be treated as a new series rather than diffed against the
+	// previous run.
+	testCases := []struct {
+		name          string
+		startTimes    []time.Time
+		metricValues  []int64
+		expectedDelta []float64
+	}{
+		{
+			name:          "counter restarted on every run",
+			startTimes:    []time.Time{time.UnixMilli(1000), time.UnixMilli(2000), time.UnixMilli(3000)},
+			metricValues:  []int64{1, 1, 1},
+			expectedDelta: []float64{1, 1, 1},
+		},
+		{
+			name:          "counter running continuously",
+			startTimes:    []time.Time{time.UnixMilli(1000), time.UnixMilli(1000), time.UnixMilli(1000)},
+			metricValues:  []int64{1, 3, 7},
+			expectedDelta: []float64{1, 2, 4},
+		},
+		{
+			name:          "counter reset partway through a series",
+			startTimes:    []time.Time{time.UnixMilli(1000), time.UnixMilli(1000), time.UnixMilli(2000)},
+			metricValues:  []int64{5, 9, 2},
+			expectedDelta: []float64{5, 4, 2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			emfCalcs := setupEmfCalculators()
+			defer require.NoError(t, shutdownEmfCalculators(emfCalcs))
+
+			for i, value := range tc.metricValues {
+				numberDPS := pmetric.NewNumberDataPointSlice()
+				numberDP := numberDPS.AppendEmpty()
+				numberDP.SetStartTimestamp(pcommon.NewTimestampFromTime(tc.startTimes[i]))
+				numberDP.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(int64(4000 + i))))
+				numberDP.SetIntValue(value)
+				numberDP.Attributes().PutStr("label1", "value1")
+
+				// retainInitialValueForDelta keeps the first point of each series,
+				// which is what makes a restarted counter observable at all.
+				dmd := generateDeltaMetricMetadata(true, "counter", true)
+				dps, retained := numberDataPointSlice{dmd, numberDPS}.CalculateDeltaDatapoints(0, instrLibName, false, emfCalcs)
+
+				require.True(t, retained, "datapoint %d should be retained", i)
+				require.Len(t, dps, 1)
+				assert.InDelta(t, tc.expectedDelta[i], dps[0].value, 0.002, "datapoint %d", i)
+			}
+		})
+	}
+}
+
+func TestCalculateDeltaDatapoints_SummaryDataPointSliceCounterReset(t *testing.T) {
+	// Summary sum/count are cumulative too, so a restarted producer must start a
+	// new series here as well rather than be diffed against the previous run.
+	emfCalcs := setupEmfCalculators()
+	defer require.NoError(t, shutdownEmfCalculators(emfCalcs))
+
+	startTimes := []time.Time{time.UnixMilli(1000), time.UnixMilli(2000)}
+	expectedSums := []float64{4.5, 4.5}
+	expectedCounts := []uint64{3, 3}
+
+	for i, startTime := range startTimes {
+		summaryDPS := pmetric.NewSummaryDataPointSlice()
+		summaryDP := summaryDPS.AppendEmpty()
+		summaryDP.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
+		summaryDP.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(int64(3000 + i))))
+		summaryDP.SetSum(4.5)
+		summaryDP.SetCount(3)
+		summaryDP.Attributes().PutStr("label1", "value1")
+
+		dmd := generateDeltaMetricMetadata(true, "foo", true)
+		dps, retained := summaryDataPointSlice{dmd, summaryDPS}.CalculateDeltaDatapoints(0, "", false, emfCalcs)
+
+		require.True(t, retained, "datapoint %d should be retained", i)
+		require.Len(t, dps, 1)
+		assert.InDelta(t, expectedSums[i], dps[0].value.(*cWMetricStats).Sum, 0.002, "datapoint %d sum", i)
+		assert.Equal(t, expectedCounts[i], dps[0].value.(*cWMetricStats).Count, "datapoint %d count", i)
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
the cumulative→delta key was metadata + labels only, so a restarted counter was diffed against its pre-restart value and emitted delta 0. Added the data point start timestamp to the key, matching how cumulativetodeltaprocessor detects resets.  with the default retain_initial_value_of_delta_metric: false, a reset now drops the first point instead of emitting 0.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #48556

<!--Describe what testing was performed and which tests were added.-->
#### Testing
two new unit tests (number + summary paths), both fail without the fix. End-to-end through the translator with the issue's five-run scenario: before 1,0,0,0,0, after 1,1,1,1,1.

<!--Describe the documentation added.-->
#### Documentation
No documentation changes.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.
