### PR TITLE
[chore] clean up linter warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,8 +14,12 @@ formatters:
         - default
         - prefix(github.com/open-telemetry/opentelemetry-collector-contrib)
     gofumpt:
-      # Choose whether to use the extra rules.
-      extra-rules: true
+      # `extra-rules: true` is deprecated in favor of enabling each extra rule
+      # individually; these three together are equivalent to the old setting.
+      extra:
+        group-params: true
+        clothe-returns: true
+        balance-calls: true
 
 issues:
   # Maximum issues count per one linter.


### PR DESCRIPTION
The linter job was spewing many of the following warnings: `WARN [formatter] gofumpt: `extra-rules` is deprecated, please use extra.group-params instead.`

#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
