### PR TITLE
[chore] Fix breaking changes from kubernetes monorepo v0.36.3 bump

### DIFF
--- a/internal/k8sinventory/informer/observer_test.go
+++ b/internal/k8sinventory/informer/observer_test.go
@@ -769,12 +769,13 @@ func TestCheckpointAdvancesAfterHandler(t *testing.T) {
 		t.Fatal("watchHandler was not called")
 	}
 
-	// While the handler is blocked, storage must not have RV 77 yet.
+	// While the handler is blocked, storage must not have RV 77 yet. (It may
+	// already hold the post-sync checkpoint of the initial, empty list.)
 	require.NoError(t, obs.cp.Flush(t.Context()))
 	verifier := checkpoint.New(storageClient, zap.NewNop())
 	rv, err := verifier.GetCheckpoint(t.Context(), "", podsGVR.Resource)
 	require.NoError(t, err)
-	assert.Empty(t, rv, "checkpoint must not advance before handler returns")
+	assert.NotEqual(t, "77", rv, "checkpoint must not advance before handler returns")
 
 	// Unblock the handler; RV 77 should now flow into storage.
 	releaseHandler()

--- a/processor/k8sattributesprocessor/internal/kube/fake_informer.go
+++ b/processor/k8sattributesprocessor/internal/kube/fake_informer.go
@@ -15,6 +15,22 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// alreadyDone is a cache.DoneChecker whose Done channel is always closed,
+// matching the fakes' HasSynced() always returning true.
+var alreadyDone = doneChecker{}
+
+type doneChecker struct{}
+
+func (doneChecker) Name() string {
+	return "fakeInformer"
+}
+
+func (doneChecker) Done() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}
+
 type FakeInformer struct {
 	*FakeController
 
@@ -154,6 +170,10 @@ func (*FakeController) LastSyncResourceVersion() string {
 	return ""
 }
 
+func (*FakeController) HasSyncedChecker() cache.DoneChecker {
+	return alreadyDone
+}
+
 func (*FakeInformer) SetWatchErrorHandler(cache.WatchErrorHandler) error {
 	return nil
 }
@@ -227,6 +247,10 @@ func (*NoOpController) HasSynced() bool {
 
 func (*NoOpController) LastSyncResourceVersion() string {
 	return ""
+}
+
+func (*NoOpController) HasSyncedChecker() cache.DoneChecker {
+	return alreadyDone
 }
 
 func (*NoOpController) SetWatchErrorHandler(cache.WatchErrorHandler) error {

--- a/receiver/k8sclusterreceiver/internal/metadata/metadatastore_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/metadatastore_test.go
@@ -91,3 +91,9 @@ func (mockStore) Replace(_ []any, _ string) error {
 func (mockStore) Resync() error {
 	return nil
 }
+
+func (mockStore) LastStoreSyncResourceVersion() string {
+	return ""
+}
+
+func (mockStore) Bookmark(_ string) {}

--- a/receiver/k8sclusterreceiver/receiver_test.go
+++ b/receiver/k8sclusterreceiver/receiver_test.go
@@ -244,8 +244,10 @@ func TestReceiverTimesOutAfterStartup(t *testing.T) {
 	}()
 	client := newFakeClientWithAllResources()
 
-	// Mock initial cache sync timing out, using a small timeout.
-	r := setupReceiver(client, nil, consumertest.NewNop(), nil, 1*time.Millisecond, tt, nil, component.MustNewID("foo"))
+	// Mock initial cache sync timing out. A zero timeout guarantees the
+	// deadline is already past before the informers can sync, regardless of
+	// how fast the fake client's initial sync happens to be.
+	r := setupReceiver(client, nil, consumertest.NewNop(), nil, 0, tt, nil, component.MustNewID("foo"))
 
 	createPods(t, client, 1, false)
 


### PR DESCRIPTION
#### Description
Adapt API breaking changes from k8s v0.36.3 modules.
All code changes are in tests only

#### Link to tracking issue
To unblock https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47953

#### Authorship

- [x] I, a human, wrote this pull request description myself.

