### PR TITLE
[chore][ci] Add missing 'other' group to govulncheck matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -213,6 +213,7 @@ jobs:
           - internal
           - pkg
           - cmd-0
+          - other
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: [setup-environment]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add missing `other` group to `govulncheck` CI.

I'll look into other PR a way to automatically use all the groups to avoid this happening again in the future.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->