### PR TITLE
[chore][ci] Fix discussion-needed label mapping in add-labels.sh

### DIFF
--- a/.github/workflows/scripts/add-labels.sh
+++ b/.github/workflows/scripts/add-labels.sh
@@ -23,7 +23,7 @@ declare -A COMMON_LABELS
 COMMON_LABELS["arm64"]="arm64"
 COMMON_LABELS["good-first-issue"]="good first issue"
 COMMON_LABELS["help-wanted"]="help wanted"
-COMMON_LABELS["needs-discussion"]="needs discussion"
+COMMON_LABELS["discussion-needed"]="discussion needed"
 COMMON_LABELS["needs-triage"]="needs triage"
 COMMON_LABELS["os:mac"]="os:mac"
 COMMON_LABELS["os:windows"]="os:windows"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Looking into [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) and into the available labels, the right label is `discussion needed` and the label in the comment should be `discussion-needed` as it is documented.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
