### PR TITLE
[chore] fix permission in update-otel.yaml

### DIFF
--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -35,7 +35,6 @@ jobs:
         with:
           client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-          permission-contents: read
           permission-pull-requests: write
       - name: Prepare to update dependencies
         run: |


### PR DESCRIPTION
#### Description
Remove "permission-contents: read" from "actions/create-github-app-token". The otelbot token doesn't need nor have this permission in the workflow. Other workflows also doesn't have this permssion.

#### Link to tracking issue
Fixes #50466

#### Authorship

- [x] I, a human, wrote this pull request description myself.

