### PR TITLE
[chore] remove unnecessary step

### DIFF
--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -30,11 +30,6 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: otelbot-token
-        with:
-          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
       - name: go mod tidy, make genotelcontribcol and make genoteltestbedcol
         run: |
           make gotidy && make genotelcontribcol && make genoteltestbedcol
@@ -42,8 +37,6 @@ jobs:
           git config user.email 197425009+otelbot@users.noreply.github.com
           echo "git diff --exit-code || (git add . && git commit -m \"go mod tidy, make genotelcontribcol and make genoteltestbedcol\" && git push)"
           git diff --exit-code || (git add . && git commit -m "go mod tidy, make genotelcontribcol and make genoteltestbedcol" && git push)
-        env:
-          GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
       - name: Remove renovatebot label
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This step is unnecessary in the tidy-dependencies as credentials are persisted at the checkout step. The workflow in core does the same.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
