### PR TITLE
[exporter/elasticsearch] fix timeoutInterceptor with timeout=0 immediately cancelling requests

### DIFF
--- a/.chloggen/50469-elasticsearch-timeoutinterceptor-zero-timeout.yaml
+++ b/.chloggen/50469-elasticsearch-timeoutinterceptor-zero-timeout.yaml
@@ -1,0 +1,13 @@
+change_type: bug_fix
+
+component: exporter/elasticsearch
+
+note: Fix `timeoutInterceptor` immediately cancelling all requests when `timeout=0`
+
+issues: [50469]
+
+subtext: |
+  Added a `perRequestTimeout <= 0` guard to skip the timeout wrapping when no timeout
+  is configured.
+
+change_logs: [user]

--- a/exporter/elasticsearchexporter/esclient.go
+++ b/exporter/elasticsearchexporter/esclient.go
@@ -60,6 +60,9 @@ func countRetriesInterceptor() elastictransport.InterceptorFunc {
 func timeoutInterceptor(perRequestTimeout time.Duration) elastictransport.InterceptorFunc {
 	return func(next elastictransport.RoundTripFunc) elastictransport.RoundTripFunc {
 		return func(req *http.Request) (*http.Response, error) {
+			if perRequestTimeout <= 0 {
+				return next(req)
+			}
 			// ctx is not reused across retries
 			// Therefore, timeoutInterceptor would not result in nesting of WithTimeout
 			ctx, cancel := context.WithTimeout(req.Context(), perRequestTimeout)

--- a/exporter/elasticsearchexporter/esclient_test.go
+++ b/exporter/elasticsearchexporter/esclient_test.go
@@ -38,6 +38,10 @@ func TestTimeoutInterceptor(t *testing.T) {
 			timeout:     30 * time.Second,
 			bodyLatency: time.Second,
 		},
+		{
+			name:    "zero_timeout",
+			timeout: 0,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			server := newESTestServerBulkHandlerFunc(t, func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
#### Description

Guard against perRequestTimeout <= 0 in timeoutInterceptor, matching the existing pattern in flushBulkIndexer. When timeout is 0, context.WithTimeout sets an already-expired deadline, causing all requests to fail immediately.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50469

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Add specific unit test for coverage of 0 timeout.

<!--Describe the documentation added.-->
#### Documentation

None

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
