### PR TITLE
[chore] [exporter/loadbalancingexporter] Migrate k8sResolver ListWatch to context-aware funcs

### DIFF
--- a/exporter/loadbalancingexporter/resolver_k8s.go
+++ b/exporter/loadbalancingexporter/resolver_k8s.go
@@ -161,15 +161,15 @@ func (r *k8sResolver) start(_ context.Context) error {
 		// Create the epsListWatcher now that we have a client
 		epsSelector := fmt.Sprintf("kubernetes.io/service-name=%s", r.svcName)
 		r.epsListWatcher = &cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = epsSelector
 				options.TimeoutSeconds = ptr.To[int64](int64(r.lwTimeout.Seconds()))
-				return r.client.DiscoveryV1().EndpointSlices(r.svcNs).List(context.Background(), options)
+				return r.client.DiscoveryV1().EndpointSlices(r.svcNs).List(ctx, options)
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = epsSelector
 				options.TimeoutSeconds = ptr.To[int64](int64(r.lwTimeout.Seconds()))
-				return r.client.DiscoveryV1().EndpointSlices(r.svcNs).Watch(context.Background(), options)
+				return r.client.DiscoveryV1().EndpointSlices(r.svcNs).Watch(ctx, options)
 			},
 		}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR replaces the deprecated `ListFunc`/`WatchFunc` fields of `cache.ListWatch` with `ListWithContextFunc`/`WatchFuncWithContext`, and threads the informer-supplied context into the EndpointSlices List/Watch calls instead of using `context.Background()`.

The informer is started via `Run(stopCh)`, which internally derives its context from `stopCh`, so the context passed to these funcs is cancelled on shutdown. This gives a cancelable context tied to the resolver's lifecycle without changing `start`'s signature or storing a context field.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50424

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~
<!--Describe the documentation added.-->
#### Documentation
~
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
