### PR TITLE
[receiver/awscloudwatch] add resource tag filter to auto-discovery

### DIFF
--- a/.chloggen/awscloudwatchreceiver-resource-tag-filter.yaml
+++ b/.chloggen/awscloudwatchreceiver-resource-tag-filter.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/aws_cloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a `resource_tags` filter to metrics auto-discovery so metrics are collected only for AWS resources whose tags match.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49951]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Because CloudWatch ListMetrics cannot filter by tag, matching resource ARNs are resolved via the
+  resourcegroupstaggingapi (GetResources) and discovered metrics are constrained to those resources.
+  Requires the tag:GetResources IAM permission. Disabled by default (no behavior change unless configured).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -96,11 +96,25 @@ Instead of listing metrics manually, the receiver can call [ListMetrics](https:/
 
 | Parameter              | Type            | Default | Description |
 | ---------------------- | --------------- | ------- | ----------- |
-| `filters`              | Object          | —       | Optional sub-block to narrow which metrics are discovered. If omitted, all metrics in all namespaces are discovered. |
-| `filters.namespace`    | String          | —       | Restrict discovery to a single namespace (e.g. `AWS/EC2`). |
-| `filters.metric_name`  | String          | —       | Restrict discovery to metrics with this name. |
-| `limit`                | Integer         | 100     | Maximum number of metrics to discover and scrape per collection cycle. |
-| `stats`                | List of strings | —       | Statistics to fetch for every discovered metric. Same values as in `queries`. |
+| `filters`               | Object          | —       | Optional sub-block to narrow which metrics are discovered. If omitted, all metrics in all namespaces are discovered. |
+| `filters.namespace`     | String          | —       | Restrict discovery to a single namespace (e.g. `AWS/EC2`). |
+| `filters.metric_name`   | String          | —       | Restrict discovery to metrics with this name. |
+| `filters.resource_tags` | List of objects | —       | Restrict discovery to metrics whose dimensions reference AWS resources carrying the given tags (see below). |
+| `limit`                 | Integer         | 100     | Maximum number of metrics to discover and scrape per collection cycle. |
+| `stats`                 | List of strings | —       | Statistics to fetch for every discovered metric. Same values as in `queries`. |
+
+##### Filtering by resource tags (`filters.resource_tags`)
+
+CloudWatch `ListMetrics` cannot filter by tag, so when `resource_tags` is set the receiver first resolves the ARNs of matching resources via the AWS [resourcegroupstaggingapi `GetResources`](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html) API, then keeps only discovered metrics whose dimension values reference one of those resources. This is useful for autoscaling fleets where the instance/resource IDs are not known ahead of time. Requires the `tag:GetResources` IAM permission in addition to the CloudWatch permissions.
+
+Each entry has:
+
+| Parameter | Type            | Description |
+| --------- | --------------- | ----------- |
+| `key`     | String          | Tag key to match. Required. |
+| `values`  | List of strings | Optional tag values; a resource matches if it has this key with one of these values. When omitted, any value matches. |
+
+Multiple entries are ANDed together (a resource must match every entry); the `values` within a single entry are ORed. These semantics mirror the underlying `GetResources` `TagFilters`. A discovered metric is kept when any of its dimension values matches a tagged resource, so metrics without dimensions are excluded when `resource_tags` is set.
 
 #### Statistics
 
@@ -176,6 +190,26 @@ awscloudwatch:
     discovery:
       filters:
         namespace: AWS/EC2
+      limit: 200
+```
+
+Auto-discover EC2 metrics only for instances tagged `Environment=production` (e.g. an autoscaling fleet):
+
+```yaml
+awscloudwatch:
+  region: us-east-1
+  metrics:
+    collection_interval: 5m
+    period: 300s
+    delay: 10m
+    discovery:
+      filters:
+        namespace: AWS/EC2
+        resource_tags:
+          - key: Environment
+            values: [production]
+          - key: Team
+            values: [backend, platform]
       limit: 200
 ```
 

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -65,6 +65,22 @@ type MetricsDiscoveryConfig struct {
 type MetricsDiscoveryFilters struct {
 	Namespace  string `mapstructure:"namespace"`
 	MetricName string `mapstructure:"metric_name"`
+	// ResourceTags restricts discovery to metrics whose dimensions reference AWS
+	// resources carrying the given tags. Because CloudWatch ListMetrics cannot
+	// filter by tag, matching resource ARNs are first resolved via the AWS
+	// resourcegroupstaggingapi (GetResources) and discovered metrics are then
+	// constrained to those resources. When empty, no tag-based filtering is applied.
+	ResourceTags []ResourceTagFilter `mapstructure:"resource_tags"`
+}
+
+// ResourceTagFilter selects AWS resources by tag. Its semantics mirror the
+// resourcegroupstaggingapi GetResources TagFilter: a resource matches when it
+// carries a tag with the given Key and, if Values is non-empty, one of the
+// listed Values. Multiple ResourceTagFilter entries are ANDed together, while
+// the Values within a single entry are ORed.
+type ResourceTagFilter struct {
+	Key    string   `mapstructure:"key"`
+	Values []string `mapstructure:"values"`
 }
 
 // MetricQuery defines a single CloudWatch metric to scrape via GetMetricData.
@@ -127,6 +143,7 @@ var (
 	errMetricsAndDiscoveryConfigured    = errors.New("metrics and discovery are mutually exclusive; set one or the other")
 	errInvalidDiscoveryLimit            = errors.New("metrics discovery limit must be greater than 0")
 	errEmptyStatName                    = errors.New("stat name must not be empty")
+	errEmptyTagFilterKey                = errors.New("resource_tags key must not be empty")
 	errCollectionIntervalLessThanPeriod = errors.New("metrics collection_interval must be greater than or equal to period")
 	errInitialLookbackAndStartFrom      = errors.New("both initial_lookback and start_from are configured, Only one or the other is permitted")
 	errInvalidInitialLookback           = errors.New("initial_lookback must be a positive duration (e.g. 1h)")
@@ -189,6 +206,13 @@ func (c *Config) validateMetricsConfig() error {
 		for j, st := range discovery.Stats {
 			if st == "" {
 				return fmt.Errorf("metrics.discovery.stats[%d]: %w", j, errEmptyStatName)
+			}
+		}
+		if f := discovery.Filters.Get(); f != nil {
+			for j, tf := range f.ResourceTags {
+				if tf.Key == "" {
+					return fmt.Errorf("metrics.discovery.filters.resource_tags[%d]: %w", j, errEmptyTagFilterKey)
+				}
 			}
 		}
 		return c.validateMetricsDurations()

--- a/receiver/awscloudwatchreceiver/config.schema.yaml
+++ b/receiver/awscloudwatchreceiver/config.schema.yaml
@@ -104,6 +104,21 @@ $defs:
         type: string
       namespace:
         type: string
+      resource_tags:
+        description: ResourceTags restricts discovery to metrics whose dimensions reference AWS resources carrying the given tags. Because CloudWatch ListMetrics cannot filter by tag, matching resource ARNs are first resolved via the AWS resourcegroupstaggingapi (GetResources) and discovered metrics are then constrained to those resources. When empty, no tag-based filtering is applied.
+        type: array
+        items:
+          $ref: resource_tag_filter
+  resource_tag_filter:
+    description: 'ResourceTagFilter selects AWS resources by tag. Its semantics mirror the resourcegroupstaggingapi GetResources TagFilter: a resource matches when it carries a tag with the given Key and, if Values is non-empty, one of the listed Values. Multiple ResourceTagFilter entries are ANDed together, while the Values within a single entry are ORed.'
+    type: object
+    properties:
+      key:
+        type: string
+      values:
+        type: array
+        items:
+          type: string
   stream_config:
     description: StreamConfig represents the configuration for the log stream filtering
     type: object

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -515,6 +515,31 @@ func TestValidateMetricsConfig(t *testing.T) {
 			expectedErr: errInvalidDiscoveryLimit,
 		},
 		{
+			name: "discovery with resource_tags valid",
+			config: withMetrics(MetricsConfig{
+				Period: 300 * time.Second,
+				Discovery: &MetricsDiscoveryConfig{
+					Limit: 100,
+					Filters: configoptional.Some(MetricsDiscoveryFilters{
+						Namespace:    "AWS/EC2",
+						ResourceTags: []ResourceTagFilter{{Key: "Environment", Values: []string{"production"}}},
+					}),
+				},
+			}),
+		},
+		{
+			name: "discovery resource_tags empty key",
+			config: withMetrics(MetricsConfig{
+				Discovery: &MetricsDiscoveryConfig{
+					Limit: 100,
+					Filters: configoptional.Some(MetricsDiscoveryFilters{
+						ResourceTags: []ResourceTagFilter{{Values: []string{"production"}}},
+					}),
+				},
+			}),
+			expectedErr: errEmptyTagFilterKey,
+		},
+		{
 			name: "collection interval too short",
 			config: withMetrics(MetricsConfig{
 				ControllerConfig: scraperhelper.ControllerConfig{CollectionInterval: 500 * time.Millisecond},

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.33.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.70.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.85.0
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.36.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.48.0
 	github.com/goccy/go-json v0.10.6
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.160.0

--- a/receiver/awscloudwatchreceiver/go.sum
+++ b/receiver/awscloudwatchreceiver/go.sum
@@ -22,6 +22,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.19 h1:bAdDl/
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.19/go.mod h1:KaUzbLxv4CeSxh6ZCl9B4m7CuFenS8kUEaDs+f/DQr4=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.1 h1:RmmWQPREQdk9U+PfqeHW3MqZaBaNK7TpV9W3RY+b+7g=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.14.1/go.mod h1:0A3W4F+68ZnNk5XcNL/e9HFMwnP8RlEicFfy6eOEDyw=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.36.2 h1:oRm0IE8VDp96+Jb962uA0lMBizn9mzD46/W30JeTKJM=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.36.2/go.mod h1:+39wzLNewz3MoCjhdLvW5nJnmHVayJeTAckPE6vWQ0w=
 github.com/aws/aws-sdk-go-v2/service/signin v1.8.0 h1:bSvKIoLuRGFqGwASgeCQncCJDi9YKKBDEmCEZzOX1uU=
 github.com/aws/aws-sdk-go-v2/service/signin v1.8.0/go.mod h1:9IqUlsJDbUPcg6cgx3WEzXdjrbWzLDQrak0aaSqlTcI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.36.0 h1:iivsh357VnfIc18IFWSuoyQEluf8frfWf4cL2Y0JUQw=

--- a/receiver/awscloudwatchreceiver/metrics.go
+++ b/receiver/awscloudwatchreceiver/metrics.go
@@ -15,6 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgttypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -48,11 +50,18 @@ type cloudWatchMetricsScraper struct {
 	metrics            []MetricQuery
 	discovery          *MetricsDiscoveryConfig
 	client             metricsClient
+	taggingClient      resourceTaggingClient
 }
 
 type metricsClient interface {
 	ListMetrics(ctx context.Context, params *cloudwatch.ListMetricsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricsOutput, error)
 	GetMetricData(ctx context.Context, params *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error)
+}
+
+// resourceTaggingClient is the subset of the AWS resourcegroupstaggingapi used to
+// resolve which resource ARNs match the configured resource_tags filters.
+type resourceTaggingClient interface {
+	GetResources(ctx context.Context, params *resourcegroupstaggingapi.GetResourcesInput, optFns ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error)
 }
 
 func newCloudWatchMetricsScraper(cfg *Config, settings receiver.Settings) *cloudWatchMetricsScraper {
@@ -89,6 +98,7 @@ func (s *cloudWatchMetricsScraper) start(ctx context.Context, _ component.Host) 
 		return err
 	}
 	s.client = cloudwatch.NewFromConfig(cfg)
+	s.taggingClient = resourcegroupstaggingapi.NewFromConfig(cfg)
 	return nil
 }
 
@@ -154,8 +164,11 @@ func alignTimeToPeriod(t time.Time, periodSec int64) time.Time {
 }
 
 // listMetrics discovers metrics via ListMetrics API, respecting discovery config (namespace, metric name, limit).
+// When resource_tags filters are configured, matching resource ARNs are first resolved via the
+// resourcegroupstaggingapi and discovered metrics are constrained to those resources.
 func (s *cloudWatchMetricsScraper) listMetrics(ctx context.Context) ([]MetricQuery, error) {
 	input := &cloudwatch.ListMetricsInput{}
+	var tagFilters []ResourceTagFilter
 	if f := s.discovery.Filters.Get(); f != nil {
 		if f.Namespace != "" {
 			input.Namespace = aws.String(f.Namespace)
@@ -163,6 +176,18 @@ func (s *cloudWatchMetricsScraper) listMetrics(ctx context.Context) ([]MetricQue
 		if f.MetricName != "" {
 			input.MetricName = aws.String(f.MetricName)
 		}
+		tagFilters = f.ResourceTags
+	}
+
+	// Resolve the set of resource identifiers whose tags match, if tag filtering is requested.
+	var allowedResourceIDs map[string]struct{}
+	if len(tagFilters) > 0 {
+		ids, err := s.resolveResourceIDsByTags(ctx, tagFilters)
+		if err != nil {
+			return nil, fmt.Errorf("resolve resource tags: %w", err)
+		}
+		s.settings.Logger.Debug("resolved tagged resources", zap.Int("count", len(ids)))
+		allowedResourceIDs = ids
 	}
 
 	var out []MetricQuery
@@ -174,13 +199,18 @@ func (s *cloudWatchMetricsScraper) listMetrics(ctx context.Context) ([]MetricQue
 			return nil, err
 		}
 		for _, met := range resp.Metrics {
+			dims := dimensionsToMap(met.Dimensions)
+			// When tag filtering is active, keep only metrics whose dimensions reference a matching resource.
+			if allowedResourceIDs != nil && !dimensionsMatchResource(dims, allowedResourceIDs) {
+				continue
+			}
 			if len(out) >= s.discovery.Limit {
 				return out, nil
 			}
 			q := MetricQuery{
 				Namespace:  aws.ToString(met.Namespace),
 				MetricName: aws.ToString(met.MetricName),
-				Dimensions: dimensionsToMap(met.Dimensions),
+				Dimensions: dims,
 				Stats:      s.discovery.Stats,
 			}
 			out = append(out, q)
@@ -191,6 +221,83 @@ func (s *cloudWatchMetricsScraper) listMetrics(ctx context.Context) ([]MetricQue
 		}
 	}
 	return out, nil
+}
+
+// resolveResourceIDsByTags calls the resourcegroupstaggingapi GetResources API with the configured
+// tag filters and returns the set of candidate resource identifiers extracted from the matching ARNs.
+// GetResources applies AND semantics across TagFilters and OR semantics within a filter's Values.
+func (s *cloudWatchMetricsScraper) resolveResourceIDsByTags(ctx context.Context, filters []ResourceTagFilter) (map[string]struct{}, error) {
+	tagFilters := make([]rgttypes.TagFilter, 0, len(filters))
+	for _, f := range filters {
+		tf := rgttypes.TagFilter{Key: aws.String(f.Key)}
+		if len(f.Values) > 0 {
+			tf.Values = f.Values
+		}
+		tagFilters = append(tagFilters, tf)
+	}
+
+	ids := make(map[string]struct{})
+	input := &resourcegroupstaggingapi.GetResourcesInput{TagFilters: tagFilters}
+	for {
+		resp, err := s.taggingClient.GetResources(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range resp.ResourceTagMappingList {
+			for _, id := range resourceIDsFromARN(aws.ToString(m.ResourceARN)) {
+				ids[id] = struct{}{}
+			}
+		}
+		// GetResources signals the end of pagination with a nil or empty PaginationToken.
+		if aws.ToString(resp.PaginationToken) == "" {
+			break
+		}
+		input.PaginationToken = resp.PaginationToken
+	}
+	return ids, nil
+}
+
+// resourceIDsFromARN extracts candidate resource identifiers from an ARN so they can be matched
+// against CloudWatch metric dimension values. Because the ARN resource segment does not always map
+// one-to-one to a dimension value (e.g. ELB dimensions carry "app/my-lb/abc123" while an EC2
+// InstanceId dimension carries just "i-abc"), several forms are produced: the full ARN, the resource
+// segment, the segment with its resource-type prefix stripped, and the last path/colon segment.
+// This is a best-effort heuristic; per-namespace ARN-to-dimension mapping (as in YACE) may refine it.
+func resourceIDsFromARN(arn string) []string {
+	if arn == "" {
+		return nil
+	}
+	set := map[string]struct{}{arn: {}}
+	// An ARN is arn:partition:service:region:account-id:resource; the resource segment is everything
+	// after the fifth colon and may itself contain "/" or ":" separators.
+	parts := strings.SplitN(arn, ":", 6)
+	if len(parts) == 6 {
+		resource := parts[5]
+		if resource != "" {
+			set[resource] = struct{}{}
+		}
+		if i := strings.IndexAny(resource, "/:"); i >= 0 && i+1 < len(resource) {
+			set[resource[i+1:]] = struct{}{}
+		}
+		if i := strings.LastIndexAny(resource, "/:"); i >= 0 && i+1 < len(resource) {
+			set[resource[i+1:]] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	return out
+}
+
+// dimensionsMatchResource reports whether any dimension value references one of the allowed resources.
+func dimensionsMatchResource(dims map[string]string, allowed map[string]struct{}) bool {
+	for _, v := range dims {
+		if _, ok := allowed[v]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func dimensionsToMap(dims []types.Dimension) map[string]string {

--- a/receiver/awscloudwatchreceiver/metrics_test.go
+++ b/receiver/awscloudwatchreceiver/metrics_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgttypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -35,6 +37,16 @@ func (m *mockMetricsClient) ListMetrics(ctx context.Context, params *cloudwatch.
 func (m *mockMetricsClient) GetMetricData(ctx context.Context, params *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
 	args := m.Called(ctx, params, optFns)
 	return args.Get(0).(*cloudwatch.GetMetricDataOutput), args.Error(1)
+}
+
+// mockTaggingClient implements resourceTaggingClient for testing.
+type mockTaggingClient struct {
+	mock.Mock
+}
+
+func (m *mockTaggingClient) GetResources(ctx context.Context, params *resourcegroupstaggingapi.GetResourcesInput, optFns ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*resourcegroupstaggingapi.GetResourcesOutput), args.Error(1)
 }
 
 func testScraper(cfg *Config) *cloudWatchMetricsScraper {
@@ -647,4 +659,200 @@ func TestScrape_DiscoveryError(t *testing.T) {
 
 	_, err := scr.scrape(t.Context())
 	require.ErrorContains(t, err, "list metrics")
+}
+
+// --- resource tag filtering tests ---
+
+func TestResourceIDsFromARN(t *testing.T) {
+	cases := []struct {
+		name string
+		arn  string
+		want []string // identifiers that must be present in the result set
+	}{
+		{
+			name: "ec2 instance",
+			arn:  "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
+			want: []string{"i-1234567890abcdef0"},
+		},
+		{
+			name: "application load balancer keeps app path",
+			arn:  "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-lb/abc123",
+			want: []string{"app/my-lb/abc123"},
+		},
+		{
+			name: "dynamodb table",
+			arn:  "arn:aws:dynamodb:us-east-1:123456789012:table/my-table",
+			want: []string{"my-table"},
+		},
+		{
+			name: "lambda function colon separator",
+			arn:  "arn:aws:lambda:us-east-1:123456789012:function:my-func",
+			want: []string{"my-func"},
+		},
+		{
+			name: "empty arn",
+			arn:  "",
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resourceIDsFromARN(tc.arn)
+			set := map[string]struct{}{}
+			for _, id := range got {
+				set[id] = struct{}{}
+			}
+			for _, w := range tc.want {
+				_, ok := set[w]
+				require.Truef(t, ok, "expected %q among %v", w, got)
+			}
+		})
+	}
+}
+
+func TestDimensionsMatchResource(t *testing.T) {
+	allowed := map[string]struct{}{"i-abc": {}, "app/my-lb/abc123": {}}
+	require.True(t, dimensionsMatchResource(map[string]string{"InstanceId": "i-abc"}, allowed))
+	require.True(t, dimensionsMatchResource(map[string]string{"LoadBalancer": "app/my-lb/abc123"}, allowed))
+	require.False(t, dimensionsMatchResource(map[string]string{"InstanceId": "i-zzz"}, allowed))
+	require.False(t, dimensionsMatchResource(nil, allowed))
+}
+
+// TestListMetrics_ResourceTagFilter proves tag-filtered discovery: only metrics whose dimensions
+// reference a tag-matched resource are kept, and the tag filters are forwarded to GetResources.
+func TestListMetrics_ResourceTagFilter(t *testing.T) {
+	mc := &mockMetricsClient{}
+	mc.On("ListMetrics", mock.Anything, mock.Anything, mock.Anything).Return(
+		&cloudwatch.ListMetricsOutput{
+			Metrics: []types.Metric{
+				{
+					Namespace:  aws.String("AWS/EC2"),
+					MetricName: aws.String("CPUUtilization"),
+					Dimensions: []types.Dimension{{Name: aws.String("InstanceId"), Value: aws.String("i-match")}},
+				},
+				{
+					Namespace:  aws.String("AWS/EC2"),
+					MetricName: aws.String("CPUUtilization"),
+					Dimensions: []types.Dimension{{Name: aws.String("InstanceId"), Value: aws.String("i-nomatch")}},
+				},
+				{
+					// No dimensions: cannot be tied to a resource, so it must be excluded.
+					Namespace:  aws.String("AWS/EC2"),
+					MetricName: aws.String("CPUUtilization"),
+				},
+			},
+			NextToken: nil,
+		}, nil,
+	)
+
+	tc := &mockTaggingClient{}
+	tc.On("GetResources", mock.Anything, mock.MatchedBy(func(p *resourcegroupstaggingapi.GetResourcesInput) bool {
+		return len(p.TagFilters) == 1 &&
+			aws.ToString(p.TagFilters[0].Key) == "Environment" &&
+			len(p.TagFilters[0].Values) == 1 && p.TagFilters[0].Values[0] == "production"
+	}), mock.Anything).Return(
+		&resourcegroupstaggingapi.GetResourcesOutput{
+			ResourceTagMappingList: []rgttypes.ResourceTagMapping{
+				{ResourceARN: aws.String("arn:aws:ec2:us-east-1:123456789012:instance/i-match")},
+			},
+		}, nil,
+	)
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{
+		Discovery: &MetricsDiscoveryConfig{
+			Limit: 100,
+			Filters: configoptional.Some(MetricsDiscoveryFilters{
+				Namespace: "AWS/EC2",
+				ResourceTags: []ResourceTagFilter{
+					{Key: "Environment", Values: []string{"production"}},
+				},
+			}),
+		},
+	}}
+	scr := testScraper(cfg)
+	scr.client = mc
+	scr.taggingClient = tc
+
+	out, err := scr.listMetrics(t.Context())
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, "i-match", out[0].Dimensions["InstanceId"])
+	mc.AssertExpectations(t)
+	tc.AssertExpectations(t)
+}
+
+func TestListMetrics_ResourceTagFilter_Paginated(t *testing.T) {
+	mc := &mockMetricsClient{}
+	mc.On("ListMetrics", mock.Anything, mock.Anything, mock.Anything).Return(
+		&cloudwatch.ListMetricsOutput{
+			Metrics: []types.Metric{
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("CPUUtilization"),
+					Dimensions: []types.Dimension{{Name: aws.String("InstanceId"), Value: aws.String("i-a")}}},
+				{Namespace: aws.String("AWS/EC2"), MetricName: aws.String("CPUUtilization"),
+					Dimensions: []types.Dimension{{Name: aws.String("InstanceId"), Value: aws.String("i-b")}}},
+			},
+		}, nil,
+	)
+
+	token := "page2"
+	tc := &mockTaggingClient{}
+	tc.On("GetResources", mock.Anything, mock.MatchedBy(func(p *resourcegroupstaggingapi.GetResourcesInput) bool {
+		return p.PaginationToken == nil
+	}), mock.Anything).Return(
+		&resourcegroupstaggingapi.GetResourcesOutput{
+			ResourceTagMappingList: []rgttypes.ResourceTagMapping{
+				{ResourceARN: aws.String("arn:aws:ec2:us-east-1:123456789012:instance/i-a")},
+			},
+			PaginationToken: &token,
+		}, nil,
+	).Once()
+	tc.On("GetResources", mock.Anything, mock.MatchedBy(func(p *resourcegroupstaggingapi.GetResourcesInput) bool {
+		return p.PaginationToken != nil && *p.PaginationToken == token
+	}), mock.Anything).Return(
+		&resourcegroupstaggingapi.GetResourcesOutput{
+			ResourceTagMappingList: []rgttypes.ResourceTagMapping{
+				{ResourceARN: aws.String("arn:aws:ec2:us-east-1:123456789012:instance/i-b")},
+			},
+			PaginationToken: aws.String(""),
+		}, nil,
+	).Once()
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{
+		Discovery: &MetricsDiscoveryConfig{
+			Limit: 100,
+			Filters: configoptional.Some(MetricsDiscoveryFilters{
+				ResourceTags: []ResourceTagFilter{{Key: "Team"}},
+			}),
+		},
+	}}
+	scr := testScraper(cfg)
+	scr.client = mc
+	scr.taggingClient = tc
+
+	out, err := scr.listMetrics(t.Context())
+	require.NoError(t, err)
+	require.Len(t, out, 2) // both instances tagged across two pages
+	tc.AssertExpectations(t)
+}
+
+func TestListMetrics_ResourceTagFilter_Error(t *testing.T) {
+	tc := &mockTaggingClient{}
+	tc.On("GetResources", mock.Anything, mock.Anything, mock.Anything).Return(
+		&resourcegroupstaggingapi.GetResourcesOutput{}, errors.New("tagging API error"),
+	)
+
+	cfg := &Config{Region: "us-east-1", Metrics: MetricsConfig{
+		Discovery: &MetricsDiscoveryConfig{
+			Limit: 100,
+			Filters: configoptional.Some(MetricsDiscoveryFilters{
+				ResourceTags: []ResourceTagFilter{{Key: "Environment", Values: []string{"production"}}},
+			}),
+		},
+	}}
+	scr := testScraper(cfg)
+	scr.client = &mockMetricsClient{}
+	scr.taggingClient = tc
+
+	_, err := scr.listMetrics(t.Context())
+	require.ErrorContains(t, err, "resolve resource tags")
 }


### PR DESCRIPTION
#### Description

Adds an optional `resource_tags` filter to the metrics auto-discovery `filters` block of the awscloudwatch receiver, so metrics are collected only for AWS resources whose tags match — needed for autoscaling fleets where static dimension IDs (e.g. `InstanceId`) are not known ahead of time.

Because CloudWatch `ListMetrics` cannot filter by tag, the discovery path first resolves the ARNs of matching resources via the AWS `resourcegroupstaggingapi` [`GetResources`](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html) API, then keeps only discovered metrics whose dimension values reference one of those resources. This follows the cloudwatch_exporter `aws_tag_select` / YACE `searchTags` precedent.

Config shape (greenlit by @dyl10s in #49951 — "could be added to the auto discovery filters configuration"):

```yaml
metrics:
  discovery:
    filters:
      namespace: AWS/EC2
      resource_tags:
        - key: Environment
          values: [production]
        - key: Team
          values: [backend, platform]
    limit: 200
```

Semantics mirror the underlying `GetResources` `TagFilters`: multiple entries are ANDed, `values` within an entry are ORed, and an entry with no `values` matches any value for that key. Disabled by default — no behavior change unless configured. Requires the `tag:GetResources` IAM permission in addition to the existing CloudWatch permissions.

The new `resourcegroupstaggingapi` client is constructed alongside the existing CloudWatch client in the metrics scraper's `start`, using the same `config.LoadDefaultConfig` options.

#### Link to tracking issue
Fixes #49951

#### Testing

`cd receiver/awscloudwatchreceiver && go build ./... && go test ./...` — all pass.

New unit tests use a mocked tagging client (`mockTaggingClient`, mirroring the existing `mockMetricsClient` pattern):
- `TestListMetrics_ResourceTagFilter` — proves tag-filtered discovery: only metrics whose dimensions reference a tag-matched resource are kept (non-matching and dimensionless metrics excluded), and the tag filters are forwarded to `GetResources`.
- `TestListMetrics_ResourceTagFilter_Paginated` — `GetResources` pagination across pages.
- `TestListMetrics_ResourceTagFilter_Error` — error propagation.
- `TestResourceIDsFromARN` / `TestDimensionsMatchResource` — ARN-to-dimension matching heuristic (EC2, ALB, DynamoDB, Lambda ARN forms).
- Config validation cases for valid `resource_tags` and empty-key rejection.

#### Documentation

README: new `filters.resource_tags` row, a dedicated subsection documenting semantics and the `tag:GetResources` IAM requirement, and a filtering example. `config.schema.yaml` regenerated via `make generate-schemas`. `.chloggen/` enhancement fragment added.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

---

cc code owners @schmikei @dyl10s for review.

**Note on the ARN-to-dimension mapping:** matching is a best-effort heuristic (full ARN, resource segment, prefix-stripped, and last path segment) that covers common namespaces (EC2 `InstanceId`, ELB `LoadBalancer`, DynamoDB `TableName`, Lambda, etc.). It has been verified against mocked responses, not live AWS. Happy to refine toward per-namespace ARN→dimension mapping (as YACE does) or adjust the config placement if preferred.
