### PR TITLE
[receiver/awscloudwatch] Enrich log records with log group tags

### DIFF
--- a/.chloggen/awscloudwatch-loggroup-tags.yaml
+++ b/.chloggen/awscloudwatch-loggroup-tags.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/aws_cloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add optional log group tag enrichment to the logs receiver, attaching CloudWatch log group tags as resource attributes on emitted log records.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48574]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Enabled per log group via `include_tags` (default `false`) on the `autodiscover` and `named` group
+  configs. Tags can be filtered with `tag_names` (allowlist) or `tag_prefix` (mutually exclusive), and the
+  resource-attribute prefix is configurable via `tag_attribute_prefix` (default `cloudwatch.log.group.tag.`).
+  When enabled, the receiver calls `ListTagsForResource`, so the `logs:ListTagsForResource` IAM permission is
+  required. Disabled by default; existing behavior is unchanged.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -61,11 +61,32 @@ The receiver makes requests to the `sts.GetCallerIdentity` API endpoint, which i
   - `streams`: (optional) If `streams` is omitted, then all streams will be attempted to retrieve events from.
     - `names`: A list of full log stream names to filter the discovered log groups to collect from.
     - `prefixes`: A list of prefixes to filter the discovered log groups to collect from.
+  - `include_tags`, `tag_names`, `tag_prefix`, `tag_attribute_prefix`: (optional) Enrich emitted log records with the source log group's CloudWatch tags. See [Log Group Tag Enrichment](#log-group-tag-enrichment).
 - `named`
   - This is a map of log group name to stream filtering options
     - `streams`: (optional)
       - `names`: A list of full log stream names to filter the discovered log groups to collect from.
       - `prefixes`: A list of prefixes to filter the discovered log groups to collect from.
+    - `include_tags`, `tag_names`, `tag_prefix`, `tag_attribute_prefix`: (optional) Enrich emitted log records with the source log group's CloudWatch tags. See [Log Group Tag Enrichment](#log-group-tag-enrichment).
+
+### Log Group Tag Enrichment
+
+Each log group can optionally have its [CloudWatch tags](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#log-group-tagging) attached as resource attributes on the log records it produces. This is useful for tenant identification, retention policy, PII classification, and routing decisions in multi-tenant/cross-account (OAM) pipelines. It is disabled by default; when disabled the receiver makes no tag API calls and behaves exactly as before.
+
+| Parameter              | Type       | Default                     | Description                                                                                                                                                                       |
+|------------------------|------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `include_tags`         | bool       | `false`                     | Enables tag enrichment. When enabled, the receiver calls `ListTagsForResource` for each log group and caches the tags, refreshing them each discovery/poll cycle.                |
+| `tag_names`            | []string   | `[]` (all tags)             | Explicit allowlist of tag keys to include. Mutually exclusive with `tag_prefix`.                                                                                                 |
+| `tag_prefix`           | string     | `""` (all tags)             | Only include tags whose key starts with this prefix. Mutually exclusive with `tag_names`.                                                                                        |
+| `tag_attribute_prefix` | string     | `cloudwatch.log.group.tag.` | Prefix prepended to tag keys when creating resource attributes. Set to `""` to pass tags through as-is (as semantic attributes usable directly by downstream routing).           |
+
+If neither `tag_names` nor `tag_prefix` is set, all tags are included. Filtering keeps attribute cardinality under control and avoids propagating AWS-managed tags (e.g. `aws:cloudformation:*`).
+
+For example, a log group `/aws/lambda/my-service` tagged `team=messaging` with `tag_names: ["team"]` and the default `tag_attribute_prefix` yields the resource attribute `cloudwatch.log.group.tag.team=messaging`, in addition to the base attributes (`aws.region`, `cloudwatch.log.group.name`, `cloudwatch.log.stream`).
+
+#### Required IAM permissions
+
+Tag enrichment requires the [`logs:ListTagsForResource`](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ListTagsForResource.html) permission in addition to the permissions the receiver already needs (`logs:DescribeLogGroups`, `logs:FilterLogEvents`). For `named` groups, `logs:DescribeLogGroups` is also used to resolve each group's ARN.
 
 ### Metrics collection
 
@@ -208,6 +229,23 @@ awscloudwatch:
         include_linked_accounts: true
         prefix: /aws/lambda/
 ```
+
+#### Logs Autodiscovery with Tag Enrichment Example
+
+```yaml
+awscloudwatch:
+  region: eu-west-1
+  logs:
+    poll_interval: 1m
+    groups:
+      autodiscover:
+        limit: 100
+        prefix: /aws/lambda/
+        include_tags: true
+        tag_names: ["team", "environment"]
+```
+
+Emitted log records gain the resource attributes `cloudwatch.log.group.tag.team` and `cloudwatch.log.group.tag.environment`. Set `tag_attribute_prefix: ""` to pass the tags through as `team` and `environment` directly.
 
 #### Logs Named Groups Example
 

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -161,15 +162,10 @@ func (t LogGroupTagsConfig) selectTags(raw map[string]string) map[string]string 
 	attrPrefix := t.attributePrefix()
 	out := make(map[string]string, len(raw))
 	for k, v := range raw {
-		include := false
+		var include bool
 		switch {
 		case len(t.TagNames) > 0:
-			for _, name := range t.TagNames {
-				if name == k {
-					include = true
-					break
-				}
-			}
+			include = slices.Contains(t.TagNames, k)
 		case t.TagPrefix != "":
 			include = strings.HasPrefix(k, t.TagPrefix)
 		default:

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -98,18 +99,98 @@ type GroupConfig struct {
 
 // AutodiscoverConfig is the configuration for the autodiscovery functionality of log groups
 type AutodiscoverConfig struct {
-	Prefix                string       `mapstructure:"prefix"`
-	Pattern               string       `mapstructure:"pattern"`
-	Limit                 int          `mapstructure:"limit"`
-	Streams               StreamConfig `mapstructure:"streams"`
-	AccountIdentifiers    []string     `mapstructure:"account_identifiers"`
-	IncludeLinkedAccounts *bool        `mapstructure:"include_linked_accounts"`
+	Prefix                string             `mapstructure:"prefix"`
+	Pattern               string             `mapstructure:"pattern"`
+	Limit                 int                `mapstructure:"limit"`
+	Streams               StreamConfig       `mapstructure:"streams"`
+	AccountIdentifiers    []string           `mapstructure:"account_identifiers"`
+	IncludeLinkedAccounts *bool              `mapstructure:"include_linked_accounts"`
+	Tags                  LogGroupTagsConfig `mapstructure:",squash"`
 }
 
 // StreamConfig represents the configuration for the log stream filtering
 type StreamConfig struct {
-	Prefixes []*string `mapstructure:"prefixes"`
-	Names    []*string `mapstructure:"names"`
+	Prefixes []*string          `mapstructure:"prefixes"`
+	Names    []*string          `mapstructure:"names"`
+	Tags     LogGroupTagsConfig `mapstructure:",squash"`
+}
+
+// defaultTagAttributePrefix is prepended to log group tag keys when they are
+// attached as resource attributes, unless tag_attribute_prefix is set explicitly
+// (including to the empty string, which passes tags through as-is).
+const defaultTagAttributePrefix = "cloudwatch.log.group.tag."
+
+// LogGroupTagsConfig configures optional enrichment of emitted log records with
+// the source log group's CloudWatch tags. It is disabled by default; when
+// enabled the receiver calls ListTagsForResource for each log group during
+// discovery and attaches the selected tags as resource attributes.
+type LogGroupTagsConfig struct {
+	// IncludeTags gates tag enrichment. When false (default) the receiver
+	// behaves exactly as before and makes no tag API calls.
+	IncludeTags bool `mapstructure:"include_tags"`
+	// TagNames is an explicit allowlist of tag keys to include. Mutually
+	// exclusive with TagPrefix. When both TagNames and TagPrefix are empty all
+	// tags are included.
+	TagNames []string `mapstructure:"tag_names"`
+	// TagPrefix includes only tags whose key starts with this prefix. Mutually
+	// exclusive with TagNames.
+	TagPrefix string `mapstructure:"tag_prefix"`
+	// TagAttributePrefix is prepended to each tag key when creating the resource
+	// attribute. A nil pointer applies defaultTagAttributePrefix; an explicit
+	// empty string passes tags through as-is. Set via mapstructure so the
+	// distinction between "unset" and "empty" is preserved.
+	TagAttributePrefix *string `mapstructure:"tag_attribute_prefix"`
+}
+
+// attributePrefix returns the effective prefix applied to tag-derived resource
+// attribute keys, defaulting to defaultTagAttributePrefix when unset.
+func (t LogGroupTagsConfig) attributePrefix() string {
+	if t.TagAttributePrefix == nil {
+		return defaultTagAttributePrefix
+	}
+	return *t.TagAttributePrefix
+}
+
+// selectTags filters the raw tag map according to the configured allowlist or
+// prefix and returns a new map keyed by the resource-attribute name (with the
+// configured attribute prefix applied).
+func (t LogGroupTagsConfig) selectTags(raw map[string]string) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	attrPrefix := t.attributePrefix()
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		include := false
+		switch {
+		case len(t.TagNames) > 0:
+			for _, name := range t.TagNames {
+				if name == k {
+					include = true
+					break
+				}
+			}
+		case t.TagPrefix != "":
+			include = strings.HasPrefix(k, t.TagPrefix)
+		default:
+			include = true
+		}
+		if include {
+			out[attrPrefix+k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// validate ensures tag_names and tag_prefix are not both set.
+func (t LogGroupTagsConfig) validate() error {
+	if len(t.TagNames) > 0 && t.TagPrefix != "" {
+		return errTagNamesAndPrefix
+	}
+	return nil
 }
 
 var (
@@ -130,6 +211,7 @@ var (
 	errCollectionIntervalLessThanPeriod = errors.New("metrics collection_interval must be greater than or equal to period")
 	errInitialLookbackAndStartFrom      = errors.New("both initial_lookback and start_from are configured, Only one or the other is permitted")
 	errInvalidInitialLookback           = errors.New("initial_lookback must be a positive duration (e.g. 1h)")
+	errTagNamesAndPrefix                = errors.New("tag_names and tag_prefix are mutually exclusive; set one or the other")
 )
 
 // Validate overrides the embedded ControllerConfig.Validate so that a zero CollectionInterval
@@ -268,6 +350,12 @@ func (c *GroupConfig) validate() error {
 		return validateAutodiscover(*c.AutodiscoverConfig)
 	}
 
+	for _, sc := range c.NamedConfigs {
+		if err := sc.Tags.validate(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -278,5 +366,5 @@ func validateAutodiscover(cfg AutodiscoverConfig) error {
 	if cfg.Pattern != "" && cfg.Prefix != "" {
 		return errPrefixAndPatternConfigured
 	}
-	return nil
+	return cfg.Tags.validate()
 }

--- a/receiver/awscloudwatchreceiver/config.schema.yaml
+++ b/receiver/awscloudwatchreceiver/config.schema.yaml
@@ -18,6 +18,8 @@ $defs:
         type: string
       streams:
         $ref: stream_config
+    allOf:
+      - $ref: log_group_tags_config
   group_config:
     description: GroupConfig is the configuration for log group collection
     type: object
@@ -29,6 +31,25 @@ $defs:
         type: object
         additionalProperties:
           $ref: stream_config
+  log_group_tags_config:
+    description: LogGroupTagsConfig configures optional enrichment of emitted log records with the source log group's CloudWatch tags. It is disabled by default; when enabled the receiver calls ListTagsForResource for each log group during discovery and attaches the selected tags as resource attributes.
+    type: object
+    properties:
+      include_tags:
+        description: IncludeTags gates tag enrichment. When false (default) the receiver behaves exactly as before and makes no tag API calls.
+        type: boolean
+      tag_attribute_prefix:
+        description: TagAttributePrefix is prepended to each tag key when creating the resource attribute. A nil pointer applies defaultTagAttributePrefix; an explicit empty string passes tags through as-is. Set via mapstructure so the distinction between "unset" and "empty" is preserved.
+        x-pointer: true
+        type: string
+      tag_names:
+        description: TagNames is an explicit allowlist of tag keys to include. Mutually exclusive with TagPrefix. When both TagNames and TagPrefix are empty all tags are included.
+        type: array
+        items:
+          type: string
+      tag_prefix:
+        description: TagPrefix includes only tags whose key starts with this prefix. Mutually exclusive with TagNames.
+        type: string
   logs_config:
     description: LogsConfig is the configuration for the logs portion of this receiver
     type: object
@@ -118,6 +139,8 @@ $defs:
         items:
           x-pointer: true
           type: string
+    allOf:
+      - $ref: log_group_tags_config
 description: Config is the overall config structure for the awscloudwatchreceiver
 type: object
 properties:

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -693,7 +693,7 @@ func TestLogGroupTagsConfigSelectTags(t *testing.T) {
 		},
 		{
 			name: "allowlist passthrough (empty attribute prefix)",
-			cfg:  LogGroupTagsConfig{IncludeTags: true, TagNames: []string{"team", "environment"}, TagAttributePrefix: stringPtr("")},
+			cfg:  LogGroupTagsConfig{IncludeTags: true, TagNames: []string{"team", "environment"}, TagAttributePrefix: aws.String("")},
 			expected: map[string]string{
 				"team":        "messaging",
 				"environment": "production",
@@ -701,7 +701,7 @@ func TestLogGroupTagsConfigSelectTags(t *testing.T) {
 		},
 		{
 			name: "tag prefix with custom attribute prefix",
-			cfg:  LogGroupTagsConfig{IncludeTags: true, TagPrefix: "log.", TagAttributePrefix: stringPtr("org.routing.")},
+			cfg:  LogGroupTagsConfig{IncludeTags: true, TagPrefix: "log.", TagAttributePrefix: aws.String("org.routing.")},
 			expected: map[string]string{
 				"org.routing.log.tenant": "acme",
 			},
@@ -721,9 +721,5 @@ func TestLogGroupTagsConfigSelectTags(t *testing.T) {
 
 	require.Nil(t, LogGroupTagsConfig{IncludeTags: true}.selectTags(nil))
 	require.Equal(t, defaultTagAttributePrefix, LogGroupTagsConfig{}.attributePrefix())
-	require.Empty(t, LogGroupTagsConfig{TagAttributePrefix: stringPtr("")}.attributePrefix())
-}
-
-func stringPtr(s string) *string {
-	return &s
+	require.Empty(t, LogGroupTagsConfig{TagAttributePrefix: aws.String("")}.attributePrefix())
 }

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -721,7 +721,7 @@ func TestLogGroupTagsConfigSelectTags(t *testing.T) {
 
 	require.Nil(t, LogGroupTagsConfig{IncludeTags: true}.selectTags(nil))
 	require.Equal(t, defaultTagAttributePrefix, LogGroupTagsConfig{}.attributePrefix())
-	require.Equal(t, "", LogGroupTagsConfig{TagAttributePrefix: stringPtr("")}.attributePrefix())
+	require.Empty(t, LogGroupTagsConfig{TagAttributePrefix: stringPtr("")}.attributePrefix())
 }
 
 func stringPtr(s string) *string {

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -176,6 +176,69 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErr: errInvalidInitialLookback,
 		},
+		{
+			name: "Autodiscover tag_names and tag_prefix mutually exclusive",
+			config: Config{
+				Region: "us-east-1",
+				Logs: LogsConfig{
+					MaxEventsPerRequest: defaultEventLimit,
+					PollInterval:        defaultPollInterval,
+					Groups: GroupConfig{
+						AutodiscoverConfig: &AutodiscoverConfig{
+							Limit: defaultLogGroupLimit,
+							Tags: LogGroupTagsConfig{
+								IncludeTags: true,
+								TagNames:    []string{"team"},
+								TagPrefix:   "log.",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errTagNamesAndPrefix,
+		},
+		{
+			name: "Named tag_names and tag_prefix mutually exclusive",
+			config: Config{
+				Region: "us-east-1",
+				Logs: LogsConfig{
+					MaxEventsPerRequest: defaultEventLimit,
+					PollInterval:        defaultPollInterval,
+					Groups: GroupConfig{
+						NamedConfigs: map[string]StreamConfig{
+							"some-log-group": {
+								Names: []*string{aws.String("some-lg-name")},
+								Tags: LogGroupTagsConfig{
+									IncludeTags: true,
+									TagNames:    []string{"team"},
+									TagPrefix:   "log.",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errTagNamesAndPrefix,
+		},
+		{
+			name: "Autodiscover tags valid with tag_names only",
+			config: Config{
+				Region: "us-east-1",
+				Logs: LogsConfig{
+					MaxEventsPerRequest: defaultEventLimit,
+					PollInterval:        defaultPollInterval,
+					Groups: GroupConfig{
+						AutodiscoverConfig: &AutodiscoverConfig{
+							Limit: defaultLogGroupLimit,
+							Tags: LogGroupTagsConfig{
+								IncludeTags: true,
+								TagNames:    []string{"team", "environment"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -595,4 +658,72 @@ func TestValidateMetricsConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLogGroupTagsConfigSelectTags(t *testing.T) {
+	raw := map[string]string{
+		"team":                        "messaging",
+		"environment":                 "production",
+		"log.tenant":                  "acme",
+		"aws:cloudformation:stack-id": "abc",
+	}
+
+	cases := []struct {
+		name     string
+		cfg      LogGroupTagsConfig
+		expected map[string]string
+	}{
+		{
+			name: "all tags with default prefix",
+			cfg:  LogGroupTagsConfig{IncludeTags: true},
+			expected: map[string]string{
+				defaultTagAttributePrefix + "team":                        "messaging",
+				defaultTagAttributePrefix + "environment":                 "production",
+				defaultTagAttributePrefix + "log.tenant":                  "acme",
+				defaultTagAttributePrefix + "aws:cloudformation:stack-id": "abc",
+			},
+		},
+		{
+			name: "allowlist with default prefix",
+			cfg:  LogGroupTagsConfig{IncludeTags: true, TagNames: []string{"team", "environment"}},
+			expected: map[string]string{
+				defaultTagAttributePrefix + "team":        "messaging",
+				defaultTagAttributePrefix + "environment": "production",
+			},
+		},
+		{
+			name: "allowlist passthrough (empty attribute prefix)",
+			cfg:  LogGroupTagsConfig{IncludeTags: true, TagNames: []string{"team", "environment"}, TagAttributePrefix: stringPtr("")},
+			expected: map[string]string{
+				"team":        "messaging",
+				"environment": "production",
+			},
+		},
+		{
+			name: "tag prefix with custom attribute prefix",
+			cfg:  LogGroupTagsConfig{IncludeTags: true, TagPrefix: "log.", TagAttributePrefix: stringPtr("org.routing.")},
+			expected: map[string]string{
+				"org.routing.log.tenant": "acme",
+			},
+		},
+		{
+			name:     "no matches returns nil",
+			cfg:      LogGroupTagsConfig{IncludeTags: true, TagNames: []string{"nonexistent"}},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.cfg.selectTags(raw))
+		})
+	}
+
+	require.Nil(t, LogGroupTagsConfig{IncludeTags: true}.selectTags(nil))
+	require.Equal(t, defaultTagAttributePrefix, LogGroupTagsConfig{}.attributePrefix())
+	require.Equal(t, "", LogGroupTagsConfig{TagAttributePrefix: stringPtr("")}.attributePrefix())
+}
+
+func stringPtr(s string) *string {
+	return &s
 }

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -48,11 +48,18 @@ type logsReceiver struct {
 	storageID                     *component.ID
 	cloudwatchCheckpointPersister *cloudwatchCheckpointPersister
 	accountID                     string
+
+	// tag enrichment
+	namedTags    map[string]LogGroupTagsConfig // named log group name -> tag config (IncludeTags only)
+	namedTagArns map[string]string             // named log group name -> resolved ARN (cached)
+	tagsCache    map[string]map[string]string  // log group name -> resource attributes derived from tags
+	tagsCacheMu  sync.RWMutex
 }
 
 type client interface {
 	DescribeLogGroups(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput, opts ...func(options *cloudwatchlogs.Options)) (*cloudwatchlogs.DescribeLogGroupsOutput, error)
 	FilterLogEvents(ctx context.Context, input *cloudwatchlogs.FilterLogEventsInput, opts ...func(options *cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error)
+	ListTagsForResource(ctx context.Context, input *cloudwatchlogs.ListTagsForResourceInput, opts ...func(options *cloudwatchlogs.Options)) (*cloudwatchlogs.ListTagsForResourceOutput, error)
 }
 
 type streamNames struct {
@@ -112,6 +119,7 @@ type groupRequest interface {
 
 func newLogsReceiver(cfg *Config, settings receiver.Settings, consumer consumer.Logs) *logsReceiver {
 	groups := []groupRequest{}
+	namedTags := map[string]LogGroupTagsConfig{}
 	for logGroupName, sc := range cfg.Logs.Groups.NamedConfigs {
 		for _, prefix := range sc.Prefixes {
 			groups = append(groups, &streamPrefix{group: logGroupName, prefix: prefix})
@@ -121,6 +129,9 @@ func newLogsReceiver(cfg *Config, settings receiver.Settings, consumer consumer.
 		}
 		if len(sc.Prefixes) == 0 && len(sc.Names) == 0 {
 			groups = append(groups, &streamNames{group: logGroupName})
+		}
+		if sc.Tags.IncludeTags {
+			namedTags[logGroupName] = sc.Tags
 		}
 	}
 
@@ -159,6 +170,9 @@ func newLogsReceiver(cfg *Config, settings receiver.Settings, consumer consumer.
 		wg:                  &sync.WaitGroup{},
 		doneChan:            make(chan bool),
 		storageID:           cfg.StorageID,
+		namedTags:           namedTags,
+		namedTagArns:        map[string]string{},
+		tagsCache:           map[string]map[string]string{},
 	}
 }
 
@@ -223,6 +237,9 @@ func (l *logsReceiver) startPolling(ctx context.Context) {
 
 func (l *logsReceiver) poll(ctx context.Context) error {
 	var errs error
+	// Refresh tags for named log groups (autodiscover refreshes tags during
+	// discovery instead). No-op when tag enrichment is disabled.
+	l.refreshNamedTags(ctx)
 	currentGroups := make(map[string]bool)
 	endTime := nowFunc()
 	for _, r := range l.groupRequests {
@@ -392,6 +409,12 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			if logStreamName != "" {
 				resourceAttributes.PutStr("cloudwatch.log.stream", logStreamName)
 			}
+			l.tagsCacheMu.RLock()
+			tags := l.tagsCache[logGroupName]
+			l.tagsCacheMu.RUnlock()
+			for attrKey, attrVal := range tags {
+				resourceAttributes.PutStr(attrKey, attrVal)
+			}
 			group[logStreamName] = resourceLogs
 
 			_ = resourceLogs.ScopeLogs().AppendEmpty()
@@ -419,6 +442,9 @@ func (l *logsReceiver) discoverGroups(ctx context.Context, auto *AutodiscoverCon
 	}
 
 	numGroups := 0
+	// When tag enrichment is enabled we rebuild the tag cache from scratch each
+	// discovery cycle so removed groups and tag changes are reflected.
+	newTagsCache := map[string]map[string]string{}
 	nextToken := aws.String("")
 	for nextToken != nil {
 		if numGroups >= auto.Limit {
@@ -465,6 +491,21 @@ func (l *logsReceiver) discoverGroups(ctx context.Context, auto *AutodiscoverCon
 
 			numGroups++
 
+			// Enrich with log group tags when enabled. The ARN is already
+			// present on the DescribeLogGroups response, so no extra lookup is
+			// needed to call ListTagsForResource.
+			if auto.Tags.IncludeTags && lg.LogGroupName != nil {
+				if lg.LogGroupArn == nil {
+					l.settings.Logger.Warn("log group has no ARN, cannot fetch tags",
+						zap.String("logGroup", *lg.LogGroupName))
+				} else if tags, tagErr := l.fetchLogGroupTags(ctx, *lg.LogGroupArn, auto.Tags); tagErr != nil {
+					l.settings.Logger.Warn("unable to list tags for log group",
+						zap.String("logGroup", *lg.LogGroupName), zap.Error(tagErr))
+				} else if tags != nil {
+					newTagsCache[*lg.LogGroupName] = tags
+				}
+			}
+
 			// default behavior is to collect all if not stream filtered
 			if len(auto.Streams.Names) == 0 && len(auto.Streams.Prefixes) == 0 {
 				groups = append(groups, &streamNames{group: *lg.LogGroupName})
@@ -481,7 +522,82 @@ func (l *logsReceiver) discoverGroups(ctx context.Context, auto *AutodiscoverCon
 		}
 		nextToken = dlgResults.NextToken
 	}
+
+	if auto.Tags.IncludeTags {
+		l.tagsCacheMu.Lock()
+		l.tagsCache = newTagsCache
+		l.tagsCacheMu.Unlock()
+	}
+
 	return groups, nil
+}
+
+// fetchLogGroupTags calls ListTagsForResource for the given log group ARN and
+// returns the tags selected and prefixed according to tcfg. A nil map is
+// returned when no tags match.
+func (l *logsReceiver) fetchLogGroupTags(ctx context.Context, arn string, tcfg LogGroupTagsConfig) (map[string]string, error) {
+	out, err := l.client.ListTagsForResource(ctx, &cloudwatchlogs.ListTagsForResourceInput{
+		ResourceArn: aws.String(arn),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tcfg.selectTags(out.Tags), nil
+}
+
+// resolveLogGroupARN resolves the ARN of a named log group via DescribeLogGroups.
+// Named groups (unlike autodiscover) are configured by name only, so the ARN
+// required by ListTagsForResource must be looked up.
+func (l *logsReceiver) resolveLogGroupARN(ctx context.Context, name string) (string, error) {
+	out, err := l.client.DescribeLogGroups(ctx, &cloudwatchlogs.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String(name),
+		Limit:              aws.Int32(maxLogGroupsPerDiscovery),
+	})
+	if err != nil {
+		return "", err
+	}
+	for i := range out.LogGroups {
+		lg := &out.LogGroups[i]
+		if lg.LogGroupName != nil && *lg.LogGroupName == name && lg.LogGroupArn != nil {
+			return *lg.LogGroupArn, nil
+		}
+	}
+	return "", fmt.Errorf("could not resolve ARN for log group %q", name)
+}
+
+// refreshNamedTags refreshes the tag cache for named log groups that have tag
+// enrichment enabled. ARNs are resolved once and cached; tags are refreshed on
+// each call so downstream attributes stay current.
+func (l *logsReceiver) refreshNamedTags(ctx context.Context) {
+	if len(l.namedTags) == 0 {
+		return
+	}
+	if err := l.ensureSession(); err != nil {
+		l.settings.Logger.Error("unable to establish a session to fetch log group tags", zap.Error(err))
+		return
+	}
+	for name, tcfg := range l.namedTags {
+		arn, ok := l.namedTagArns[name]
+		if !ok {
+			resolved, err := l.resolveLogGroupARN(ctx, name)
+			if err != nil {
+				l.settings.Logger.Warn("unable to resolve ARN for log group tags",
+					zap.String("logGroup", name), zap.Error(err))
+				continue
+			}
+			arn = resolved
+			l.namedTagArns[name] = arn
+		}
+		tags, err := l.fetchLogGroupTags(ctx, arn, tcfg)
+		if err != nil {
+			l.settings.Logger.Warn("unable to list tags for log group",
+				zap.String("logGroup", name), zap.Error(err))
+			continue
+		}
+		l.tagsCacheMu.Lock()
+		l.tagsCache[name] = tags
+		l.tagsCacheMu.Unlock()
+	}
 }
 
 func (l *logsReceiver) ensureSession() error {

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -1313,7 +1313,7 @@ func TestNamedGroupTagEnrichment(t *testing.T) {
 			testLogGroupName: {
 				Names: []*string{aws.String(testLogStreamName)},
 				// tag_prefix "log." with passthrough attribute prefix ("").
-				Tags: LogGroupTagsConfig{IncludeTags: true, TagPrefix: "log.", TagAttributePrefix: stringPtr("")},
+				Tags: LogGroupTagsConfig{IncludeTags: true, TagPrefix: "log.", TagAttributePrefix: aws.String("")},
 			},
 		},
 	}

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 
@@ -1161,4 +1162,173 @@ func (mc *mockClient) DescribeLogGroups(ctx context.Context, input *cloudwatchlo
 func (mc *mockClient) FilterLogEvents(ctx context.Context, input *cloudwatchlogs.FilterLogEventsInput, opts ...func(options *cloudwatchlogs.Options)) (*cloudwatchlogs.FilterLogEventsOutput, error) {
 	args := mc.Called(ctx, input, opts)
 	return args.Get(0).(*cloudwatchlogs.FilterLogEventsOutput), args.Error(1)
+}
+
+func (mc *mockClient) ListTagsForResource(ctx context.Context, input *cloudwatchlogs.ListTagsForResourceInput, opts ...func(options *cloudwatchlogs.Options)) (*cloudwatchlogs.ListTagsForResourceOutput, error) {
+	args := mc.Called(ctx, input, opts)
+	return args.Get(0).(*cloudwatchlogs.ListTagsForResourceOutput), args.Error(1)
+}
+
+func TestAutodiscoverWithTagEnrichment(t *testing.T) {
+	mc := &mockClient{}
+	arn := "arn:aws:logs:us-west-1:123456789012:log-group:" + testLogGroupName
+
+	mc.On("DescribeLogGroups", mock.Anything, mock.Anything, mock.Anything).Return(
+		&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []types.LogGroup{
+				{LogGroupName: aws.String(testLogGroupName), LogGroupArn: aws.String(arn)},
+			},
+			NextToken: nil,
+		}, nil,
+	)
+
+	var capturedArn string
+	mc.On("ListTagsForResource", mock.Anything, mock.MatchedBy(func(in *cloudwatchlogs.ListTagsForResourceInput) bool {
+		if in.ResourceArn != nil {
+			capturedArn = *in.ResourceArn
+		}
+		return true
+	}), mock.Anything).Return(&cloudwatchlogs.ListTagsForResourceOutput{
+		Tags: map[string]string{
+			"team":                          "messaging",
+			"environment":                   "production",
+			"aws:cloudformation:stack-name": "my-stack",
+		},
+	}, nil)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-1"
+	cfg.Logs.Groups = GroupConfig{
+		AutodiscoverConfig: &AutodiscoverConfig{
+			Limit: 1,
+			Tags:  LogGroupTagsConfig{IncludeTags: true, TagNames: []string{"team", "environment"}},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	rcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	}, sink)
+	rcvr.client = mc
+
+	grs, err := rcvr.discoverGroups(t.Context(), cfg.Logs.Groups.AutodiscoverConfig)
+	require.NoError(t, err)
+	require.Len(t, grs, 1)
+	require.Equal(t, arn, capturedArn, "ListTagsForResource should be called with the log group ARN")
+
+	rcvr.tagsCacheMu.RLock()
+	cached := rcvr.tagsCache[testLogGroupName]
+	rcvr.tagsCacheMu.RUnlock()
+	require.Equal(t, map[string]string{
+		"cloudwatch.log.group.tag.team":        "messaging",
+		"cloudwatch.log.group.tag.environment": "production",
+	}, cached, "only allowlisted tags should be cached, prefixed with the default attribute prefix")
+
+	logs := rcvr.processEvents(pcommon.NewTimestampFromTime(time.Now()), testLogGroupName, &cloudwatchlogs.FilterLogEventsOutput{
+		Events: []types.FilteredLogEvent{
+			{
+				Timestamp:     aws.Int64(testTimeStamp),
+				EventId:       aws.String(testEventIDs[0]),
+				Message:       aws.String("hello world"),
+				LogStreamName: aws.String(testLogStreamName),
+			},
+		},
+	})
+
+	require.Equal(t, 1, logs.ResourceLogs().Len())
+	attrs := logs.ResourceLogs().At(0).Resource().Attributes()
+
+	v, ok := attrs.Get("cloudwatch.log.group.tag.team")
+	require.True(t, ok)
+	require.Equal(t, "messaging", v.Str())
+
+	v, ok = attrs.Get("cloudwatch.log.group.tag.environment")
+	require.True(t, ok)
+	require.Equal(t, "production", v.Str())
+
+	// AWS-managed tag not in the allowlist must not be emitted.
+	_, ok = attrs.Get("cloudwatch.log.group.tag.aws:cloudformation:stack-name")
+	require.False(t, ok)
+
+	// Base resource attributes remain present.
+	v, ok = attrs.Get("cloudwatch.log.group.name")
+	require.True(t, ok)
+	require.Equal(t, testLogGroupName, v.Str())
+}
+
+func TestAutodiscoverTagsDisabledMakesNoTagCall(t *testing.T) {
+	mc := &mockClient{}
+	mc.On("DescribeLogGroups", mock.Anything, mock.Anything, mock.Anything).Return(
+		&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []types.LogGroup{
+				{LogGroupName: aws.String(testLogGroupName), LogGroupArn: aws.String("arn:aws:logs:us-west-1:123456789012:log-group:" + testLogGroupName)},
+			},
+		}, nil,
+	)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-1"
+	cfg.Logs.Groups = GroupConfig{
+		AutodiscoverConfig: &AutodiscoverConfig{Limit: 1},
+	}
+
+	sink := &consumertest.LogsSink{}
+	rcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	}, sink)
+	rcvr.client = mc
+
+	_, err := rcvr.discoverGroups(t.Context(), cfg.Logs.Groups.AutodiscoverConfig)
+	require.NoError(t, err)
+	mc.AssertNotCalled(t, "ListTagsForResource", mock.Anything, mock.Anything, mock.Anything)
+
+	rcvr.tagsCacheMu.RLock()
+	require.Empty(t, rcvr.tagsCache)
+	rcvr.tagsCacheMu.RUnlock()
+}
+
+func TestNamedGroupTagEnrichment(t *testing.T) {
+	mc := &mockClient{}
+	arn := "arn:aws:logs:us-west-1:123456789012:log-group:" + testLogGroupName
+
+	mc.On("DescribeLogGroups", mock.Anything, mock.MatchedBy(func(in *cloudwatchlogs.DescribeLogGroupsInput) bool {
+		return in.LogGroupNamePrefix != nil && *in.LogGroupNamePrefix == testLogGroupName
+	}), mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+		LogGroups: []types.LogGroup{
+			{LogGroupName: aws.String(testLogGroupName), LogGroupArn: aws.String(arn)},
+		},
+	}, nil)
+
+	mc.On("ListTagsForResource", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.ListTagsForResourceOutput{
+		Tags: map[string]string{
+			"log.tenant": "acme",
+			"team":       "messaging",
+		},
+	}, nil)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-1"
+	cfg.Logs.Groups = GroupConfig{
+		NamedConfigs: map[string]StreamConfig{
+			testLogGroupName: {
+				Names: []*string{aws.String(testLogStreamName)},
+				// tag_prefix "log." with passthrough attribute prefix ("").
+				Tags: LogGroupTagsConfig{IncludeTags: true, TagPrefix: "log.", TagAttributePrefix: stringPtr("")},
+			},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	rcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	}, sink)
+	rcvr.client = mc
+
+	rcvr.refreshNamedTags(t.Context())
+
+	rcvr.tagsCacheMu.RLock()
+	cached := rcvr.tagsCache[testLogGroupName]
+	rcvr.tagsCacheMu.RUnlock()
+	require.Equal(t, map[string]string{"log.tenant": "acme"}, cached, "only log.-prefixed tags, passed through without an attribute prefix")
+	require.Equal(t, arn, rcvr.namedTagArns[testLogGroupName], "resolved ARN should be cached")
 }


### PR DESCRIPTION
#### Description

Adds an optional `include_tags` option to the awscloudwatch **logs** receiver that attaches a source log group's CloudWatch tags as resource attributes on emitted log records, as requested in #48574. Useful for tenant identification, retention policy, PII classification, and routing in multi-tenant / cross-account (OAM) pipelines.

Config (per group, on both `autodiscover` and `named`):

| Option | Type | Default | Description |
|---|---|---|---|
| `include_tags` | bool | `false` | Enables tag enrichment (gates everything below). |
| `tag_names` | []string | `[]` (all) | Allowlist of tag keys. Mutually exclusive with `tag_prefix`. |
| `tag_prefix` | string | `""` (all) | Include only tags whose key starts with this prefix. Mutually exclusive with `tag_names`. |
| `tag_attribute_prefix` | string | `cloudwatch.log.group.tag.` | Prefix prepended to tag keys when building resource attributes. Set to `""` to pass tags through as-is. |

Mechanism:
- **autodiscover**: `DescribeLogGroups` already returns `LogGroupArn`, so the receiver calls `ListTagsForResource` for each discovered group, filters per config, caches tags per group (rebuilt each discovery cycle), and attaches the selected tags as resource attributes.
- **named**: resolves each group's ARN via `DescribeLogGroups` (cached) and refreshes tags each poll.

Disabled by default — with `include_tags: false` the receiver makes no tag API calls and behavior is unchanged. Requires the `logs:ListTagsForResource` IAM permission (documented in the README).

This is a separate feature from my open PR #50451 (tag *filtering for metrics discovery*); this one adds tag *enrichment to log records*. Happy to sequence the two however the code owners prefer.

#### Link to tracking issue
Fixes #48574

#### Testing

`go build ./...`, `go test ./...`, and `go vet ./...` all pass in `receiver/awscloudwatchreceiver`. Added unit tests using the package's existing mocked client (`mockClient`, extended with `ListTagsForResource`):
- `TestAutodiscoverWithTagEnrichment` — mocked `DescribeLogGroups` (with ARN) + `ListTagsForResource`, asserts the ARN is passed to the tags API, the cache holds only allowlisted/prefixed tags, and `processEvents` emits them as resource attributes while AWS-managed tags outside the allowlist are excluded.
- `TestAutodiscoverTagsDisabledMakesNoTagCall` — asserts no tag API call and empty cache when disabled (default).
- `TestNamedGroupTagEnrichment` — named group with `tag_prefix` + passthrough (`tag_attribute_prefix: ""`); asserts ARN resolution + filtered tags.
- `TestLogGroupTagsConfigSelectTags` — tag filtering/prefixing matrix.
- Mutually-exclusive `tag_names`/`tag_prefix` validation added to `TestValidate` for both autodiscover and named.

#### Documentation

Updated the receiver README with a "Log Group Tag Enrichment" section (option table, filtering semantics, example config, and the required `logs:ListTagsForResource` IAM permission). Regenerated `config.schema.yaml` via `make generate-schemas`. Added a `.chloggen` enhancement fragment.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.

---

cc code owners @schmikei @dyl10s — this is `waiting-for-code-owners` and I haven't received an explicit greenlight yet, so please treat the config shape (field names + default `tag_attribute_prefix`) as a proposal open to change. I asked for confirmation on #48574 as well.
