### PR TITLE
[receiver/datadog] Improve span error and status translation

### DIFF
--- a/.chloggen/datadogreceiver-exception-span-events.yaml
+++ b/.chloggen/datadogreceiver-exception-span-events.yaml
@@ -10,7 +10,7 @@ component: receiver/datadog
 note: Translate Datadog error tags on spans into an OpenTelemetry `exception` span event instead of span attributes.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [00000]
+issues: [50446]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/datadogreceiver-exception-span-events.yaml
+++ b/.chloggen/datadogreceiver-exception-span-events.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Translate Datadog error tags on spans into an OpenTelemetry `exception` span event instead of span attributes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [00000]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: >
+  `error.msg`/`error.message`, `error.type`/`error.kind` and `error.stack`/`error.stacktrace` are now
+  mapped to an `exception` span event with `exception.message`, `exception.type` and
+  `exception.stacktrace` (per the OpenTelemetry exception convention), unless the span already carries
+  an `exception` event, and are no longer emitted as span attributes. Previously only `error.msg` and
+  `error.stacktrace` were mapped, as `exception.message`/`exception.stacktrace` span attributes, while
+  error types and the `error.stack` stack traces that Datadog tracers actually send were dropped.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/datadogreceiver-unset-span-status.yaml
+++ b/.chloggen/datadogreceiver-unset-span-status.yaml
@@ -10,7 +10,7 @@ component: receiver/datadog
 note: Report spans without a Datadog error with an Unset status code instead of Ok.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [00000]
+issues: [50446]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/datadogreceiver-unset-span-status.yaml
+++ b/.chloggen/datadogreceiver-unset-span-status.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Report spans without a Datadog error with an Unset status code instead of Ok.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [00000]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: >
+  Datadog `error == 0` means "not an error", which corresponds to the OpenTelemetry default status
+  (Unset); Ok is reserved for spans explicitly marked successful. The receiver previously reported
+  Ok for every non-error span.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -88,6 +88,8 @@ var datadogKnownResourceAttributes = map[string]string{
 	"db.statement": string(conventions.DBQueryTextKey),
 
 	// Other
+	// The error.* mappings are kept for signals without span events (e.g. logs); trace spans
+	// instead turn the error.* tags into an OTel exception span event (see addExceptionSpanEvent).
 	"process_id":       string(conventions.ProcessPIDKey),
 	"error.stacktrace": string(conventions.ExceptionStacktraceKey),
 	"error.msg":        string(conventions.ExceptionMessageKey),

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -88,8 +88,6 @@ var datadogKnownResourceAttributes = map[string]string{
 	"db.statement": string(conventions.DBQueryTextKey),
 
 	// Other
-	// The error.* mappings are kept for signals without span events (e.g. logs); trace spans
-	// instead turn the error.* tags into an OTel exception span event (see addExceptionSpanEvent).
 	"process_id":       string(conventions.ProcessPIDKey),
 	"error.stacktrace": string(conventions.ExceptionStacktraceKey),
 	"error.msg":        string(conventions.ExceptionMessageKey),

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -650,7 +650,7 @@ func addExceptionSpanEvent(span *pb.Span, newSpan *ptrace.Span) {
 	if msg == "" && typ == "" && stack == "" {
 		return
 	}
-	// Avoid duplicating an exception event already produced from the native span_events field.
+
 	for _, event := range newSpan.Events().All() {
 		if event.Name() == "exception" {
 			return

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -337,11 +337,12 @@ func ToTraces(logger *zap.Logger, payload *pb.TracerPayload, req *http.Request, 
 			if hasSamplingPriority {
 				newSpan.Attributes().PutStr("sampling.priority", fmt.Sprintf("%f", samplingPriority))
 			}
-			// A Datadog error of 0 means "not an error", which maps to the OTel default status (Unset).
+
 			if span.Error > 0 {
 				newSpan.Status().SetCode(ptrace.StatusCodeError)
 			}
 			addExceptionSpanEvent(span, &newSpan)
+
 			newSpan.Attributes().PutStr(attributeDatadogSpanID, strconv.FormatUint(span.SpanID, 10))
 			newSpan.Attributes().PutStr(attributeDatadogTraceID, strconv.FormatUint(span.TraceID, 10))
 			for k, v := range span.GetMeta() {
@@ -633,7 +634,7 @@ func putAttributeAnyValue(attrs pcommon.Map, key string, v *pb.AttributeAnyValue
 }
 
 // addExceptionSpanEvent converts Datadog error tags into an OpenTelemetry `exception` span event.
-// Datadog tracers report an error either as an exception span event (translated by setSpanEvents) or
+// Datadog tracers report an error either as an exception span event or
 // as error.* tags; when only the tags are present this reconstructs the event so downstream consumers
 // see OTel-native exception semantics. The consumed tags are removed so they do not also surface as
 // raw span attributes. dd-trace tracers use error.message/error.type; some use error.msg/error.kind/error.stacktrace.

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -333,14 +333,15 @@ func ToTraces(logger *zap.Logger, payload *pb.TracerPayload, req *http.Request, 
 			newSpan.SetEndTimestamp(pcommon.Timestamp(span.Start + span.Duration))
 			newSpan.SetParentSpanID(uInt64ToSpanID(span.ParentID))
 			newSpan.SetName(span.Name)
-			newSpan.Status().SetCode(ptrace.StatusCodeOk)
 			newSpan.Attributes().PutStr("dd.span.Resource", span.Resource)
 			if hasSamplingPriority {
 				newSpan.Attributes().PutStr("sampling.priority", fmt.Sprintf("%f", samplingPriority))
 			}
+			// A Datadog error of 0 means "not an error", which maps to the OTel default status (Unset).
 			if span.Error > 0 {
 				newSpan.Status().SetCode(ptrace.StatusCodeError)
 			}
+			addExceptionSpanEvent(span, &newSpan)
 			newSpan.Attributes().PutStr(attributeDatadogSpanID, strconv.FormatUint(span.SpanID, 10))
 			newSpan.Attributes().PutStr(attributeDatadogTraceID, strconv.FormatUint(span.TraceID, 10))
 			for k, v := range span.GetMeta() {
@@ -629,6 +630,53 @@ func putAttributeAnyValue(attrs pcommon.Map, key string, v *pb.AttributeAnyValue
 			}
 		}
 	}
+}
+
+// addExceptionSpanEvent converts Datadog error tags into an OpenTelemetry `exception` span event.
+// Datadog tracers report an error either as an exception span event (translated by setSpanEvents) or
+// as error.* tags; when only the tags are present this reconstructs the event so downstream consumers
+// see OTel-native exception semantics. The consumed tags are removed so they do not also surface as
+// raw span attributes. dd-trace tracers use error.message/error.type; some use error.msg/error.kind/error.stacktrace.
+func addExceptionSpanEvent(span *pb.Span, newSpan *ptrace.Span) {
+	msg := firstMeta(span, "error.msg", "error.message")
+	typ := firstMeta(span, "error.type", "error.kind")
+	stack := firstMeta(span, "error.stack", "error.stacktrace")
+
+	for _, k := range []string{"error.msg", "error.message", "error.type", "error.kind", "error.stack", "error.stacktrace"} {
+		delete(span.Meta, k)
+	}
+
+	if msg == "" && typ == "" && stack == "" {
+		return
+	}
+	// Avoid duplicating an exception event already produced from the native span_events field.
+	for _, event := range newSpan.Events().All() {
+		if event.Name() == "exception" {
+			return
+		}
+	}
+
+	event := newSpan.Events().AppendEmpty()
+	event.SetName("exception")
+	event.SetTimestamp(pcommon.Timestamp(span.Start + span.Duration))
+	if msg != "" {
+		event.Attributes().PutStr(string(conventions.ExceptionMessageKey), msg)
+	}
+	if typ != "" {
+		event.Attributes().PutStr(string(conventions.ExceptionTypeKey), typ)
+	}
+	if stack != "" {
+		event.Attributes().PutStr(string(conventions.ExceptionStacktraceKey), stack)
+	}
+}
+
+func firstMeta(span *pb.Span, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := span.Meta[k]; ok && v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 var bufferPool = sync.Pool{

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -1337,11 +1337,12 @@ func TestAddExceptionSpanEvent(t *testing.T) {
 		assertExceptionAttr(t, event, "exception.message", "connection refused")
 		assertExceptionAttr(t, event, "exception.type", "ConnectionError")
 		assertExceptionAttr(t, event, "exception.stacktrace", "at main.go:42")
-		// The error.* tags are consumed, not also emitted as raw span attributes.
+
 		for _, k := range []string{"error.message", "error.type", "error.stack"} {
 			_, ok := span.Attributes().Get(k)
 			assert.False(t, ok, "%s leaked as a span attribute", k)
 		}
+
 		assert.Equal(t, ptrace.StatusCodeError, span.Status().Code())
 	})
 
@@ -1362,7 +1363,7 @@ func TestAddExceptionSpanEvent(t *testing.T) {
 		})
 		require.Equal(t, 1, span.Events().Len())
 		assertExceptionAttr(t, span.Events().At(0), "exception.stacktrace", "at main.go:7")
-		// The tag is consumed by the event, so it must not also land on the span as exception.stacktrace.
+
 		_, ok := span.Attributes().Get("exception.stacktrace")
 		assert.False(t, ok, "error.stacktrace leaked as a span attribute")
 	})
@@ -1388,7 +1389,6 @@ func TestAddExceptionSpanEvent(t *testing.T) {
 }
 
 func TestSpanStatus(t *testing.T) {
-	// A Datadog error of 0 maps to the OTel default status (Unset); a non-zero error maps to Error.
 	nonError := translateSingleSpan(t, &pb.Span{TraceID: 1, SpanID: 1})
 	assert.Equal(t, ptrace.StatusCodeUnset, nonError.Status().Code())
 

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -1314,3 +1314,84 @@ func TestSetSpanEvents(t *testing.T) {
 		assert.Equal(t, "b", arr.Slice().At(1).Str())
 	})
 }
+
+func TestAddExceptionSpanEvent(t *testing.T) {
+	assertExceptionAttr := func(t *testing.T, event ptrace.SpanEvent, key, want string) {
+		v, ok := event.Attributes().Get(key)
+		require.True(t, ok, "missing %s", key)
+		assert.Equal(t, want, v.Str())
+	}
+
+	t.Run("synthesized from error tags", func(t *testing.T) {
+		span := translateSingleSpan(t, &pb.Span{
+			TraceID: 1, SpanID: 1, Error: 1,
+			Meta: map[string]string{
+				"error.message": "connection refused",
+				"error.type":    "ConnectionError",
+				"error.stack":   "at main.go:42",
+			},
+		})
+		require.Equal(t, 1, span.Events().Len())
+		event := span.Events().At(0)
+		assert.Equal(t, "exception", event.Name())
+		assertExceptionAttr(t, event, "exception.message", "connection refused")
+		assertExceptionAttr(t, event, "exception.type", "ConnectionError")
+		assertExceptionAttr(t, event, "exception.stacktrace", "at main.go:42")
+		// The error.* tags are consumed, not also emitted as raw span attributes.
+		for _, k := range []string{"error.message", "error.type", "error.stack"} {
+			_, ok := span.Attributes().Get(k)
+			assert.False(t, ok, "%s leaked as a span attribute", k)
+		}
+		assert.Equal(t, ptrace.StatusCodeError, span.Status().Code())
+	})
+
+	t.Run("error.msg and error.kind variants", func(t *testing.T) {
+		span := translateSingleSpan(t, &pb.Span{
+			TraceID: 1, SpanID: 1, Error: 1,
+			Meta: map[string]string{"error.msg": "boom", "error.kind": "RuntimeError"},
+		})
+		require.Equal(t, 1, span.Events().Len())
+		assertExceptionAttr(t, span.Events().At(0), "exception.message", "boom")
+		assertExceptionAttr(t, span.Events().At(0), "exception.type", "RuntimeError")
+	})
+
+	t.Run("error.stacktrace alias", func(t *testing.T) {
+		span := translateSingleSpan(t, &pb.Span{
+			TraceID: 1, SpanID: 1, Error: 1,
+			Meta: map[string]string{"error.msg": "boom", "error.stacktrace": "at main.go:7"},
+		})
+		require.Equal(t, 1, span.Events().Len())
+		assertExceptionAttr(t, span.Events().At(0), "exception.stacktrace", "at main.go:7")
+		// The tag is consumed by the event, so it must not also land on the span as exception.stacktrace.
+		_, ok := span.Attributes().Get("exception.stacktrace")
+		assert.False(t, ok, "error.stacktrace leaked as a span attribute")
+	})
+
+	t.Run("no duplicate when exception event already present", func(t *testing.T) {
+		span := translateSingleSpan(t, &pb.Span{
+			TraceID: 1, SpanID: 1, Error: 1,
+			SpanEvents: []*pb.SpanEvent{{Name: "exception", TimeUnixNano: 5, Attributes: map[string]*pb.AttributeAnyValue{
+				"exception.message": {Type: pb.AttributeAnyValue_STRING_VALUE, StringValue: "from event"},
+			}}},
+			Meta: map[string]string{"error.message": "from tag"},
+		})
+		require.Equal(t, 1, span.Events().Len())
+		assertExceptionAttr(t, span.Events().At(0), "exception.message", "from event")
+		_, ok := span.Attributes().Get("error.message")
+		assert.False(t, ok, "error.message leaked as a span attribute")
+	})
+
+	t.Run("no event without error tags", func(t *testing.T) {
+		span := translateSingleSpan(t, &pb.Span{TraceID: 1, SpanID: 1})
+		assert.Equal(t, 0, span.Events().Len())
+	})
+}
+
+func TestSpanStatus(t *testing.T) {
+	// A Datadog error of 0 maps to the OTel default status (Unset); a non-zero error maps to Error.
+	nonError := translateSingleSpan(t, &pb.Span{TraceID: 1, SpanID: 1})
+	assert.Equal(t, ptrace.StatusCodeUnset, nonError.Status().Code())
+
+	errored := translateSingleSpan(t, &pb.Span{TraceID: 2, SpanID: 2, Error: 1})
+	assert.Equal(t, ptrace.StatusCodeError, errored.Status().Code())
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Small fixes: Datadog `error.*` tags on a span now become an OTel `exception` span event instead of span attributes, and spans without a Datadog error report an `Unset` status instead of `Ok`.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
