### PR TITLE
feat: Added ASM metrics for oracle

### DIFF
--- a/.chloggen/oracledbreceiver-asm-metrics.yaml
+++ b/.chloggen/oracledbreceiver-asm-metrics.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/oracledbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add opt-in Automatic Storage Management (ASM) diskgroup and disk metrics (`oracledb.asm_diskgroup.*`, `oracledb.asm_disk.*`).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50487]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  All 5 metrics are disabled by default. Sourced from `V$ASM_DISKGROUP_STAT` and `V$ASM_DISK_STAT`,
+  queried from the regular RDBMS connection (no `+ASM` instance connection required). Both views
+  return zero rows, not an error, on instances that don't use ASM.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/oracledbreceiver-asm-metrics.yaml
+++ b/.chloggen/oracledbreceiver-asm-metrics.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/oracledbreceiver
+component: receiver/oracledb
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add opt-in Automatic Storage Management (ASM) diskgroup and disk metrics (`oracledb.asm_diskgroup.*`, `oracledb.asm_disk.*`).

--- a/.chloggen/oracledbreceiver-asm-metrics.yaml
+++ b/.chloggen/oracledbreceiver-asm-metrics.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/oracledb
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add opt-in Automatic Storage Management (ASM) diskgroup and disk metrics (`oracledb.asm_diskgroup.*`, `oracledb.asm_disk.*`).
+note: Add opt-in Automatic Storage Management (ASM) diskgroup and disk metrics (`oracledb.asm.disk_group.*`, `oracledb.asm.disk.*`).
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [50487]

--- a/receiver/oracledbreceiver/README.md
+++ b/receiver/oracledbreceiver/README.md
@@ -105,6 +105,15 @@ GRANT SELECT ON DBA_TABLESPACE_USAGE_METRICS TO <username>;
 GRANT SELECT ON V_$SGAINFO TO <username>;
 ```
 
+### ASM metrics
+
+Grants required for ASM metrics.
+
+```sql
+GRANT SELECT ON V_$ASM_DISKGROUP_STAT TO <username>;
+GRANT SELECT ON V_$ASM_DISK_STAT TO <username>;
+```
+
 ### Per-PDB metrics (CDB multitenant deployments)
 
 When connected to a CDB root (Oracle 12c+), the receiver can collect per-PDB metrics

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -310,7 +310,7 @@ metrics:
     enabled: true
 ```
 
-### oracledb.asm_disk.errors
+### oracledb.asm.disk.errors
 
 Count of I/O errors on an ASM disk.
 
@@ -322,11 +322,11 @@ Count of I/O errors on an ASM disk.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
-| oracledb.asm_disk.name | The name of the ASM disk. | Any Str | Recommended | - |
+| oracledb.asm.disk_group.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+| oracledb.asm.disk.name | The name of the ASM disk. | Any Str | Recommended | - |
 | disk.io.direction | Direction of the storage I/O operation. | Str: ``read``, ``write`` | Recommended | - |
 
-### oracledb.asm_diskgroup.free
+### oracledb.asm.disk_group.free
 
 Free space in an ASM diskgroup.
 
@@ -338,9 +338,9 @@ Free space in an ASM diskgroup.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+| oracledb.asm.disk_group.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
 
-### oracledb.asm_diskgroup.offline_disks
+### oracledb.asm.disk_group.offline_disks
 
 Count of disks currently offline within an ASM diskgroup.
 
@@ -352,9 +352,9 @@ Count of disks currently offline within an ASM diskgroup.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+| oracledb.asm.disk_group.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
 
-### oracledb.asm_diskgroup.total
+### oracledb.asm.disk_group.total
 
 Total space in an ASM diskgroup.
 
@@ -366,9 +366,9 @@ Total space in an ASM diskgroup.
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+| oracledb.asm.disk_group.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
 
-### oracledb.asm_diskgroup.usable_free
+### oracledb.asm.disk_group.usable_free
 
 Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.
 
@@ -380,7 +380,7 @@ Free space that can safely be used for files after accounting for ASM redundancy
 
 | Name | Description | Values | Requirement Level | Semantic Convention |
 | ---- | ----------- | ------ | ----------------- | ------------------- |
-| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+| oracledb.asm.disk_group.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
 
 ### oracledb.buffer.inspected
 

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -370,7 +370,7 @@ Total space in an ASM diskgroup.
 
 ### oracledb.asm_diskgroup.usable_free
 
-Free space in an ASM diskgroup.
+Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.
 
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -326,6 +326,20 @@ Count of I/O errors on an ASM disk.
 | oracledb.asm.disk.name | The name of the ASM disk. | Any Str | Recommended | - |
 | disk.io.direction | Direction of the storage I/O operation. | Str: ``read``, ``write`` | Recommended | - |
 
+### oracledb.asm.disk_group.capacity
+
+Total space in an ASM diskgroup.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.asm.disk_group.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+
 ### oracledb.asm.disk_group.free
 
 Free space in an ASM diskgroup.
@@ -347,20 +361,6 @@ Count of disks currently offline within an ASM diskgroup.
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
 | {disk} | Gauge | Int | Development |
-
-#### Attributes
-
-| Name | Description | Values | Requirement Level | Semantic Convention |
-| ---- | ----------- | ------ | ----------------- | ------------------- |
-| oracledb.asm.disk_group.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
-
-### oracledb.asm.disk_group.total
-
-Total space in an ASM diskgroup.
-
-| Unit | Metric Type | Value Type | Stability |
-| ---- | ----------- | ---------- | --------- |
-| By | Gauge | Int | Development |
 
 #### Attributes
 

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -310,6 +310,78 @@ metrics:
     enabled: true
 ```
 
+### oracledb.asm_disk.errors
+
+Count of I/O errors on an ASM disk.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {error} | Sum | Int | Cumulative | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+| oracledb.asm_disk.name | The name of the ASM disk. | Any Str | Recommended | - |
+| disk.io.direction | Direction of the storage I/O operation. | Str: ``read``, ``write`` | Recommended | - |
+
+### oracledb.asm_diskgroup.free
+
+Free space in an ASM diskgroup.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+
+### oracledb.asm_diskgroup.offline_disks
+
+Count of disks currently offline within an ASM diskgroup.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {disk} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+
+### oracledb.asm_diskgroup.total
+
+Total space in an ASM diskgroup.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+
+### oracledb.asm_diskgroup.usable_free
+
+Free space in an ASM diskgroup.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| oracledb.asm_diskgroup.name | The name of the ASM diskgroup. | Any Str | Recommended | - |
+
 ### oracledb.buffer.inspected
 
 Number of buffers inspected from the end of the LRU queue while a process searched for a reusable buffer, grouped by buffer state.

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -10,6 +10,248 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
+// OracledbAsmDiskErrorsMetricAttributeKey specifies the key of an attribute for the oracledb.asm_disk.errors metric.
+type OracledbAsmDiskErrorsMetricAttributeKey string
+
+const (
+	OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskErrorsMetricAttributeKey = "oracledb.asm_diskgroup.name"
+	OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName      OracledbAsmDiskErrorsMetricAttributeKey = "oracledb.asm_disk.name"
+	OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection          OracledbAsmDiskErrorsMetricAttributeKey = "disk.io.direction"
+)
+
+// OracledbAsmDiskErrorsMetricConfig provides config for the oracledb.asm_disk.errors metric.
+type OracledbAsmDiskErrorsMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                    `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbAsmDiskErrorsMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbAsmDiskErrorsMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbAsmDiskErrorsMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection:
+		default:
+			return fmt.Errorf("metric oracledb.asm_disk.errors doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name, oracledb.asm_disk.name, disk.io.direction]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// OracledbAsmDiskgroupFreeMetricAttributeKey specifies the key of an attribute for the oracledb.asm_diskgroup.free metric.
+type OracledbAsmDiskgroupFreeMetricAttributeKey string
+
+const (
+	OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskgroupFreeMetricAttributeKey = "oracledb.asm_diskgroup.name"
+)
+
+// OracledbAsmDiskgroupFreeMetricConfig provides config for the oracledb.asm_diskgroup.free metric.
+type OracledbAsmDiskgroupFreeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                       `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbAsmDiskgroupFreeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbAsmDiskgroupFreeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbAsmDiskgroupFreeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName:
+		default:
+			return fmt.Errorf("metric oracledb.asm_diskgroup.free doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// OracledbAsmDiskgroupOfflineDisksMetricAttributeKey specifies the key of an attribute for the oracledb.asm_diskgroup.offline_disks metric.
+type OracledbAsmDiskgroupOfflineDisksMetricAttributeKey string
+
+const (
+	OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskgroupOfflineDisksMetricAttributeKey = "oracledb.asm_diskgroup.name"
+)
+
+// OracledbAsmDiskgroupOfflineDisksMetricConfig provides config for the oracledb.asm_diskgroup.offline_disks metric.
+type OracledbAsmDiskgroupOfflineDisksMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbAsmDiskgroupOfflineDisksMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbAsmDiskgroupOfflineDisksMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName:
+		default:
+			return fmt.Errorf("metric oracledb.asm_diskgroup.offline_disks doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// OracledbAsmDiskgroupTotalMetricAttributeKey specifies the key of an attribute for the oracledb.asm_diskgroup.total metric.
+type OracledbAsmDiskgroupTotalMetricAttributeKey string
+
+const (
+	OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskgroupTotalMetricAttributeKey = "oracledb.asm_diskgroup.name"
+)
+
+// OracledbAsmDiskgroupTotalMetricConfig provides config for the oracledb.asm_diskgroup.total metric.
+type OracledbAsmDiskgroupTotalMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbAsmDiskgroupTotalMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbAsmDiskgroupTotalMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbAsmDiskgroupTotalMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName:
+		default:
+			return fmt.Errorf("metric oracledb.asm_diskgroup.total doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// OracledbAsmDiskgroupUsableFreeMetricAttributeKey specifies the key of an attribute for the oracledb.asm_diskgroup.usable_free metric.
+type OracledbAsmDiskgroupUsableFreeMetricAttributeKey string
+
+const (
+	OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskgroupUsableFreeMetricAttributeKey = "oracledb.asm_diskgroup.name"
+)
+
+// OracledbAsmDiskgroupUsableFreeMetricConfig provides config for the oracledb.asm_diskgroup.usable_free metric.
+type OracledbAsmDiskgroupUsableFreeMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                             `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbAsmDiskgroupUsableFreeMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbAsmDiskgroupUsableFreeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbAsmDiskgroupUsableFreeMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName:
+		default:
+			return fmt.Errorf("metric oracledb.asm_diskgroup.usable_free doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // OracledbBufferInspectedMetricAttributeKey specifies the key of an attribute for the oracledb.buffer.inspected metric.
 type OracledbBufferInspectedMetricAttributeKey string
 
@@ -5074,6 +5316,11 @@ func (ms *OracledbUserRollbacksMetricConfig) Validate() error {
 
 // MetricsConfig provides config for oracledb metrics.
 type MetricsConfig struct {
+	OracledbAsmDiskErrors                         OracledbAsmDiskErrorsMetricConfig                         `mapstructure:"oracledb.asm_disk.errors"`
+	OracledbAsmDiskgroupFree                      OracledbAsmDiskgroupFreeMetricConfig                      `mapstructure:"oracledb.asm_diskgroup.free"`
+	OracledbAsmDiskgroupOfflineDisks              OracledbAsmDiskgroupOfflineDisksMetricConfig              `mapstructure:"oracledb.asm_diskgroup.offline_disks"`
+	OracledbAsmDiskgroupTotal                     OracledbAsmDiskgroupTotalMetricConfig                     `mapstructure:"oracledb.asm_diskgroup.total"`
+	OracledbAsmDiskgroupUsableFree                OracledbAsmDiskgroupUsableFreeMetricConfig                `mapstructure:"oracledb.asm_diskgroup.usable_free"`
 	OracledbBufferInspected                       OracledbBufferInspectedMetricConfig                       `mapstructure:"oracledb.buffer.inspected"`
 	OracledbBufferRequests                        OracledbBufferRequestsMetricConfig                        `mapstructure:"oracledb.buffer.requests"`
 	OracledbBufferCacheBlockChanges               OracledbBufferCacheBlockChangesMetricConfig               `mapstructure:"oracledb.buffer_cache.block.changes"`
@@ -5208,6 +5455,31 @@ type MetricsConfig struct {
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		OracledbAsmDiskErrors: OracledbAsmDiskErrorsMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
+		},
+		OracledbAsmDiskgroupFree: OracledbAsmDiskgroupFreeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []OracledbAsmDiskgroupFreeMetricAttributeKey{OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+		},
+		OracledbAsmDiskgroupOfflineDisks: OracledbAsmDiskgroupOfflineDisksMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey{OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName},
+		},
+		OracledbAsmDiskgroupTotal: OracledbAsmDiskgroupTotalMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []OracledbAsmDiskgroupTotalMetricAttributeKey{OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName},
+		},
+		OracledbAsmDiskgroupUsableFree: OracledbAsmDiskgroupUsableFreeMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []OracledbAsmDiskgroupUsableFreeMetricAttributeKey{OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+		},
 		OracledbBufferInspected: OracledbBufferInspectedMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -60,6 +60,54 @@ func (ms *OracledbAsmDiskErrorsMetricConfig) Validate() error {
 	return nil
 }
 
+// OracledbAsmDiskGroupCapacityMetricAttributeKey specifies the key of an attribute for the oracledb.asm.disk_group.capacity metric.
+type OracledbAsmDiskGroupCapacityMetricAttributeKey string
+
+const (
+	OracledbAsmDiskGroupCapacityMetricAttributeKeyOracledbAsmDiskGroupName OracledbAsmDiskGroupCapacityMetricAttributeKey = "oracledb.asm.disk_group.name"
+)
+
+// OracledbAsmDiskGroupCapacityMetricConfig provides config for the oracledb.asm.disk_group.capacity metric.
+type OracledbAsmDiskGroupCapacityMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []OracledbAsmDiskGroupCapacityMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *OracledbAsmDiskGroupCapacityMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *OracledbAsmDiskGroupCapacityMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case OracledbAsmDiskGroupCapacityMetricAttributeKeyOracledbAsmDiskGroupName:
+		default:
+			return fmt.Errorf("metric oracledb.asm.disk_group.capacity doesn't have an attribute %v, valid attributes: [oracledb.asm.disk_group.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
 // OracledbAsmDiskGroupFreeMetricAttributeKey specifies the key of an attribute for the oracledb.asm.disk_group.free metric.
 type OracledbAsmDiskGroupFreeMetricAttributeKey string
 
@@ -144,54 +192,6 @@ func (ms *OracledbAsmDiskGroupOfflineDisksMetricConfig) Validate() error {
 		case OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName:
 		default:
 			return fmt.Errorf("metric oracledb.asm.disk_group.offline_disks doesn't have an attribute %v, valid attributes: [oracledb.asm.disk_group.name]", val)
-		}
-	}
-
-	switch ms.AggregationStrategy {
-	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
-	default:
-		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
-	}
-
-	return nil
-}
-
-// OracledbAsmDiskGroupTotalMetricAttributeKey specifies the key of an attribute for the oracledb.asm.disk_group.total metric.
-type OracledbAsmDiskGroupTotalMetricAttributeKey string
-
-const (
-	OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName OracledbAsmDiskGroupTotalMetricAttributeKey = "oracledb.asm.disk_group.name"
-)
-
-// OracledbAsmDiskGroupTotalMetricConfig provides config for the oracledb.asm.disk_group.total metric.
-type OracledbAsmDiskGroupTotalMetricConfig struct {
-	Enabled          bool `mapstructure:"enabled"`
-	enabledSetByUser bool
-
-	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OracledbAsmDiskGroupTotalMetricAttributeKey `mapstructure:"attributes"`
-}
-
-func (ms *OracledbAsmDiskGroupTotalMetricConfig) Unmarshal(parser *confmap.Conf) error {
-	if parser == nil {
-		return nil
-	}
-
-	err := parser.Unmarshal(ms)
-	if err != nil {
-		return err
-	}
-
-	ms.enabledSetByUser = parser.IsSet("enabled")
-	return nil
-}
-
-func (ms *OracledbAsmDiskGroupTotalMetricConfig) Validate() error {
-	for _, val := range ms.EnabledAttributes {
-		switch val {
-		case OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName:
-		default:
-			return fmt.Errorf("metric oracledb.asm.disk_group.total doesn't have an attribute %v, valid attributes: [oracledb.asm.disk_group.name]", val)
 		}
 	}
 
@@ -5317,9 +5317,9 @@ func (ms *OracledbUserRollbacksMetricConfig) Validate() error {
 // MetricsConfig provides config for oracledb metrics.
 type MetricsConfig struct {
 	OracledbAsmDiskErrors                         OracledbAsmDiskErrorsMetricConfig                         `mapstructure:"oracledb.asm.disk.errors"`
+	OracledbAsmDiskGroupCapacity                  OracledbAsmDiskGroupCapacityMetricConfig                  `mapstructure:"oracledb.asm.disk_group.capacity"`
 	OracledbAsmDiskGroupFree                      OracledbAsmDiskGroupFreeMetricConfig                      `mapstructure:"oracledb.asm.disk_group.free"`
 	OracledbAsmDiskGroupOfflineDisks              OracledbAsmDiskGroupOfflineDisksMetricConfig              `mapstructure:"oracledb.asm.disk_group.offline_disks"`
-	OracledbAsmDiskGroupTotal                     OracledbAsmDiskGroupTotalMetricConfig                     `mapstructure:"oracledb.asm.disk_group.total"`
 	OracledbAsmDiskGroupUsableFree                OracledbAsmDiskGroupUsableFreeMetricConfig                `mapstructure:"oracledb.asm.disk_group.usable_free"`
 	OracledbBufferInspected                       OracledbBufferInspectedMetricConfig                       `mapstructure:"oracledb.buffer.inspected"`
 	OracledbBufferRequests                        OracledbBufferRequestsMetricConfig                        `mapstructure:"oracledb.buffer.requests"`
@@ -5460,6 +5460,11 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskGroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
 		},
+		OracledbAsmDiskGroupCapacity: OracledbAsmDiskGroupCapacityMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []OracledbAsmDiskGroupCapacityMetricAttributeKey{OracledbAsmDiskGroupCapacityMetricAttributeKeyOracledbAsmDiskGroupName},
+		},
 		OracledbAsmDiskGroupFree: OracledbAsmDiskGroupFreeMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
@@ -5469,11 +5474,6 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
 			EnabledAttributes:   []OracledbAsmDiskGroupOfflineDisksMetricAttributeKey{OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName},
-		},
-		OracledbAsmDiskGroupTotal: OracledbAsmDiskGroupTotalMetricConfig{
-			Enabled:             false,
-			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OracledbAsmDiskGroupTotalMetricAttributeKey{OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName},
 		},
 		OracledbAsmDiskGroupUsableFree: OracledbAsmDiskGroupUsableFreeMetricConfig{
 			Enabled:             false,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -10,16 +10,16 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
-// OracledbAsmDiskErrorsMetricAttributeKey specifies the key of an attribute for the oracledb.asm_disk.errors metric.
+// OracledbAsmDiskErrorsMetricAttributeKey specifies the key of an attribute for the oracledb.asm.disk.errors metric.
 type OracledbAsmDiskErrorsMetricAttributeKey string
 
 const (
-	OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskErrorsMetricAttributeKey = "oracledb.asm_diskgroup.name"
-	OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName      OracledbAsmDiskErrorsMetricAttributeKey = "oracledb.asm_disk.name"
+	OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskGroupName OracledbAsmDiskErrorsMetricAttributeKey = "oracledb.asm.disk_group.name"
+	OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName      OracledbAsmDiskErrorsMetricAttributeKey = "oracledb.asm.disk.name"
 	OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection          OracledbAsmDiskErrorsMetricAttributeKey = "disk.io.direction"
 )
 
-// OracledbAsmDiskErrorsMetricConfig provides config for the oracledb.asm_disk.errors metric.
+// OracledbAsmDiskErrorsMetricConfig provides config for the oracledb.asm.disk.errors metric.
 type OracledbAsmDiskErrorsMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
@@ -45,9 +45,9 @@ func (ms *OracledbAsmDiskErrorsMetricConfig) Unmarshal(parser *confmap.Conf) err
 func (ms *OracledbAsmDiskErrorsMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection:
+		case OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskGroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection:
 		default:
-			return fmt.Errorf("metric oracledb.asm_disk.errors doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name, oracledb.asm_disk.name, disk.io.direction]", val)
+			return fmt.Errorf("metric oracledb.asm.disk.errors doesn't have an attribute %v, valid attributes: [oracledb.asm.disk_group.name, oracledb.asm.disk.name, disk.io.direction]", val)
 		}
 	}
 
@@ -60,23 +60,23 @@ func (ms *OracledbAsmDiskErrorsMetricConfig) Validate() error {
 	return nil
 }
 
-// OracledbAsmDiskgroupFreeMetricAttributeKey specifies the key of an attribute for the oracledb.asm_diskgroup.free metric.
-type OracledbAsmDiskgroupFreeMetricAttributeKey string
+// OracledbAsmDiskGroupFreeMetricAttributeKey specifies the key of an attribute for the oracledb.asm.disk_group.free metric.
+type OracledbAsmDiskGroupFreeMetricAttributeKey string
 
 const (
-	OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskgroupFreeMetricAttributeKey = "oracledb.asm_diskgroup.name"
+	OracledbAsmDiskGroupFreeMetricAttributeKeyOracledbAsmDiskGroupName OracledbAsmDiskGroupFreeMetricAttributeKey = "oracledb.asm.disk_group.name"
 )
 
-// OracledbAsmDiskgroupFreeMetricConfig provides config for the oracledb.asm_diskgroup.free metric.
-type OracledbAsmDiskgroupFreeMetricConfig struct {
+// OracledbAsmDiskGroupFreeMetricConfig provides config for the oracledb.asm.disk_group.free metric.
+type OracledbAsmDiskGroupFreeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
 	AggregationStrategy string                                       `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OracledbAsmDiskgroupFreeMetricAttributeKey `mapstructure:"attributes"`
+	EnabledAttributes   []OracledbAsmDiskGroupFreeMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OracledbAsmDiskgroupFreeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OracledbAsmDiskGroupFreeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -90,12 +90,12 @@ func (ms *OracledbAsmDiskgroupFreeMetricConfig) Unmarshal(parser *confmap.Conf) 
 	return nil
 }
 
-func (ms *OracledbAsmDiskgroupFreeMetricConfig) Validate() error {
+func (ms *OracledbAsmDiskGroupFreeMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName:
+		case OracledbAsmDiskGroupFreeMetricAttributeKeyOracledbAsmDiskGroupName:
 		default:
-			return fmt.Errorf("metric oracledb.asm_diskgroup.free doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name]", val)
+			return fmt.Errorf("metric oracledb.asm.disk_group.free doesn't have an attribute %v, valid attributes: [oracledb.asm.disk_group.name]", val)
 		}
 	}
 
@@ -108,23 +108,23 @@ func (ms *OracledbAsmDiskgroupFreeMetricConfig) Validate() error {
 	return nil
 }
 
-// OracledbAsmDiskgroupOfflineDisksMetricAttributeKey specifies the key of an attribute for the oracledb.asm_diskgroup.offline_disks metric.
-type OracledbAsmDiskgroupOfflineDisksMetricAttributeKey string
+// OracledbAsmDiskGroupOfflineDisksMetricAttributeKey specifies the key of an attribute for the oracledb.asm.disk_group.offline_disks metric.
+type OracledbAsmDiskGroupOfflineDisksMetricAttributeKey string
 
 const (
-	OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskgroupOfflineDisksMetricAttributeKey = "oracledb.asm_diskgroup.name"
+	OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName OracledbAsmDiskGroupOfflineDisksMetricAttributeKey = "oracledb.asm.disk_group.name"
 )
 
-// OracledbAsmDiskgroupOfflineDisksMetricConfig provides config for the oracledb.asm_diskgroup.offline_disks metric.
-type OracledbAsmDiskgroupOfflineDisksMetricConfig struct {
+// OracledbAsmDiskGroupOfflineDisksMetricConfig provides config for the oracledb.asm.disk_group.offline_disks metric.
+type OracledbAsmDiskGroupOfflineDisksMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
 	AggregationStrategy string                                               `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey `mapstructure:"attributes"`
+	EnabledAttributes   []OracledbAsmDiskGroupOfflineDisksMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OracledbAsmDiskgroupOfflineDisksMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OracledbAsmDiskGroupOfflineDisksMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -138,12 +138,12 @@ func (ms *OracledbAsmDiskgroupOfflineDisksMetricConfig) Unmarshal(parser *confma
 	return nil
 }
 
-func (ms *OracledbAsmDiskgroupOfflineDisksMetricConfig) Validate() error {
+func (ms *OracledbAsmDiskGroupOfflineDisksMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName:
+		case OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName:
 		default:
-			return fmt.Errorf("metric oracledb.asm_diskgroup.offline_disks doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name]", val)
+			return fmt.Errorf("metric oracledb.asm.disk_group.offline_disks doesn't have an attribute %v, valid attributes: [oracledb.asm.disk_group.name]", val)
 		}
 	}
 
@@ -156,23 +156,23 @@ func (ms *OracledbAsmDiskgroupOfflineDisksMetricConfig) Validate() error {
 	return nil
 }
 
-// OracledbAsmDiskgroupTotalMetricAttributeKey specifies the key of an attribute for the oracledb.asm_diskgroup.total metric.
-type OracledbAsmDiskgroupTotalMetricAttributeKey string
+// OracledbAsmDiskGroupTotalMetricAttributeKey specifies the key of an attribute for the oracledb.asm.disk_group.total metric.
+type OracledbAsmDiskGroupTotalMetricAttributeKey string
 
 const (
-	OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskgroupTotalMetricAttributeKey = "oracledb.asm_diskgroup.name"
+	OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName OracledbAsmDiskGroupTotalMetricAttributeKey = "oracledb.asm.disk_group.name"
 )
 
-// OracledbAsmDiskgroupTotalMetricConfig provides config for the oracledb.asm_diskgroup.total metric.
-type OracledbAsmDiskgroupTotalMetricConfig struct {
+// OracledbAsmDiskGroupTotalMetricConfig provides config for the oracledb.asm.disk_group.total metric.
+type OracledbAsmDiskGroupTotalMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
 	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OracledbAsmDiskgroupTotalMetricAttributeKey `mapstructure:"attributes"`
+	EnabledAttributes   []OracledbAsmDiskGroupTotalMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OracledbAsmDiskgroupTotalMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OracledbAsmDiskGroupTotalMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -186,12 +186,12 @@ func (ms *OracledbAsmDiskgroupTotalMetricConfig) Unmarshal(parser *confmap.Conf)
 	return nil
 }
 
-func (ms *OracledbAsmDiskgroupTotalMetricConfig) Validate() error {
+func (ms *OracledbAsmDiskGroupTotalMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName:
+		case OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName:
 		default:
-			return fmt.Errorf("metric oracledb.asm_diskgroup.total doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name]", val)
+			return fmt.Errorf("metric oracledb.asm.disk_group.total doesn't have an attribute %v, valid attributes: [oracledb.asm.disk_group.name]", val)
 		}
 	}
 
@@ -204,23 +204,23 @@ func (ms *OracledbAsmDiskgroupTotalMetricConfig) Validate() error {
 	return nil
 }
 
-// OracledbAsmDiskgroupUsableFreeMetricAttributeKey specifies the key of an attribute for the oracledb.asm_diskgroup.usable_free metric.
-type OracledbAsmDiskgroupUsableFreeMetricAttributeKey string
+// OracledbAsmDiskGroupUsableFreeMetricAttributeKey specifies the key of an attribute for the oracledb.asm.disk_group.usable_free metric.
+type OracledbAsmDiskGroupUsableFreeMetricAttributeKey string
 
 const (
-	OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName OracledbAsmDiskgroupUsableFreeMetricAttributeKey = "oracledb.asm_diskgroup.name"
+	OracledbAsmDiskGroupUsableFreeMetricAttributeKeyOracledbAsmDiskGroupName OracledbAsmDiskGroupUsableFreeMetricAttributeKey = "oracledb.asm.disk_group.name"
 )
 
-// OracledbAsmDiskgroupUsableFreeMetricConfig provides config for the oracledb.asm_diskgroup.usable_free metric.
-type OracledbAsmDiskgroupUsableFreeMetricConfig struct {
+// OracledbAsmDiskGroupUsableFreeMetricConfig provides config for the oracledb.asm.disk_group.usable_free metric.
+type OracledbAsmDiskGroupUsableFreeMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
 
 	AggregationStrategy string                                             `mapstructure:"aggregation_strategy"`
-	EnabledAttributes   []OracledbAsmDiskgroupUsableFreeMetricAttributeKey `mapstructure:"attributes"`
+	EnabledAttributes   []OracledbAsmDiskGroupUsableFreeMetricAttributeKey `mapstructure:"attributes"`
 }
 
-func (ms *OracledbAsmDiskgroupUsableFreeMetricConfig) Unmarshal(parser *confmap.Conf) error {
+func (ms *OracledbAsmDiskGroupUsableFreeMetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -234,12 +234,12 @@ func (ms *OracledbAsmDiskgroupUsableFreeMetricConfig) Unmarshal(parser *confmap.
 	return nil
 }
 
-func (ms *OracledbAsmDiskgroupUsableFreeMetricConfig) Validate() error {
+func (ms *OracledbAsmDiskGroupUsableFreeMetricConfig) Validate() error {
 	for _, val := range ms.EnabledAttributes {
 		switch val {
-		case OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName:
+		case OracledbAsmDiskGroupUsableFreeMetricAttributeKeyOracledbAsmDiskGroupName:
 		default:
-			return fmt.Errorf("metric oracledb.asm_diskgroup.usable_free doesn't have an attribute %v, valid attributes: [oracledb.asm_diskgroup.name]", val)
+			return fmt.Errorf("metric oracledb.asm.disk_group.usable_free doesn't have an attribute %v, valid attributes: [oracledb.asm.disk_group.name]", val)
 		}
 	}
 
@@ -5316,11 +5316,11 @@ func (ms *OracledbUserRollbacksMetricConfig) Validate() error {
 
 // MetricsConfig provides config for oracledb metrics.
 type MetricsConfig struct {
-	OracledbAsmDiskErrors                         OracledbAsmDiskErrorsMetricConfig                         `mapstructure:"oracledb.asm_disk.errors"`
-	OracledbAsmDiskgroupFree                      OracledbAsmDiskgroupFreeMetricConfig                      `mapstructure:"oracledb.asm_diskgroup.free"`
-	OracledbAsmDiskgroupOfflineDisks              OracledbAsmDiskgroupOfflineDisksMetricConfig              `mapstructure:"oracledb.asm_diskgroup.offline_disks"`
-	OracledbAsmDiskgroupTotal                     OracledbAsmDiskgroupTotalMetricConfig                     `mapstructure:"oracledb.asm_diskgroup.total"`
-	OracledbAsmDiskgroupUsableFree                OracledbAsmDiskgroupUsableFreeMetricConfig                `mapstructure:"oracledb.asm_diskgroup.usable_free"`
+	OracledbAsmDiskErrors                         OracledbAsmDiskErrorsMetricConfig                         `mapstructure:"oracledb.asm.disk.errors"`
+	OracledbAsmDiskGroupFree                      OracledbAsmDiskGroupFreeMetricConfig                      `mapstructure:"oracledb.asm.disk_group.free"`
+	OracledbAsmDiskGroupOfflineDisks              OracledbAsmDiskGroupOfflineDisksMetricConfig              `mapstructure:"oracledb.asm.disk_group.offline_disks"`
+	OracledbAsmDiskGroupTotal                     OracledbAsmDiskGroupTotalMetricConfig                     `mapstructure:"oracledb.asm.disk_group.total"`
+	OracledbAsmDiskGroupUsableFree                OracledbAsmDiskGroupUsableFreeMetricConfig                `mapstructure:"oracledb.asm.disk_group.usable_free"`
 	OracledbBufferInspected                       OracledbBufferInspectedMetricConfig                       `mapstructure:"oracledb.buffer.inspected"`
 	OracledbBufferRequests                        OracledbBufferRequestsMetricConfig                        `mapstructure:"oracledb.buffer.requests"`
 	OracledbBufferCacheBlockChanges               OracledbBufferCacheBlockChangesMetricConfig               `mapstructure:"oracledb.buffer_cache.block.changes"`
@@ -5458,27 +5458,27 @@ func DefaultMetricsConfig() MetricsConfig {
 		OracledbAsmDiskErrors: OracledbAsmDiskErrorsMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategySum,
-			EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
+			EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskGroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
 		},
-		OracledbAsmDiskgroupFree: OracledbAsmDiskgroupFreeMetricConfig{
+		OracledbAsmDiskGroupFree: OracledbAsmDiskGroupFreeMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OracledbAsmDiskgroupFreeMetricAttributeKey{OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+			EnabledAttributes:   []OracledbAsmDiskGroupFreeMetricAttributeKey{OracledbAsmDiskGroupFreeMetricAttributeKeyOracledbAsmDiskGroupName},
 		},
-		OracledbAsmDiskgroupOfflineDisks: OracledbAsmDiskgroupOfflineDisksMetricConfig{
+		OracledbAsmDiskGroupOfflineDisks: OracledbAsmDiskGroupOfflineDisksMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey{OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName},
+			EnabledAttributes:   []OracledbAsmDiskGroupOfflineDisksMetricAttributeKey{OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName},
 		},
-		OracledbAsmDiskgroupTotal: OracledbAsmDiskgroupTotalMetricConfig{
+		OracledbAsmDiskGroupTotal: OracledbAsmDiskGroupTotalMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OracledbAsmDiskgroupTotalMetricAttributeKey{OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName},
+			EnabledAttributes:   []OracledbAsmDiskGroupTotalMetricAttributeKey{OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName},
 		},
-		OracledbAsmDiskgroupUsableFree: OracledbAsmDiskgroupUsableFreeMetricConfig{
+		OracledbAsmDiskGroupUsableFree: OracledbAsmDiskGroupUsableFreeMetricConfig{
 			Enabled:             false,
 			AggregationStrategy: AggregationStrategyAvg,
-			EnabledAttributes:   []OracledbAsmDiskgroupUsableFreeMetricAttributeKey{OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+			EnabledAttributes:   []OracledbAsmDiskGroupUsableFreeMetricAttributeKey{OracledbAsmDiskGroupUsableFreeMetricAttributeKeyOracledbAsmDiskGroupName},
 		},
 		OracledbBufferInspected: OracledbBufferInspectedMetricConfig{
 			Enabled:             false,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -30,27 +30,27 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbAsmDiskErrors: OracledbAsmDiskErrorsMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
+						EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskGroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
 					},
-					OracledbAsmDiskgroupFree: OracledbAsmDiskgroupFreeMetricConfig{
+					OracledbAsmDiskGroupFree: OracledbAsmDiskGroupFreeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskgroupFreeMetricAttributeKey{OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+						EnabledAttributes:   []OracledbAsmDiskGroupFreeMetricAttributeKey{OracledbAsmDiskGroupFreeMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
-					OracledbAsmDiskgroupOfflineDisks: OracledbAsmDiskgroupOfflineDisksMetricConfig{
+					OracledbAsmDiskGroupOfflineDisks: OracledbAsmDiskGroupOfflineDisksMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey{OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName},
+						EnabledAttributes:   []OracledbAsmDiskGroupOfflineDisksMetricAttributeKey{OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
-					OracledbAsmDiskgroupTotal: OracledbAsmDiskgroupTotalMetricConfig{
+					OracledbAsmDiskGroupTotal: OracledbAsmDiskGroupTotalMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskgroupTotalMetricAttributeKey{OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName},
+						EnabledAttributes:   []OracledbAsmDiskGroupTotalMetricAttributeKey{OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
-					OracledbAsmDiskgroupUsableFree: OracledbAsmDiskgroupUsableFreeMetricConfig{
+					OracledbAsmDiskGroupUsableFree: OracledbAsmDiskGroupUsableFreeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskgroupUsableFreeMetricAttributeKey{OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+						EnabledAttributes:   []OracledbAsmDiskGroupUsableFreeMetricAttributeKey{OracledbAsmDiskGroupUsableFreeMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
 					OracledbBufferInspected: OracledbBufferInspectedMetricConfig{
 						Enabled:             true,
@@ -637,27 +637,27 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					OracledbAsmDiskErrors: OracledbAsmDiskErrorsMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
-						EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
+						EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskGroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
 					},
-					OracledbAsmDiskgroupFree: OracledbAsmDiskgroupFreeMetricConfig{
+					OracledbAsmDiskGroupFree: OracledbAsmDiskGroupFreeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskgroupFreeMetricAttributeKey{OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+						EnabledAttributes:   []OracledbAsmDiskGroupFreeMetricAttributeKey{OracledbAsmDiskGroupFreeMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
-					OracledbAsmDiskgroupOfflineDisks: OracledbAsmDiskgroupOfflineDisksMetricConfig{
+					OracledbAsmDiskGroupOfflineDisks: OracledbAsmDiskGroupOfflineDisksMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey{OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName},
+						EnabledAttributes:   []OracledbAsmDiskGroupOfflineDisksMetricAttributeKey{OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
-					OracledbAsmDiskgroupTotal: OracledbAsmDiskgroupTotalMetricConfig{
+					OracledbAsmDiskGroupTotal: OracledbAsmDiskGroupTotalMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskgroupTotalMetricAttributeKey{OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName},
+						EnabledAttributes:   []OracledbAsmDiskGroupTotalMetricAttributeKey{OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
-					OracledbAsmDiskgroupUsableFree: OracledbAsmDiskgroupUsableFreeMetricConfig{
+					OracledbAsmDiskGroupUsableFree: OracledbAsmDiskGroupUsableFreeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskgroupUsableFreeMetricAttributeKey{OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+						EnabledAttributes:   []OracledbAsmDiskGroupUsableFreeMetricAttributeKey{OracledbAsmDiskGroupUsableFreeMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
 					OracledbBufferInspected: OracledbBufferInspectedMetricConfig{
 						Enabled:             false,
@@ -1241,7 +1241,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbAsmDiskErrorsMetricConfig{}, OracledbAsmDiskgroupFreeMetricConfig{}, OracledbAsmDiskgroupOfflineDisksMetricConfig{}, OracledbAsmDiskgroupTotalMetricConfig{}, OracledbAsmDiskgroupUsableFreeMetricConfig{}, OracledbBufferInspectedMetricConfig{}, OracledbBufferRequestsMetricConfig{}, OracledbBufferCacheBlockChangesMetricConfig{}, OracledbBufferCacheBlockChangesRateMetricConfig{}, OracledbBufferCacheBlockGetsMetricConfig{}, OracledbBufferCacheUtilizationMetricConfig{}, OracledbCallCountMetricConfig{}, OracledbCallRecursiveCPUTimeMetricConfig{}, OracledbCheckpointBuffersMetricConfig{}, OracledbCheckpointCompletedMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUUsageRateMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbCursorCacheHitsMetricConfig{}, OracledbCursorCacheSizeMetricConfig{}, OracledbCursorCacheUtilizationMetricConfig{}, OracledbCursorOpenMetricConfig{}, OracledbCursorOpenRateMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbTimeMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksRateMetricConfig{}, OracledbEnqueueOperationsMetricConfig{}, OracledbEnqueueTimeoutsRateMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbExecutionsRateMetricConfig{}, OracledbGcCurrentBlockTimeMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHardParsesRateMetricConfig{}, OracledbHostCPUUsageRateMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbIoRequestsRateMetricConfig{}, OracledbIoSingleBlockReadLatencyMetricConfig{}, OracledbIoThroughputRateMetricConfig{}, OracledbJvmMemoryCommittedMetricConfig{}, OracledbJvmMemoryLiveMetricConfig{}, OracledbJvmMemoryUsedMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLobOperationsMetricConfig{}, OracledbLockTimeMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogicalReadsRateMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbLogonsRateMetricConfig{}, OracledbOsSwapsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseCPUTimeMetricConfig{}, OracledbParseElapsedTimeMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaCacheUtilizationMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoRequestsRateMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalIoTransferredRateMetricConfig{}, OracledbPhysicalOperationsRateMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecoveryBlocksMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoRequestsMetricConfig{}, OracledbRedoRetriesMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoSizeRateMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbScanCountMetricConfig{}, OracledbScanTableRowsMetricConfig{}, OracledbSessionAverageMetricConfig{}, OracledbSessionStoredProcedureMemoryMetricConfig{}, OracledbSessionWaitTimeMetricConfig{}, OracledbSessionWaitsMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSgaLimitMetricConfig{}, OracledbSgaUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSmonPostsMetricConfig{}, OracledbSortOperationsMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSortRowsMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbSystemCPUCountMetricConfig{}, OracledbSystemMemoryLimitMetricConfig{}, OracledbSystemProcessCountMetricConfig{}, OracledbTablespaceLimitMetricConfig{}, OracledbTablespaceStatusMetricConfig{}, OracledbTablespaceUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionResponseTimeMetricConfig{}, OracledbTransactionRollbacksMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsRateMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, HostNameResourceAttributeConfig{}, OracleDbHostingTypeResourceAttributeConfig{}, OracleDbOpenModeResourceAttributeConfig{}, OracleDbRoleResourceAttributeConfig{}, OracleDbVersionResourceAttributeConfig{}, OracledbInstanceNameResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbAsmDiskErrorsMetricConfig{}, OracledbAsmDiskGroupFreeMetricConfig{}, OracledbAsmDiskGroupOfflineDisksMetricConfig{}, OracledbAsmDiskGroupTotalMetricConfig{}, OracledbAsmDiskGroupUsableFreeMetricConfig{}, OracledbBufferInspectedMetricConfig{}, OracledbBufferRequestsMetricConfig{}, OracledbBufferCacheBlockChangesMetricConfig{}, OracledbBufferCacheBlockChangesRateMetricConfig{}, OracledbBufferCacheBlockGetsMetricConfig{}, OracledbBufferCacheUtilizationMetricConfig{}, OracledbCallCountMetricConfig{}, OracledbCallRecursiveCPUTimeMetricConfig{}, OracledbCheckpointBuffersMetricConfig{}, OracledbCheckpointCompletedMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUUsageRateMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbCursorCacheHitsMetricConfig{}, OracledbCursorCacheSizeMetricConfig{}, OracledbCursorCacheUtilizationMetricConfig{}, OracledbCursorOpenMetricConfig{}, OracledbCursorOpenRateMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbTimeMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksRateMetricConfig{}, OracledbEnqueueOperationsMetricConfig{}, OracledbEnqueueTimeoutsRateMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbExecutionsRateMetricConfig{}, OracledbGcCurrentBlockTimeMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHardParsesRateMetricConfig{}, OracledbHostCPUUsageRateMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbIoRequestsRateMetricConfig{}, OracledbIoSingleBlockReadLatencyMetricConfig{}, OracledbIoThroughputRateMetricConfig{}, OracledbJvmMemoryCommittedMetricConfig{}, OracledbJvmMemoryLiveMetricConfig{}, OracledbJvmMemoryUsedMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLobOperationsMetricConfig{}, OracledbLockTimeMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogicalReadsRateMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbLogonsRateMetricConfig{}, OracledbOsSwapsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseCPUTimeMetricConfig{}, OracledbParseElapsedTimeMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaCacheUtilizationMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoRequestsRateMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalIoTransferredRateMetricConfig{}, OracledbPhysicalOperationsRateMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecoveryBlocksMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoRequestsMetricConfig{}, OracledbRedoRetriesMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoSizeRateMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbScanCountMetricConfig{}, OracledbScanTableRowsMetricConfig{}, OracledbSessionAverageMetricConfig{}, OracledbSessionStoredProcedureMemoryMetricConfig{}, OracledbSessionWaitTimeMetricConfig{}, OracledbSessionWaitsMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSgaLimitMetricConfig{}, OracledbSgaUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSmonPostsMetricConfig{}, OracledbSortOperationsMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSortRowsMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbSystemCPUCountMetricConfig{}, OracledbSystemMemoryLimitMetricConfig{}, OracledbSystemProcessCountMetricConfig{}, OracledbTablespaceLimitMetricConfig{}, OracledbTablespaceStatusMetricConfig{}, OracledbTablespaceUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionResponseTimeMetricConfig{}, OracledbTransactionRollbacksMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsRateMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, HostNameResourceAttributeConfig{}, OracleDbHostingTypeResourceAttributeConfig{}, OracleDbOpenModeResourceAttributeConfig{}, OracleDbRoleResourceAttributeConfig{}, OracleDbVersionResourceAttributeConfig{}, OracledbInstanceNameResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -1251,57 +1251,57 @@ func TestOracledbAsmDiskErrorsMetricsConfig_Validate(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 
 	cfg.EnabledAttributes = []OracledbAsmDiskErrorsMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_disk.errors doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name, oracledb.asm_disk.name, disk.io.direction]")
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm.disk.errors doesn't have an attribute invalid, valid attributes: [oracledb.asm.disk_group.name, oracledb.asm.disk.name, disk.io.direction]")
 
 	cfg = DefaultMetricsConfig().OracledbAsmDiskErrors
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
-func TestOracledbAsmDiskgroupFreeMetricsConfig_Validate(t *testing.T) {
-	cfg := DefaultMetricsConfig().OracledbAsmDiskgroupFree
+func TestOracledbAsmDiskGroupFreeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskGroupFree
 	require.NoError(t, cfg.Validate())
 
-	cfg.EnabledAttributes = []OracledbAsmDiskgroupFreeMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_diskgroup.free doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name]")
+	cfg.EnabledAttributes = []OracledbAsmDiskGroupFreeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm.disk_group.free doesn't have an attribute invalid, valid attributes: [oracledb.asm.disk_group.name]")
 
-	cfg = DefaultMetricsConfig().OracledbAsmDiskgroupFree
+	cfg = DefaultMetricsConfig().OracledbAsmDiskGroupFree
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
-func TestOracledbAsmDiskgroupOfflineDisksMetricsConfig_Validate(t *testing.T) {
-	cfg := DefaultMetricsConfig().OracledbAsmDiskgroupOfflineDisks
+func TestOracledbAsmDiskGroupOfflineDisksMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskGroupOfflineDisks
 	require.NoError(t, cfg.Validate())
 
-	cfg.EnabledAttributes = []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_diskgroup.offline_disks doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name]")
+	cfg.EnabledAttributes = []OracledbAsmDiskGroupOfflineDisksMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm.disk_group.offline_disks doesn't have an attribute invalid, valid attributes: [oracledb.asm.disk_group.name]")
 
-	cfg = DefaultMetricsConfig().OracledbAsmDiskgroupOfflineDisks
+	cfg = DefaultMetricsConfig().OracledbAsmDiskGroupOfflineDisks
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
-func TestOracledbAsmDiskgroupTotalMetricsConfig_Validate(t *testing.T) {
-	cfg := DefaultMetricsConfig().OracledbAsmDiskgroupTotal
+func TestOracledbAsmDiskGroupTotalMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskGroupTotal
 	require.NoError(t, cfg.Validate())
 
-	cfg.EnabledAttributes = []OracledbAsmDiskgroupTotalMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_diskgroup.total doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name]")
+	cfg.EnabledAttributes = []OracledbAsmDiskGroupTotalMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm.disk_group.total doesn't have an attribute invalid, valid attributes: [oracledb.asm.disk_group.name]")
 
-	cfg = DefaultMetricsConfig().OracledbAsmDiskgroupTotal
+	cfg = DefaultMetricsConfig().OracledbAsmDiskGroupTotal
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
 
-func TestOracledbAsmDiskgroupUsableFreeMetricsConfig_Validate(t *testing.T) {
-	cfg := DefaultMetricsConfig().OracledbAsmDiskgroupUsableFree
+func TestOracledbAsmDiskGroupUsableFreeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskGroupUsableFree
 	require.NoError(t, cfg.Validate())
 
-	cfg.EnabledAttributes = []OracledbAsmDiskgroupUsableFreeMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_diskgroup.usable_free doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name]")
+	cfg.EnabledAttributes = []OracledbAsmDiskGroupUsableFreeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm.disk_group.usable_free doesn't have an attribute invalid, valid attributes: [oracledb.asm.disk_group.name]")
 
-	cfg = DefaultMetricsConfig().OracledbAsmDiskgroupUsableFree
+	cfg = DefaultMetricsConfig().OracledbAsmDiskGroupUsableFree
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -27,6 +27,31 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					OracledbAsmDiskErrors: OracledbAsmDiskErrorsMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
+					},
+					OracledbAsmDiskgroupFree: OracledbAsmDiskgroupFreeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskgroupFreeMetricAttributeKey{OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+					},
+					OracledbAsmDiskgroupOfflineDisks: OracledbAsmDiskgroupOfflineDisksMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey{OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName},
+					},
+					OracledbAsmDiskgroupTotal: OracledbAsmDiskgroupTotalMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskgroupTotalMetricAttributeKey{OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName},
+					},
+					OracledbAsmDiskgroupUsableFree: OracledbAsmDiskgroupUsableFreeMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskgroupUsableFreeMetricAttributeKey{OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+					},
 					OracledbBufferInspected: OracledbBufferInspectedMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategySum,
@@ -609,6 +634,31 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					OracledbAsmDiskErrors: OracledbAsmDiskErrorsMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
+					},
+					OracledbAsmDiskgroupFree: OracledbAsmDiskgroupFreeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskgroupFreeMetricAttributeKey{OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+					},
+					OracledbAsmDiskgroupOfflineDisks: OracledbAsmDiskgroupOfflineDisksMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey{OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName},
+					},
+					OracledbAsmDiskgroupTotal: OracledbAsmDiskgroupTotalMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskgroupTotalMetricAttributeKey{OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName},
+					},
+					OracledbAsmDiskgroupUsableFree: OracledbAsmDiskgroupUsableFreeMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskgroupUsableFreeMetricAttributeKey{OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName},
+					},
 					OracledbBufferInspected: OracledbBufferInspectedMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategySum,
@@ -1191,11 +1241,71 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbBufferInspectedMetricConfig{}, OracledbBufferRequestsMetricConfig{}, OracledbBufferCacheBlockChangesMetricConfig{}, OracledbBufferCacheBlockChangesRateMetricConfig{}, OracledbBufferCacheBlockGetsMetricConfig{}, OracledbBufferCacheUtilizationMetricConfig{}, OracledbCallCountMetricConfig{}, OracledbCallRecursiveCPUTimeMetricConfig{}, OracledbCheckpointBuffersMetricConfig{}, OracledbCheckpointCompletedMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUUsageRateMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbCursorCacheHitsMetricConfig{}, OracledbCursorCacheSizeMetricConfig{}, OracledbCursorCacheUtilizationMetricConfig{}, OracledbCursorOpenMetricConfig{}, OracledbCursorOpenRateMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbTimeMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksRateMetricConfig{}, OracledbEnqueueOperationsMetricConfig{}, OracledbEnqueueTimeoutsRateMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbExecutionsRateMetricConfig{}, OracledbGcCurrentBlockTimeMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHardParsesRateMetricConfig{}, OracledbHostCPUUsageRateMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbIoRequestsRateMetricConfig{}, OracledbIoSingleBlockReadLatencyMetricConfig{}, OracledbIoThroughputRateMetricConfig{}, OracledbJvmMemoryCommittedMetricConfig{}, OracledbJvmMemoryLiveMetricConfig{}, OracledbJvmMemoryUsedMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLobOperationsMetricConfig{}, OracledbLockTimeMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogicalReadsRateMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbLogonsRateMetricConfig{}, OracledbOsSwapsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseCPUTimeMetricConfig{}, OracledbParseElapsedTimeMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaCacheUtilizationMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoRequestsRateMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalIoTransferredRateMetricConfig{}, OracledbPhysicalOperationsRateMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecoveryBlocksMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoRequestsMetricConfig{}, OracledbRedoRetriesMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoSizeRateMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbScanCountMetricConfig{}, OracledbScanTableRowsMetricConfig{}, OracledbSessionAverageMetricConfig{}, OracledbSessionStoredProcedureMemoryMetricConfig{}, OracledbSessionWaitTimeMetricConfig{}, OracledbSessionWaitsMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSgaLimitMetricConfig{}, OracledbSgaUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSmonPostsMetricConfig{}, OracledbSortOperationsMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSortRowsMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbSystemCPUCountMetricConfig{}, OracledbSystemMemoryLimitMetricConfig{}, OracledbSystemProcessCountMetricConfig{}, OracledbTablespaceLimitMetricConfig{}, OracledbTablespaceStatusMetricConfig{}, OracledbTablespaceUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionResponseTimeMetricConfig{}, OracledbTransactionRollbacksMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsRateMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, HostNameResourceAttributeConfig{}, OracleDbHostingTypeResourceAttributeConfig{}, OracleDbOpenModeResourceAttributeConfig{}, OracleDbRoleResourceAttributeConfig{}, OracleDbVersionResourceAttributeConfig{}, OracledbInstanceNameResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbAsmDiskErrorsMetricConfig{}, OracledbAsmDiskgroupFreeMetricConfig{}, OracledbAsmDiskgroupOfflineDisksMetricConfig{}, OracledbAsmDiskgroupTotalMetricConfig{}, OracledbAsmDiskgroupUsableFreeMetricConfig{}, OracledbBufferInspectedMetricConfig{}, OracledbBufferRequestsMetricConfig{}, OracledbBufferCacheBlockChangesMetricConfig{}, OracledbBufferCacheBlockChangesRateMetricConfig{}, OracledbBufferCacheBlockGetsMetricConfig{}, OracledbBufferCacheUtilizationMetricConfig{}, OracledbCallCountMetricConfig{}, OracledbCallRecursiveCPUTimeMetricConfig{}, OracledbCheckpointBuffersMetricConfig{}, OracledbCheckpointCompletedMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUUsageRateMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbCursorCacheHitsMetricConfig{}, OracledbCursorCacheSizeMetricConfig{}, OracledbCursorCacheUtilizationMetricConfig{}, OracledbCursorOpenMetricConfig{}, OracledbCursorOpenRateMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbTimeMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksRateMetricConfig{}, OracledbEnqueueOperationsMetricConfig{}, OracledbEnqueueTimeoutsRateMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbExecutionsRateMetricConfig{}, OracledbGcCurrentBlockTimeMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHardParsesRateMetricConfig{}, OracledbHostCPUUsageRateMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbIoRequestsRateMetricConfig{}, OracledbIoSingleBlockReadLatencyMetricConfig{}, OracledbIoThroughputRateMetricConfig{}, OracledbJvmMemoryCommittedMetricConfig{}, OracledbJvmMemoryLiveMetricConfig{}, OracledbJvmMemoryUsedMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLobOperationsMetricConfig{}, OracledbLockTimeMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogicalReadsRateMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbLogonsRateMetricConfig{}, OracledbOsSwapsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseCPUTimeMetricConfig{}, OracledbParseElapsedTimeMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaCacheUtilizationMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoRequestsRateMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalIoTransferredRateMetricConfig{}, OracledbPhysicalOperationsRateMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecoveryBlocksMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoRequestsMetricConfig{}, OracledbRedoRetriesMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoSizeRateMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbScanCountMetricConfig{}, OracledbScanTableRowsMetricConfig{}, OracledbSessionAverageMetricConfig{}, OracledbSessionStoredProcedureMemoryMetricConfig{}, OracledbSessionWaitTimeMetricConfig{}, OracledbSessionWaitsMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSgaLimitMetricConfig{}, OracledbSgaUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSmonPostsMetricConfig{}, OracledbSortOperationsMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSortRowsMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbSystemCPUCountMetricConfig{}, OracledbSystemMemoryLimitMetricConfig{}, OracledbSystemProcessCountMetricConfig{}, OracledbTablespaceLimitMetricConfig{}, OracledbTablespaceStatusMetricConfig{}, OracledbTablespaceUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionResponseTimeMetricConfig{}, OracledbTransactionRollbacksMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsRateMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, HostNameResourceAttributeConfig{}, OracleDbHostingTypeResourceAttributeConfig{}, OracleDbOpenModeResourceAttributeConfig{}, OracleDbRoleResourceAttributeConfig{}, OracleDbVersionResourceAttributeConfig{}, OracledbInstanceNameResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
 }
+func TestOracledbAsmDiskErrorsMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskErrors
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbAsmDiskErrorsMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_disk.errors doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name, oracledb.asm_disk.name, disk.io.direction]")
+
+	cfg = DefaultMetricsConfig().OracledbAsmDiskErrors
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbAsmDiskgroupFreeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskgroupFree
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbAsmDiskgroupFreeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_diskgroup.free doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name]")
+
+	cfg = DefaultMetricsConfig().OracledbAsmDiskgroupFree
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbAsmDiskgroupOfflineDisksMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskgroupOfflineDisks
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbAsmDiskgroupOfflineDisksMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_diskgroup.offline_disks doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name]")
+
+	cfg = DefaultMetricsConfig().OracledbAsmDiskgroupOfflineDisks
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbAsmDiskgroupTotalMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskgroupTotal
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbAsmDiskgroupTotalMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_diskgroup.total doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name]")
+
+	cfg = DefaultMetricsConfig().OracledbAsmDiskgroupTotal
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbAsmDiskgroupUsableFreeMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskgroupUsableFree
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbAsmDiskgroupUsableFreeMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm_diskgroup.usable_free doesn't have an attribute invalid, valid attributes: [oracledb.asm_diskgroup.name]")
+
+	cfg = DefaultMetricsConfig().OracledbAsmDiskgroupUsableFree
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
 func TestOracledbBufferInspectedMetricsConfig_Validate(t *testing.T) {
 	cfg := DefaultMetricsConfig().OracledbBufferInspected
 	require.NoError(t, cfg.Validate())

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -32,6 +32,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskGroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
 					},
+					OracledbAsmDiskGroupCapacity: OracledbAsmDiskGroupCapacityMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskGroupCapacityMetricAttributeKey{OracledbAsmDiskGroupCapacityMetricAttributeKeyOracledbAsmDiskGroupName},
+					},
 					OracledbAsmDiskGroupFree: OracledbAsmDiskGroupFreeMetricConfig{
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -41,11 +46,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             true,
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []OracledbAsmDiskGroupOfflineDisksMetricAttributeKey{OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName},
-					},
-					OracledbAsmDiskGroupTotal: OracledbAsmDiskGroupTotalMetricConfig{
-						Enabled:             true,
-						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskGroupTotalMetricAttributeKey{OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
 					OracledbAsmDiskGroupUsableFree: OracledbAsmDiskGroupUsableFreeMetricConfig{
 						Enabled:             true,
@@ -639,6 +639,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []OracledbAsmDiskErrorsMetricAttributeKey{OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskGroupName, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection},
 					},
+					OracledbAsmDiskGroupCapacity: OracledbAsmDiskGroupCapacityMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []OracledbAsmDiskGroupCapacityMetricAttributeKey{OracledbAsmDiskGroupCapacityMetricAttributeKeyOracledbAsmDiskGroupName},
+					},
 					OracledbAsmDiskGroupFree: OracledbAsmDiskGroupFreeMetricConfig{
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
@@ -648,11 +653,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						Enabled:             false,
 						AggregationStrategy: AggregationStrategyAvg,
 						EnabledAttributes:   []OracledbAsmDiskGroupOfflineDisksMetricAttributeKey{OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName},
-					},
-					OracledbAsmDiskGroupTotal: OracledbAsmDiskGroupTotalMetricConfig{
-						Enabled:             false,
-						AggregationStrategy: AggregationStrategyAvg,
-						EnabledAttributes:   []OracledbAsmDiskGroupTotalMetricAttributeKey{OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName},
 					},
 					OracledbAsmDiskGroupUsableFree: OracledbAsmDiskGroupUsableFreeMetricConfig{
 						Enabled:             false,
@@ -1241,7 +1241,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbAsmDiskErrorsMetricConfig{}, OracledbAsmDiskGroupFreeMetricConfig{}, OracledbAsmDiskGroupOfflineDisksMetricConfig{}, OracledbAsmDiskGroupTotalMetricConfig{}, OracledbAsmDiskGroupUsableFreeMetricConfig{}, OracledbBufferInspectedMetricConfig{}, OracledbBufferRequestsMetricConfig{}, OracledbBufferCacheBlockChangesMetricConfig{}, OracledbBufferCacheBlockChangesRateMetricConfig{}, OracledbBufferCacheBlockGetsMetricConfig{}, OracledbBufferCacheUtilizationMetricConfig{}, OracledbCallCountMetricConfig{}, OracledbCallRecursiveCPUTimeMetricConfig{}, OracledbCheckpointBuffersMetricConfig{}, OracledbCheckpointCompletedMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUUsageRateMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbCursorCacheHitsMetricConfig{}, OracledbCursorCacheSizeMetricConfig{}, OracledbCursorCacheUtilizationMetricConfig{}, OracledbCursorOpenMetricConfig{}, OracledbCursorOpenRateMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbTimeMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksRateMetricConfig{}, OracledbEnqueueOperationsMetricConfig{}, OracledbEnqueueTimeoutsRateMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbExecutionsRateMetricConfig{}, OracledbGcCurrentBlockTimeMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHardParsesRateMetricConfig{}, OracledbHostCPUUsageRateMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbIoRequestsRateMetricConfig{}, OracledbIoSingleBlockReadLatencyMetricConfig{}, OracledbIoThroughputRateMetricConfig{}, OracledbJvmMemoryCommittedMetricConfig{}, OracledbJvmMemoryLiveMetricConfig{}, OracledbJvmMemoryUsedMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLobOperationsMetricConfig{}, OracledbLockTimeMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogicalReadsRateMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbLogonsRateMetricConfig{}, OracledbOsSwapsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseCPUTimeMetricConfig{}, OracledbParseElapsedTimeMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaCacheUtilizationMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoRequestsRateMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalIoTransferredRateMetricConfig{}, OracledbPhysicalOperationsRateMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecoveryBlocksMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoRequestsMetricConfig{}, OracledbRedoRetriesMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoSizeRateMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbScanCountMetricConfig{}, OracledbScanTableRowsMetricConfig{}, OracledbSessionAverageMetricConfig{}, OracledbSessionStoredProcedureMemoryMetricConfig{}, OracledbSessionWaitTimeMetricConfig{}, OracledbSessionWaitsMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSgaLimitMetricConfig{}, OracledbSgaUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSmonPostsMetricConfig{}, OracledbSortOperationsMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSortRowsMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbSystemCPUCountMetricConfig{}, OracledbSystemMemoryLimitMetricConfig{}, OracledbSystemProcessCountMetricConfig{}, OracledbTablespaceLimitMetricConfig{}, OracledbTablespaceStatusMetricConfig{}, OracledbTablespaceUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionResponseTimeMetricConfig{}, OracledbTransactionRollbacksMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsRateMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, HostNameResourceAttributeConfig{}, OracleDbHostingTypeResourceAttributeConfig{}, OracleDbOpenModeResourceAttributeConfig{}, OracleDbRoleResourceAttributeConfig{}, OracleDbVersionResourceAttributeConfig{}, OracledbInstanceNameResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(OracledbAsmDiskErrorsMetricConfig{}, OracledbAsmDiskGroupCapacityMetricConfig{}, OracledbAsmDiskGroupFreeMetricConfig{}, OracledbAsmDiskGroupOfflineDisksMetricConfig{}, OracledbAsmDiskGroupUsableFreeMetricConfig{}, OracledbBufferInspectedMetricConfig{}, OracledbBufferRequestsMetricConfig{}, OracledbBufferCacheBlockChangesMetricConfig{}, OracledbBufferCacheBlockChangesRateMetricConfig{}, OracledbBufferCacheBlockGetsMetricConfig{}, OracledbBufferCacheUtilizationMetricConfig{}, OracledbCallCountMetricConfig{}, OracledbCallRecursiveCPUTimeMetricConfig{}, OracledbCheckpointBuffersMetricConfig{}, OracledbCheckpointCompletedMetricConfig{}, OracledbConsistentGetsMetricConfig{}, OracledbCPUUsageRateMetricConfig{}, OracledbCPUTimeMetricConfig{}, OracledbCursorCacheHitsMetricConfig{}, OracledbCursorCacheSizeMetricConfig{}, OracledbCursorCacheUtilizationMetricConfig{}, OracledbCursorOpenMetricConfig{}, OracledbCursorOpenRateMetricConfig{}, OracledbDataDictionaryHitRatioMetricConfig{}, OracledbDatabaseCPUUtilizationMetricConfig{}, OracledbDatabaseWaitUtilizationMetricConfig{}, OracledbDbTimeMetricConfig{}, OracledbDbBlockGetsMetricConfig{}, OracledbDdlStatementsParallelizedMetricConfig{}, OracledbDmlLocksLimitMetricConfig{}, OracledbDmlLocksUsageMetricConfig{}, OracledbDmlStatementsParallelizedMetricConfig{}, OracledbEnqueueDeadlocksRateMetricConfig{}, OracledbEnqueueOperationsMetricConfig{}, OracledbEnqueueTimeoutsRateMetricConfig{}, OracledbEnqueueDeadlocksMetricConfig{}, OracledbEnqueueLocksLimitMetricConfig{}, OracledbEnqueueLocksUsageMetricConfig{}, OracledbEnqueueResourcesLimitMetricConfig{}, OracledbEnqueueResourcesUsageMetricConfig{}, OracledbExchangeDeadlocksMetricConfig{}, OracledbExecutionUtilizationMetricConfig{}, OracledbExecutionsMetricConfig{}, OracledbExecutionsRateMetricConfig{}, OracledbGcCurrentBlockTimeMetricConfig{}, OracledbHardParsesMetricConfig{}, OracledbHardParsesRateMetricConfig{}, OracledbHostCPUUsageRateMetricConfig{}, OracledbHostCPUUtilizationMetricConfig{}, OracledbIoRequestsRateMetricConfig{}, OracledbIoSingleBlockReadLatencyMetricConfig{}, OracledbIoThroughputRateMetricConfig{}, OracledbJvmMemoryCommittedMetricConfig{}, OracledbJvmMemoryLiveMetricConfig{}, OracledbJvmMemoryUsedMetricConfig{}, OracledbLibraryCacheUtilizationMetricConfig{}, OracledbLobOperationsMetricConfig{}, OracledbLockTimeMetricConfig{}, OracledbLogicalReadsMetricConfig{}, OracledbLogicalReadsRateMetricConfig{}, OracledbLogonsMetricConfig{}, OracledbLogonsRateMetricConfig{}, OracledbOsSwapsMetricConfig{}, OracledbParallelOperationsDowngraded1To25PctMetricConfig{}, OracledbParallelOperationsDowngraded25To50PctMetricConfig{}, OracledbParallelOperationsDowngraded50To75PctMetricConfig{}, OracledbParallelOperationsDowngraded75To99PctMetricConfig{}, OracledbParallelOperationsDowngradedToSerialMetricConfig{}, OracledbParallelOperationsNotDowngradedMetricConfig{}, OracledbParseCPUTimeMetricConfig{}, OracledbParseElapsedTimeMetricConfig{}, OracledbParseRateMetricConfig{}, OracledbParseUtilizationMetricConfig{}, OracledbParseCallsMetricConfig{}, OracledbPgaCacheUtilizationMetricConfig{}, OracledbPgaMemoryMetricConfig{}, OracledbPhysicalIoCacheWritesMetricConfig{}, OracledbPhysicalIoRequestsMetricConfig{}, OracledbPhysicalIoRequestsRateMetricConfig{}, OracledbPhysicalIoTransferredMetricConfig{}, OracledbPhysicalIoTransferredRateMetricConfig{}, OracledbPhysicalOperationsRateMetricConfig{}, OracledbPhysicalReadIoRequestsMetricConfig{}, OracledbPhysicalReadsMetricConfig{}, OracledbPhysicalReadsDirectMetricConfig{}, OracledbPhysicalWriteIoRequestsMetricConfig{}, OracledbPhysicalWritesMetricConfig{}, OracledbPhysicalWritesDirectMetricConfig{}, OracledbProcessesLimitMetricConfig{}, OracledbProcessesUsageMetricConfig{}, OracledbQueriesParallelizedMetricConfig{}, OracledbRecoveryBlocksMetricConfig{}, OracledbRecycleBinLimitMetricConfig{}, OracledbRedoBlocksMetricConfig{}, OracledbRedoOperationsMetricConfig{}, OracledbRedoRequestsMetricConfig{}, OracledbRedoRetriesMetricConfig{}, OracledbRedoSizeMetricConfig{}, OracledbRedoSizeRateMetricConfig{}, OracledbRedoTimeMetricConfig{}, OracledbRedoAllocationUtilizationMetricConfig{}, OracledbScanCountMetricConfig{}, OracledbScanTableRowsMetricConfig{}, OracledbSessionAverageMetricConfig{}, OracledbSessionStoredProcedureMemoryMetricConfig{}, OracledbSessionWaitTimeMetricConfig{}, OracledbSessionWaitsMetricConfig{}, OracledbSessionsLimitMetricConfig{}, OracledbSessionsUsageMetricConfig{}, OracledbSgaLimitMetricConfig{}, OracledbSgaUsageMetricConfig{}, OracledbSharedPoolUtilizationMetricConfig{}, OracledbSmonPostsMetricConfig{}, OracledbSortOperationsMetricConfig{}, OracledbSortRatioMetricConfig{}, OracledbSortRowsMetricConfig{}, OracledbSQLServiceResponseDurationMetricConfig{}, OracledbSqlnetIoTransferredMetricConfig{}, OracledbStorageUsageMetricConfig{}, OracledbStorageUtilizationMetricConfig{}, OracledbSystemCPUCountMetricConfig{}, OracledbSystemMemoryLimitMetricConfig{}, OracledbSystemProcessCountMetricConfig{}, OracledbTablespaceLimitMetricConfig{}, OracledbTablespaceStatusMetricConfig{}, OracledbTablespaceUtilizationMetricConfig{}, OracledbTablespaceSizeLimitMetricConfig{}, OracledbTablespaceSizeUsageMetricConfig{}, OracledbTransactionResponseTimeMetricConfig{}, OracledbTransactionRollbacksMetricConfig{}, OracledbTransactionsLimitMetricConfig{}, OracledbTransactionsRateMetricConfig{}, OracledbTransactionsUsageMetricConfig{}, OracledbUserCommitsMetricConfig{}, OracledbUserRollbacksMetricConfig{}, HostNameResourceAttributeConfig{}, OracleDbHostingTypeResourceAttributeConfig{}, OracleDbOpenModeResourceAttributeConfig{}, OracleDbRoleResourceAttributeConfig{}, OracleDbVersionResourceAttributeConfig{}, OracledbInstanceNameResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -1254,6 +1254,18 @@ func TestOracledbAsmDiskErrorsMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm.disk.errors doesn't have an attribute invalid, valid attributes: [oracledb.asm.disk_group.name, oracledb.asm.disk.name, disk.io.direction]")
 
 	cfg = DefaultMetricsConfig().OracledbAsmDiskErrors
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestOracledbAsmDiskGroupCapacityMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().OracledbAsmDiskGroupCapacity
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []OracledbAsmDiskGroupCapacityMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm.disk_group.capacity doesn't have an attribute invalid, valid attributes: [oracledb.asm.disk_group.name]")
+
+	cfg = DefaultMetricsConfig().OracledbAsmDiskGroupCapacity
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }
@@ -1278,18 +1290,6 @@ func TestOracledbAsmDiskGroupOfflineDisksMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm.disk_group.offline_disks doesn't have an attribute invalid, valid attributes: [oracledb.asm.disk_group.name]")
 
 	cfg = DefaultMetricsConfig().OracledbAsmDiskGroupOfflineDisks
-	cfg.AggregationStrategy = "invalid"
-	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
-}
-
-func TestOracledbAsmDiskGroupTotalMetricsConfig_Validate(t *testing.T) {
-	cfg := DefaultMetricsConfig().OracledbAsmDiskGroupTotal
-	require.NoError(t, cfg.Validate())
-
-	cfg.EnabledAttributes = []OracledbAsmDiskGroupTotalMetricAttributeKey{"invalid"}
-	require.ErrorContains(t, cfg.Validate(), "metric oracledb.asm.disk_group.total doesn't have an attribute invalid, valid attributes: [oracledb.asm.disk_group.name]")
-
-	cfg = DefaultMetricsConfig().OracledbAsmDiskGroupTotal
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -636,24 +636,24 @@ var MapAttributeOracledbTransactionType = map[string]AttributeOracledbTransactio
 
 var MetricsInfo = metricsInfo{
 	OracledbAsmDiskErrors: metricInfo{
-		Name:       "oracledb.asm_disk.errors",
-		Attributes: []string{"oracledb.asm_diskgroup.name", "oracledb.asm_disk.name", "disk.io.direction"},
+		Name:       "oracledb.asm.disk.errors",
+		Attributes: []string{"oracledb.asm.disk_group.name", "oracledb.asm.disk.name", "disk.io.direction"},
 	},
-	OracledbAsmDiskgroupFree: metricInfo{
-		Name:       "oracledb.asm_diskgroup.free",
-		Attributes: []string{"oracledb.asm_diskgroup.name"},
+	OracledbAsmDiskGroupFree: metricInfo{
+		Name:       "oracledb.asm.disk_group.free",
+		Attributes: []string{"oracledb.asm.disk_group.name"},
 	},
-	OracledbAsmDiskgroupOfflineDisks: metricInfo{
-		Name:       "oracledb.asm_diskgroup.offline_disks",
-		Attributes: []string{"oracledb.asm_diskgroup.name"},
+	OracledbAsmDiskGroupOfflineDisks: metricInfo{
+		Name:       "oracledb.asm.disk_group.offline_disks",
+		Attributes: []string{"oracledb.asm.disk_group.name"},
 	},
-	OracledbAsmDiskgroupTotal: metricInfo{
-		Name:       "oracledb.asm_diskgroup.total",
-		Attributes: []string{"oracledb.asm_diskgroup.name"},
+	OracledbAsmDiskGroupTotal: metricInfo{
+		Name:       "oracledb.asm.disk_group.total",
+		Attributes: []string{"oracledb.asm.disk_group.name"},
 	},
-	OracledbAsmDiskgroupUsableFree: metricInfo{
-		Name:       "oracledb.asm_diskgroup.usable_free",
-		Attributes: []string{"oracledb.asm_diskgroup.name"},
+	OracledbAsmDiskGroupUsableFree: metricInfo{
+		Name:       "oracledb.asm.disk_group.usable_free",
+		Attributes: []string{"oracledb.asm.disk_group.name"},
 	},
 	OracledbBufferInspected: metricInfo{
 		Name:       "oracledb.buffer.inspected",
@@ -1136,10 +1136,10 @@ var MetricsInfo = metricsInfo{
 
 type metricsInfo struct {
 	OracledbAsmDiskErrors                         metricInfo
-	OracledbAsmDiskgroupFree                      metricInfo
-	OracledbAsmDiskgroupOfflineDisks              metricInfo
-	OracledbAsmDiskgroupTotal                     metricInfo
-	OracledbAsmDiskgroupUsableFree                metricInfo
+	OracledbAsmDiskGroupFree                      metricInfo
+	OracledbAsmDiskGroupOfflineDisks              metricInfo
+	OracledbAsmDiskGroupTotal                     metricInfo
+	OracledbAsmDiskGroupUsableFree                metricInfo
 	OracledbBufferInspected                       metricInfo
 	OracledbBufferRequests                        metricInfo
 	OracledbBufferCacheBlockChanges               metricInfo
@@ -1284,9 +1284,9 @@ type metricOracledbAsmDiskErrors struct {
 	aggDataPoints []int64                           // slice containing number of aggregated datapoints at each index
 }
 
-// init fills oracledb.asm_disk.errors metric with initial data.
+// init fills oracledb.asm.disk.errors metric with initial data.
 func (m *metricOracledbAsmDiskErrors) init() {
-	m.data.SetName("oracledb.asm_disk.errors")
+	m.data.SetName("oracledb.asm.disk.errors")
 	m.data.SetDescription("Count of I/O errors on an ASM disk.")
 	m.data.SetUnit("{error}")
 	m.data.SetEmptySum()
@@ -1296,7 +1296,7 @@ func (m *metricOracledbAsmDiskErrors) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricOracledbAsmDiskErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string, oracledbAsmDiskNameAttributeValue string, diskIoDirectionAttributeValue string) {
+func (m *metricOracledbAsmDiskErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string, oracledbAsmDiskNameAttributeValue string, diskIoDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -1304,11 +1304,11 @@ func (m *metricOracledbAsmDiskErrors) recordDataPoint(start pcommon.Timestamp, t
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName) {
-		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskGroupName) {
+		dp.Attributes().PutStr("oracledb.asm.disk_group.name", oracledbAsmDiskGroupNameAttributeValue)
 	}
 	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName) {
-		dp.Attributes().PutStr("oracledb.asm_disk.name", oracledbAsmDiskNameAttributeValue)
+		dp.Attributes().PutStr("oracledb.asm.disk.name", oracledbAsmDiskNameAttributeValue)
 	}
 	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection) {
 		dp.Attributes().PutStr("disk.io.direction", diskIoDirectionAttributeValue)
@@ -1374,16 +1374,16 @@ func newMetricOracledbAsmDiskErrors(cfg OracledbAsmDiskErrorsMetricConfig) metri
 	return m
 }
 
-type metricOracledbAsmDiskgroupFree struct {
+type metricOracledbAsmDiskGroupFree struct {
 	data          pmetric.Metric                       // data buffer for generated metric.
-	config        OracledbAsmDiskgroupFreeMetricConfig // metric config provided by user.
+	config        OracledbAsmDiskGroupFreeMetricConfig // metric config provided by user.
 	capacity      int                                  // max observed number of data points added to the metric.
 	aggDataPoints []int64                              // slice containing number of aggregated datapoints at each index
 }
 
-// init fills oracledb.asm_diskgroup.free metric with initial data.
-func (m *metricOracledbAsmDiskgroupFree) init() {
-	m.data.SetName("oracledb.asm_diskgroup.free")
+// init fills oracledb.asm.disk_group.free metric with initial data.
+func (m *metricOracledbAsmDiskGroupFree) init() {
+	m.data.SetName("oracledb.asm.disk_group.free")
 	m.data.SetDescription("Free space in an ASM diskgroup.")
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
@@ -1391,7 +1391,7 @@ func (m *metricOracledbAsmDiskgroupFree) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricOracledbAsmDiskgroupFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+func (m *metricOracledbAsmDiskGroupFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -1399,8 +1399,8 @@ func (m *metricOracledbAsmDiskgroupFree) recordDataPoint(start pcommon.Timestamp
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName) {
-		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskGroupFreeMetricAttributeKeyOracledbAsmDiskGroupName) {
+		dp.Attributes().PutStr("oracledb.asm.disk_group.name", oracledbAsmDiskGroupNameAttributeValue)
 	}
 
 	var s string
@@ -1433,14 +1433,14 @@ func (m *metricOracledbAsmDiskgroupFree) recordDataPoint(start pcommon.Timestamp
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbAsmDiskgroupFree) updateCapacity() {
+func (m *metricOracledbAsmDiskGroupFree) updateCapacity() {
 	if m.data.Gauge().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbAsmDiskgroupFree) emit(metrics pmetric.MetricSlice) {
+func (m *metricOracledbAsmDiskGroupFree) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		if m.config.AggregationStrategy == AggregationStrategyAvg {
 			for i, aggCount := range m.aggDataPoints {
@@ -1453,8 +1453,8 @@ func (m *metricOracledbAsmDiskgroupFree) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOracledbAsmDiskgroupFree(cfg OracledbAsmDiskgroupFreeMetricConfig) metricOracledbAsmDiskgroupFree {
-	m := metricOracledbAsmDiskgroupFree{config: cfg}
+func newMetricOracledbAsmDiskGroupFree(cfg OracledbAsmDiskGroupFreeMetricConfig) metricOracledbAsmDiskGroupFree {
+	m := metricOracledbAsmDiskGroupFree{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -1463,16 +1463,16 @@ func newMetricOracledbAsmDiskgroupFree(cfg OracledbAsmDiskgroupFreeMetricConfig)
 	return m
 }
 
-type metricOracledbAsmDiskgroupOfflineDisks struct {
+type metricOracledbAsmDiskGroupOfflineDisks struct {
 	data          pmetric.Metric                               // data buffer for generated metric.
-	config        OracledbAsmDiskgroupOfflineDisksMetricConfig // metric config provided by user.
+	config        OracledbAsmDiskGroupOfflineDisksMetricConfig // metric config provided by user.
 	capacity      int                                          // max observed number of data points added to the metric.
 	aggDataPoints []int64                                      // slice containing number of aggregated datapoints at each index
 }
 
-// init fills oracledb.asm_diskgroup.offline_disks metric with initial data.
-func (m *metricOracledbAsmDiskgroupOfflineDisks) init() {
-	m.data.SetName("oracledb.asm_diskgroup.offline_disks")
+// init fills oracledb.asm.disk_group.offline_disks metric with initial data.
+func (m *metricOracledbAsmDiskGroupOfflineDisks) init() {
+	m.data.SetName("oracledb.asm.disk_group.offline_disks")
 	m.data.SetDescription("Count of disks currently offline within an ASM diskgroup.")
 	m.data.SetUnit("{disk}")
 	m.data.SetEmptyGauge()
@@ -1480,7 +1480,7 @@ func (m *metricOracledbAsmDiskgroupOfflineDisks) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricOracledbAsmDiskgroupOfflineDisks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+func (m *metricOracledbAsmDiskGroupOfflineDisks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -1488,8 +1488,8 @@ func (m *metricOracledbAsmDiskgroupOfflineDisks) recordDataPoint(start pcommon.T
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName) {
-		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskGroupOfflineDisksMetricAttributeKeyOracledbAsmDiskGroupName) {
+		dp.Attributes().PutStr("oracledb.asm.disk_group.name", oracledbAsmDiskGroupNameAttributeValue)
 	}
 
 	var s string
@@ -1522,14 +1522,14 @@ func (m *metricOracledbAsmDiskgroupOfflineDisks) recordDataPoint(start pcommon.T
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbAsmDiskgroupOfflineDisks) updateCapacity() {
+func (m *metricOracledbAsmDiskGroupOfflineDisks) updateCapacity() {
 	if m.data.Gauge().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbAsmDiskgroupOfflineDisks) emit(metrics pmetric.MetricSlice) {
+func (m *metricOracledbAsmDiskGroupOfflineDisks) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		if m.config.AggregationStrategy == AggregationStrategyAvg {
 			for i, aggCount := range m.aggDataPoints {
@@ -1542,8 +1542,8 @@ func (m *metricOracledbAsmDiskgroupOfflineDisks) emit(metrics pmetric.MetricSlic
 	}
 }
 
-func newMetricOracledbAsmDiskgroupOfflineDisks(cfg OracledbAsmDiskgroupOfflineDisksMetricConfig) metricOracledbAsmDiskgroupOfflineDisks {
-	m := metricOracledbAsmDiskgroupOfflineDisks{config: cfg}
+func newMetricOracledbAsmDiskGroupOfflineDisks(cfg OracledbAsmDiskGroupOfflineDisksMetricConfig) metricOracledbAsmDiskGroupOfflineDisks {
+	m := metricOracledbAsmDiskGroupOfflineDisks{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -1552,16 +1552,16 @@ func newMetricOracledbAsmDiskgroupOfflineDisks(cfg OracledbAsmDiskgroupOfflineDi
 	return m
 }
 
-type metricOracledbAsmDiskgroupTotal struct {
+type metricOracledbAsmDiskGroupTotal struct {
 	data          pmetric.Metric                        // data buffer for generated metric.
-	config        OracledbAsmDiskgroupTotalMetricConfig // metric config provided by user.
+	config        OracledbAsmDiskGroupTotalMetricConfig // metric config provided by user.
 	capacity      int                                   // max observed number of data points added to the metric.
 	aggDataPoints []int64                               // slice containing number of aggregated datapoints at each index
 }
 
-// init fills oracledb.asm_diskgroup.total metric with initial data.
-func (m *metricOracledbAsmDiskgroupTotal) init() {
-	m.data.SetName("oracledb.asm_diskgroup.total")
+// init fills oracledb.asm.disk_group.total metric with initial data.
+func (m *metricOracledbAsmDiskGroupTotal) init() {
+	m.data.SetName("oracledb.asm.disk_group.total")
 	m.data.SetDescription("Total space in an ASM diskgroup.")
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
@@ -1569,7 +1569,7 @@ func (m *metricOracledbAsmDiskgroupTotal) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricOracledbAsmDiskgroupTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+func (m *metricOracledbAsmDiskGroupTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -1577,8 +1577,8 @@ func (m *metricOracledbAsmDiskgroupTotal) recordDataPoint(start pcommon.Timestam
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName) {
-		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName) {
+		dp.Attributes().PutStr("oracledb.asm.disk_group.name", oracledbAsmDiskGroupNameAttributeValue)
 	}
 
 	var s string
@@ -1611,14 +1611,14 @@ func (m *metricOracledbAsmDiskgroupTotal) recordDataPoint(start pcommon.Timestam
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbAsmDiskgroupTotal) updateCapacity() {
+func (m *metricOracledbAsmDiskGroupTotal) updateCapacity() {
 	if m.data.Gauge().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbAsmDiskgroupTotal) emit(metrics pmetric.MetricSlice) {
+func (m *metricOracledbAsmDiskGroupTotal) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		if m.config.AggregationStrategy == AggregationStrategyAvg {
 			for i, aggCount := range m.aggDataPoints {
@@ -1631,8 +1631,8 @@ func (m *metricOracledbAsmDiskgroupTotal) emit(metrics pmetric.MetricSlice) {
 	}
 }
 
-func newMetricOracledbAsmDiskgroupTotal(cfg OracledbAsmDiskgroupTotalMetricConfig) metricOracledbAsmDiskgroupTotal {
-	m := metricOracledbAsmDiskgroupTotal{config: cfg}
+func newMetricOracledbAsmDiskGroupTotal(cfg OracledbAsmDiskGroupTotalMetricConfig) metricOracledbAsmDiskGroupTotal {
+	m := metricOracledbAsmDiskGroupTotal{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -1641,16 +1641,16 @@ func newMetricOracledbAsmDiskgroupTotal(cfg OracledbAsmDiskgroupTotalMetricConfi
 	return m
 }
 
-type metricOracledbAsmDiskgroupUsableFree struct {
+type metricOracledbAsmDiskGroupUsableFree struct {
 	data          pmetric.Metric                             // data buffer for generated metric.
-	config        OracledbAsmDiskgroupUsableFreeMetricConfig // metric config provided by user.
+	config        OracledbAsmDiskGroupUsableFreeMetricConfig // metric config provided by user.
 	capacity      int                                        // max observed number of data points added to the metric.
 	aggDataPoints []int64                                    // slice containing number of aggregated datapoints at each index
 }
 
-// init fills oracledb.asm_diskgroup.usable_free metric with initial data.
-func (m *metricOracledbAsmDiskgroupUsableFree) init() {
-	m.data.SetName("oracledb.asm_diskgroup.usable_free")
+// init fills oracledb.asm.disk_group.usable_free metric with initial data.
+func (m *metricOracledbAsmDiskGroupUsableFree) init() {
+	m.data.SetName("oracledb.asm.disk_group.usable_free")
 	m.data.SetDescription("Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.")
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
@@ -1658,7 +1658,7 @@ func (m *metricOracledbAsmDiskgroupUsableFree) init() {
 	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
-func (m *metricOracledbAsmDiskgroupUsableFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+func (m *metricOracledbAsmDiskGroupUsableFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -1666,8 +1666,8 @@ func (m *metricOracledbAsmDiskgroupUsableFree) recordDataPoint(start pcommon.Tim
 	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName) {
-		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskGroupUsableFreeMetricAttributeKeyOracledbAsmDiskGroupName) {
+		dp.Attributes().PutStr("oracledb.asm.disk_group.name", oracledbAsmDiskGroupNameAttributeValue)
 	}
 
 	var s string
@@ -1700,14 +1700,14 @@ func (m *metricOracledbAsmDiskgroupUsableFree) recordDataPoint(start pcommon.Tim
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbAsmDiskgroupUsableFree) updateCapacity() {
+func (m *metricOracledbAsmDiskGroupUsableFree) updateCapacity() {
 	if m.data.Gauge().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbAsmDiskgroupUsableFree) emit(metrics pmetric.MetricSlice) {
+func (m *metricOracledbAsmDiskGroupUsableFree) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		if m.config.AggregationStrategy == AggregationStrategyAvg {
 			for i, aggCount := range m.aggDataPoints {
@@ -1720,8 +1720,8 @@ func (m *metricOracledbAsmDiskgroupUsableFree) emit(metrics pmetric.MetricSlice)
 	}
 }
 
-func newMetricOracledbAsmDiskgroupUsableFree(cfg OracledbAsmDiskgroupUsableFreeMetricConfig) metricOracledbAsmDiskgroupUsableFree {
-	m := metricOracledbAsmDiskgroupUsableFree{config: cfg}
+func newMetricOracledbAsmDiskGroupUsableFree(cfg OracledbAsmDiskGroupUsableFreeMetricConfig) metricOracledbAsmDiskGroupUsableFree {
+	m := metricOracledbAsmDiskGroupUsableFree{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -11842,10 +11842,10 @@ type MetricsBuilder struct {
 	resourceAttributeIncludeFilter                      map[string]filter.Filter
 	resourceAttributeExcludeFilter                      map[string]filter.Filter
 	metricOracledbAsmDiskErrors                         metricOracledbAsmDiskErrors
-	metricOracledbAsmDiskgroupFree                      metricOracledbAsmDiskgroupFree
-	metricOracledbAsmDiskgroupOfflineDisks              metricOracledbAsmDiskgroupOfflineDisks
-	metricOracledbAsmDiskgroupTotal                     metricOracledbAsmDiskgroupTotal
-	metricOracledbAsmDiskgroupUsableFree                metricOracledbAsmDiskgroupUsableFree
+	metricOracledbAsmDiskGroupFree                      metricOracledbAsmDiskGroupFree
+	metricOracledbAsmDiskGroupOfflineDisks              metricOracledbAsmDiskGroupOfflineDisks
+	metricOracledbAsmDiskGroupTotal                     metricOracledbAsmDiskGroupTotal
+	metricOracledbAsmDiskGroupUsableFree                metricOracledbAsmDiskGroupUsableFree
 	metricOracledbBufferInspected                       metricOracledbBufferInspected
 	metricOracledbBufferRequests                        metricOracledbBufferRequests
 	metricOracledbBufferCacheBlockChanges               metricOracledbBufferCacheBlockChanges
@@ -12002,10 +12002,10 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricsBuffer:                                       pmetric.NewMetrics(),
 		buildInfo:                                           settings.BuildInfo,
 		metricOracledbAsmDiskErrors:                         newMetricOracledbAsmDiskErrors(mbc.Metrics.OracledbAsmDiskErrors),
-		metricOracledbAsmDiskgroupFree:                      newMetricOracledbAsmDiskgroupFree(mbc.Metrics.OracledbAsmDiskgroupFree),
-		metricOracledbAsmDiskgroupOfflineDisks:              newMetricOracledbAsmDiskgroupOfflineDisks(mbc.Metrics.OracledbAsmDiskgroupOfflineDisks),
-		metricOracledbAsmDiskgroupTotal:                     newMetricOracledbAsmDiskgroupTotal(mbc.Metrics.OracledbAsmDiskgroupTotal),
-		metricOracledbAsmDiskgroupUsableFree:                newMetricOracledbAsmDiskgroupUsableFree(mbc.Metrics.OracledbAsmDiskgroupUsableFree),
+		metricOracledbAsmDiskGroupFree:                      newMetricOracledbAsmDiskGroupFree(mbc.Metrics.OracledbAsmDiskGroupFree),
+		metricOracledbAsmDiskGroupOfflineDisks:              newMetricOracledbAsmDiskGroupOfflineDisks(mbc.Metrics.OracledbAsmDiskGroupOfflineDisks),
+		metricOracledbAsmDiskGroupTotal:                     newMetricOracledbAsmDiskGroupTotal(mbc.Metrics.OracledbAsmDiskGroupTotal),
+		metricOracledbAsmDiskGroupUsableFree:                newMetricOracledbAsmDiskGroupUsableFree(mbc.Metrics.OracledbAsmDiskGroupUsableFree),
 		metricOracledbBufferInspected:                       newMetricOracledbBufferInspected(mbc.Metrics.OracledbBufferInspected),
 		metricOracledbBufferRequests:                        newMetricOracledbBufferRequests(mbc.Metrics.OracledbBufferRequests),
 		metricOracledbBufferCacheBlockChanges:               newMetricOracledbBufferCacheBlockChanges(mbc.Metrics.OracledbBufferCacheBlockChanges),
@@ -12263,10 +12263,10 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricOracledbAsmDiskErrors.emit(ils.Metrics())
-	mb.metricOracledbAsmDiskgroupFree.emit(ils.Metrics())
-	mb.metricOracledbAsmDiskgroupOfflineDisks.emit(ils.Metrics())
-	mb.metricOracledbAsmDiskgroupTotal.emit(ils.Metrics())
-	mb.metricOracledbAsmDiskgroupUsableFree.emit(ils.Metrics())
+	mb.metricOracledbAsmDiskGroupFree.emit(ils.Metrics())
+	mb.metricOracledbAsmDiskGroupOfflineDisks.emit(ils.Metrics())
+	mb.metricOracledbAsmDiskGroupTotal.emit(ils.Metrics())
+	mb.metricOracledbAsmDiskGroupUsableFree.emit(ils.Metrics())
 	mb.metricOracledbBufferInspected.emit(ils.Metrics())
 	mb.metricOracledbBufferRequests.emit(ils.Metrics())
 	mb.metricOracledbBufferCacheBlockChanges.emit(ils.Metrics())
@@ -12428,34 +12428,34 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 	return metrics
 }
 
-// RecordOracledbAsmDiskErrorsDataPoint adds a data point to oracledb.asm_disk.errors metric.
-func (mb *MetricsBuilder) RecordOracledbAsmDiskErrorsDataPoint(ts pcommon.Timestamp, inputVal string, oracledbAsmDiskgroupNameAttributeValue string, oracledbAsmDiskNameAttributeValue string, diskIoDirectionAttributeValue AttributeDiskIoDirection) error {
+// RecordOracledbAsmDiskErrorsDataPoint adds a data point to oracledb.asm.disk.errors metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskErrorsDataPoint(ts pcommon.Timestamp, inputVal string, oracledbAsmDiskGroupNameAttributeValue string, oracledbAsmDiskNameAttributeValue string, diskIoDirectionAttributeValue AttributeDiskIoDirection) error {
 	val, err := strconv.ParseInt(inputVal, 10, 64)
 	if err != nil {
 		return fmt.Errorf("failed to parse int64 for OracledbAsmDiskErrors, value was %s: %w", inputVal, err)
 	}
-	mb.metricOracledbAsmDiskErrors.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue, oracledbAsmDiskNameAttributeValue, diskIoDirectionAttributeValue.String())
+	mb.metricOracledbAsmDiskErrors.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskGroupNameAttributeValue, oracledbAsmDiskNameAttributeValue, diskIoDirectionAttributeValue.String())
 	return nil
 }
 
-// RecordOracledbAsmDiskgroupFreeDataPoint adds a data point to oracledb.asm_diskgroup.free metric.
-func (mb *MetricsBuilder) RecordOracledbAsmDiskgroupFreeDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
-	mb.metricOracledbAsmDiskgroupFree.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue)
+// RecordOracledbAsmDiskGroupFreeDataPoint adds a data point to oracledb.asm.disk_group.free metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskGroupFreeDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
+	mb.metricOracledbAsmDiskGroupFree.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskGroupNameAttributeValue)
 }
 
-// RecordOracledbAsmDiskgroupOfflineDisksDataPoint adds a data point to oracledb.asm_diskgroup.offline_disks metric.
-func (mb *MetricsBuilder) RecordOracledbAsmDiskgroupOfflineDisksDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
-	mb.metricOracledbAsmDiskgroupOfflineDisks.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue)
+// RecordOracledbAsmDiskGroupOfflineDisksDataPoint adds a data point to oracledb.asm.disk_group.offline_disks metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskGroupOfflineDisksDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
+	mb.metricOracledbAsmDiskGroupOfflineDisks.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskGroupNameAttributeValue)
 }
 
-// RecordOracledbAsmDiskgroupTotalDataPoint adds a data point to oracledb.asm_diskgroup.total metric.
-func (mb *MetricsBuilder) RecordOracledbAsmDiskgroupTotalDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
-	mb.metricOracledbAsmDiskgroupTotal.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue)
+// RecordOracledbAsmDiskGroupTotalDataPoint adds a data point to oracledb.asm.disk_group.total metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskGroupTotalDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
+	mb.metricOracledbAsmDiskGroupTotal.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskGroupNameAttributeValue)
 }
 
-// RecordOracledbAsmDiskgroupUsableFreeDataPoint adds a data point to oracledb.asm_diskgroup.usable_free metric.
-func (mb *MetricsBuilder) RecordOracledbAsmDiskgroupUsableFreeDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
-	mb.metricOracledbAsmDiskgroupUsableFree.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue)
+// RecordOracledbAsmDiskGroupUsableFreeDataPoint adds a data point to oracledb.asm.disk_group.usable_free metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskGroupUsableFreeDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
+	mb.metricOracledbAsmDiskGroupUsableFree.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskGroupNameAttributeValue)
 }
 
 // RecordOracledbBufferInspectedDataPoint adds a data point to oracledb.buffer.inspected metric.

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -635,6 +635,26 @@ var MapAttributeOracledbTransactionType = map[string]AttributeOracledbTransactio
 }
 
 var MetricsInfo = metricsInfo{
+	OracledbAsmDiskErrors: metricInfo{
+		Name:       "oracledb.asm_disk.errors",
+		Attributes: []string{"oracledb.asm_diskgroup.name", "oracledb.asm_disk.name", "disk.io.direction"},
+	},
+	OracledbAsmDiskgroupFree: metricInfo{
+		Name:       "oracledb.asm_diskgroup.free",
+		Attributes: []string{"oracledb.asm_diskgroup.name"},
+	},
+	OracledbAsmDiskgroupOfflineDisks: metricInfo{
+		Name:       "oracledb.asm_diskgroup.offline_disks",
+		Attributes: []string{"oracledb.asm_diskgroup.name"},
+	},
+	OracledbAsmDiskgroupTotal: metricInfo{
+		Name:       "oracledb.asm_diskgroup.total",
+		Attributes: []string{"oracledb.asm_diskgroup.name"},
+	},
+	OracledbAsmDiskgroupUsableFree: metricInfo{
+		Name:       "oracledb.asm_diskgroup.usable_free",
+		Attributes: []string{"oracledb.asm_diskgroup.name"},
+	},
 	OracledbBufferInspected: metricInfo{
 		Name:       "oracledb.buffer.inspected",
 		Attributes: []string{"oracledb.buffer.state"},
@@ -1115,6 +1135,11 @@ var MetricsInfo = metricsInfo{
 }
 
 type metricsInfo struct {
+	OracledbAsmDiskErrors                         metricInfo
+	OracledbAsmDiskgroupFree                      metricInfo
+	OracledbAsmDiskgroupOfflineDisks              metricInfo
+	OracledbAsmDiskgroupTotal                     metricInfo
+	OracledbAsmDiskgroupUsableFree                metricInfo
 	OracledbBufferInspected                       metricInfo
 	OracledbBufferRequests                        metricInfo
 	OracledbBufferCacheBlockChanges               metricInfo
@@ -1250,6 +1275,459 @@ type metricsInfo struct {
 type metricInfo struct {
 	Name       string
 	Attributes []string
+}
+
+type metricOracledbAsmDiskErrors struct {
+	data          pmetric.Metric                    // data buffer for generated metric.
+	config        OracledbAsmDiskErrorsMetricConfig // metric config provided by user.
+	capacity      int                               // max observed number of data points added to the metric.
+	aggDataPoints []int64                           // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.asm_disk.errors metric with initial data.
+func (m *metricOracledbAsmDiskErrors) init() {
+	m.data.SetName("oracledb.asm_disk.errors")
+	m.data.SetDescription("Count of I/O errors on an ASM disk.")
+	m.data.SetUnit("{error}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbAsmDiskErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string, oracledbAsmDiskNameAttributeValue string, diskIoDirectionAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskgroupName) {
+		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskErrorsMetricAttributeKeyOracledbAsmDiskName) {
+		dp.Attributes().PutStr("oracledb.asm_disk.name", oracledbAsmDiskNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskErrorsMetricAttributeKeyDiskIoDirection) {
+		dp.Attributes().PutStr("disk.io.direction", diskIoDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbAsmDiskErrors) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbAsmDiskErrors) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbAsmDiskErrors(cfg OracledbAsmDiskErrorsMetricConfig) metricOracledbAsmDiskErrors {
+	m := metricOracledbAsmDiskErrors{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbAsmDiskgroupFree struct {
+	data          pmetric.Metric                       // data buffer for generated metric.
+	config        OracledbAsmDiskgroupFreeMetricConfig // metric config provided by user.
+	capacity      int                                  // max observed number of data points added to the metric.
+	aggDataPoints []int64                              // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.asm_diskgroup.free metric with initial data.
+func (m *metricOracledbAsmDiskgroupFree) init() {
+	m.data.SetName("oracledb.asm_diskgroup.free")
+	m.data.SetDescription("Free space in an ASM diskgroup.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbAsmDiskgroupFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskgroupFreeMetricAttributeKeyOracledbAsmDiskgroupName) {
+		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbAsmDiskgroupFree) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbAsmDiskgroupFree) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbAsmDiskgroupFree(cfg OracledbAsmDiskgroupFreeMetricConfig) metricOracledbAsmDiskgroupFree {
+	m := metricOracledbAsmDiskgroupFree{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbAsmDiskgroupOfflineDisks struct {
+	data          pmetric.Metric                               // data buffer for generated metric.
+	config        OracledbAsmDiskgroupOfflineDisksMetricConfig // metric config provided by user.
+	capacity      int                                          // max observed number of data points added to the metric.
+	aggDataPoints []int64                                      // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.asm_diskgroup.offline_disks metric with initial data.
+func (m *metricOracledbAsmDiskgroupOfflineDisks) init() {
+	m.data.SetName("oracledb.asm_diskgroup.offline_disks")
+	m.data.SetDescription("Count of disks currently offline within an ASM diskgroup.")
+	m.data.SetUnit("{disk}")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbAsmDiskgroupOfflineDisks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskgroupOfflineDisksMetricAttributeKeyOracledbAsmDiskgroupName) {
+		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbAsmDiskgroupOfflineDisks) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbAsmDiskgroupOfflineDisks) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbAsmDiskgroupOfflineDisks(cfg OracledbAsmDiskgroupOfflineDisksMetricConfig) metricOracledbAsmDiskgroupOfflineDisks {
+	m := metricOracledbAsmDiskgroupOfflineDisks{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbAsmDiskgroupTotal struct {
+	data          pmetric.Metric                        // data buffer for generated metric.
+	config        OracledbAsmDiskgroupTotalMetricConfig // metric config provided by user.
+	capacity      int                                   // max observed number of data points added to the metric.
+	aggDataPoints []int64                               // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.asm_diskgroup.total metric with initial data.
+func (m *metricOracledbAsmDiskgroupTotal) init() {
+	m.data.SetName("oracledb.asm_diskgroup.total")
+	m.data.SetDescription("Total space in an ASM diskgroup.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbAsmDiskgroupTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskgroupTotalMetricAttributeKeyOracledbAsmDiskgroupName) {
+		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbAsmDiskgroupTotal) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbAsmDiskgroupTotal) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbAsmDiskgroupTotal(cfg OracledbAsmDiskgroupTotalMetricConfig) metricOracledbAsmDiskgroupTotal {
+	m := metricOracledbAsmDiskgroupTotal{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricOracledbAsmDiskgroupUsableFree struct {
+	data          pmetric.Metric                             // data buffer for generated metric.
+	config        OracledbAsmDiskgroupUsableFreeMetricConfig // metric config provided by user.
+	capacity      int                                        // max observed number of data points added to the metric.
+	aggDataPoints []int64                                    // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.asm_diskgroup.usable_free metric with initial data.
+func (m *metricOracledbAsmDiskgroupUsableFree) init() {
+	m.data.SetName("oracledb.asm_diskgroup.usable_free")
+	m.data.SetDescription("Free space in an ASM diskgroup.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbAsmDiskgroupUsableFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskgroupUsableFreeMetricAttributeKeyOracledbAsmDiskgroupName) {
+		dp.Attributes().PutStr("oracledb.asm_diskgroup.name", oracledbAsmDiskgroupNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbAsmDiskgroupUsableFree) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbAsmDiskgroupUsableFree) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbAsmDiskgroupUsableFree(cfg OracledbAsmDiskgroupUsableFreeMetricConfig) metricOracledbAsmDiskgroupUsableFree {
+	m := metricOracledbAsmDiskgroupUsableFree{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
 }
 
 type metricOracledbBufferInspected struct {
@@ -11363,6 +11841,11 @@ type MetricsBuilder struct {
 	buildInfo                                           component.BuildInfo  // contains version information.
 	resourceAttributeIncludeFilter                      map[string]filter.Filter
 	resourceAttributeExcludeFilter                      map[string]filter.Filter
+	metricOracledbAsmDiskErrors                         metricOracledbAsmDiskErrors
+	metricOracledbAsmDiskgroupFree                      metricOracledbAsmDiskgroupFree
+	metricOracledbAsmDiskgroupOfflineDisks              metricOracledbAsmDiskgroupOfflineDisks
+	metricOracledbAsmDiskgroupTotal                     metricOracledbAsmDiskgroupTotal
+	metricOracledbAsmDiskgroupUsableFree                metricOracledbAsmDiskgroupUsableFree
 	metricOracledbBufferInspected                       metricOracledbBufferInspected
 	metricOracledbBufferRequests                        metricOracledbBufferRequests
 	metricOracledbBufferCacheBlockChanges               metricOracledbBufferCacheBlockChanges
@@ -11514,13 +11997,18 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                                mbc,
-		startTime:                             pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:                         pmetric.NewMetrics(),
-		buildInfo:                             settings.BuildInfo,
-		metricOracledbBufferInspected:         newMetricOracledbBufferInspected(mbc.Metrics.OracledbBufferInspected),
-		metricOracledbBufferRequests:          newMetricOracledbBufferRequests(mbc.Metrics.OracledbBufferRequests),
-		metricOracledbBufferCacheBlockChanges: newMetricOracledbBufferCacheBlockChanges(mbc.Metrics.OracledbBufferCacheBlockChanges),
+		config:                                              mbc,
+		startTime:                                           pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                                       pmetric.NewMetrics(),
+		buildInfo:                                           settings.BuildInfo,
+		metricOracledbAsmDiskErrors:                         newMetricOracledbAsmDiskErrors(mbc.Metrics.OracledbAsmDiskErrors),
+		metricOracledbAsmDiskgroupFree:                      newMetricOracledbAsmDiskgroupFree(mbc.Metrics.OracledbAsmDiskgroupFree),
+		metricOracledbAsmDiskgroupOfflineDisks:              newMetricOracledbAsmDiskgroupOfflineDisks(mbc.Metrics.OracledbAsmDiskgroupOfflineDisks),
+		metricOracledbAsmDiskgroupTotal:                     newMetricOracledbAsmDiskgroupTotal(mbc.Metrics.OracledbAsmDiskgroupTotal),
+		metricOracledbAsmDiskgroupUsableFree:                newMetricOracledbAsmDiskgroupUsableFree(mbc.Metrics.OracledbAsmDiskgroupUsableFree),
+		metricOracledbBufferInspected:                       newMetricOracledbBufferInspected(mbc.Metrics.OracledbBufferInspected),
+		metricOracledbBufferRequests:                        newMetricOracledbBufferRequests(mbc.Metrics.OracledbBufferRequests),
+		metricOracledbBufferCacheBlockChanges:               newMetricOracledbBufferCacheBlockChanges(mbc.Metrics.OracledbBufferCacheBlockChanges),
 		metricOracledbBufferCacheBlockChangesRate:           newMetricOracledbBufferCacheBlockChangesRate(mbc.Metrics.OracledbBufferCacheBlockChangesRate),
 		metricOracledbBufferCacheBlockGets:                  newMetricOracledbBufferCacheBlockGets(mbc.Metrics.OracledbBufferCacheBlockGets),
 		metricOracledbBufferCacheUtilization:                newMetricOracledbBufferCacheUtilization(mbc.Metrics.OracledbBufferCacheUtilization),
@@ -11774,6 +12262,11 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	ils.Scope().SetName(ScopeName)
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricOracledbAsmDiskErrors.emit(ils.Metrics())
+	mb.metricOracledbAsmDiskgroupFree.emit(ils.Metrics())
+	mb.metricOracledbAsmDiskgroupOfflineDisks.emit(ils.Metrics())
+	mb.metricOracledbAsmDiskgroupTotal.emit(ils.Metrics())
+	mb.metricOracledbAsmDiskgroupUsableFree.emit(ils.Metrics())
 	mb.metricOracledbBufferInspected.emit(ils.Metrics())
 	mb.metricOracledbBufferRequests.emit(ils.Metrics())
 	mb.metricOracledbBufferCacheBlockChanges.emit(ils.Metrics())
@@ -11933,6 +12426,36 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 	metrics := mb.metricsBuffer
 	mb.metricsBuffer = pmetric.NewMetrics()
 	return metrics
+}
+
+// RecordOracledbAsmDiskErrorsDataPoint adds a data point to oracledb.asm_disk.errors metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskErrorsDataPoint(ts pcommon.Timestamp, inputVal string, oracledbAsmDiskgroupNameAttributeValue string, oracledbAsmDiskNameAttributeValue string, diskIoDirectionAttributeValue AttributeDiskIoDirection) error {
+	val, err := strconv.ParseInt(inputVal, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse int64 for OracledbAsmDiskErrors, value was %s: %w", inputVal, err)
+	}
+	mb.metricOracledbAsmDiskErrors.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue, oracledbAsmDiskNameAttributeValue, diskIoDirectionAttributeValue.String())
+	return nil
+}
+
+// RecordOracledbAsmDiskgroupFreeDataPoint adds a data point to oracledb.asm_diskgroup.free metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskgroupFreeDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+	mb.metricOracledbAsmDiskgroupFree.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue)
+}
+
+// RecordOracledbAsmDiskgroupOfflineDisksDataPoint adds a data point to oracledb.asm_diskgroup.offline_disks metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskgroupOfflineDisksDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+	mb.metricOracledbAsmDiskgroupOfflineDisks.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue)
+}
+
+// RecordOracledbAsmDiskgroupTotalDataPoint adds a data point to oracledb.asm_diskgroup.total metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskgroupTotalDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+	mb.metricOracledbAsmDiskgroupTotal.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue)
+}
+
+// RecordOracledbAsmDiskgroupUsableFreeDataPoint adds a data point to oracledb.asm_diskgroup.usable_free metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskgroupUsableFreeDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskgroupNameAttributeValue string) {
+	mb.metricOracledbAsmDiskgroupUsableFree.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskgroupNameAttributeValue)
 }
 
 // RecordOracledbBufferInspectedDataPoint adds a data point to oracledb.buffer.inspected metric.

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -639,16 +639,16 @@ var MetricsInfo = metricsInfo{
 		Name:       "oracledb.asm.disk.errors",
 		Attributes: []string{"oracledb.asm.disk_group.name", "oracledb.asm.disk.name", "disk.io.direction"},
 	},
+	OracledbAsmDiskGroupCapacity: metricInfo{
+		Name:       "oracledb.asm.disk_group.capacity",
+		Attributes: []string{"oracledb.asm.disk_group.name"},
+	},
 	OracledbAsmDiskGroupFree: metricInfo{
 		Name:       "oracledb.asm.disk_group.free",
 		Attributes: []string{"oracledb.asm.disk_group.name"},
 	},
 	OracledbAsmDiskGroupOfflineDisks: metricInfo{
 		Name:       "oracledb.asm.disk_group.offline_disks",
-		Attributes: []string{"oracledb.asm.disk_group.name"},
-	},
-	OracledbAsmDiskGroupTotal: metricInfo{
-		Name:       "oracledb.asm.disk_group.total",
 		Attributes: []string{"oracledb.asm.disk_group.name"},
 	},
 	OracledbAsmDiskGroupUsableFree: metricInfo{
@@ -1136,9 +1136,9 @@ var MetricsInfo = metricsInfo{
 
 type metricsInfo struct {
 	OracledbAsmDiskErrors                         metricInfo
+	OracledbAsmDiskGroupCapacity                  metricInfo
 	OracledbAsmDiskGroupFree                      metricInfo
 	OracledbAsmDiskGroupOfflineDisks              metricInfo
-	OracledbAsmDiskGroupTotal                     metricInfo
 	OracledbAsmDiskGroupUsableFree                metricInfo
 	OracledbBufferInspected                       metricInfo
 	OracledbBufferRequests                        metricInfo
@@ -1374,6 +1374,95 @@ func newMetricOracledbAsmDiskErrors(cfg OracledbAsmDiskErrorsMetricConfig) metri
 	return m
 }
 
+type metricOracledbAsmDiskGroupCapacity struct {
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        OracledbAsmDiskGroupCapacityMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []int64                                  // slice containing number of aggregated datapoints at each index
+}
+
+// init fills oracledb.asm.disk_group.capacity metric with initial data.
+func (m *metricOracledbAsmDiskGroupCapacity) init() {
+	m.data.SetName("oracledb.asm.disk_group.capacity")
+	m.data.SetDescription("Total space in an ASM diskgroup.")
+	m.data.SetUnit("By")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricOracledbAsmDiskGroupCapacity) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskGroupCapacityMetricAttributeKeyOracledbAsmDiskGroupName) {
+		dp.Attributes().PutStr("oracledb.asm.disk_group.name", oracledbAsmDiskGroupNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricOracledbAsmDiskGroupCapacity) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricOracledbAsmDiskGroupCapacity) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricOracledbAsmDiskGroupCapacity(cfg OracledbAsmDiskGroupCapacityMetricConfig) metricOracledbAsmDiskGroupCapacity {
+	m := metricOracledbAsmDiskGroupCapacity{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricOracledbAsmDiskGroupFree struct {
 	data          pmetric.Metric                       // data buffer for generated metric.
 	config        OracledbAsmDiskGroupFreeMetricConfig // metric config provided by user.
@@ -1544,95 +1633,6 @@ func (m *metricOracledbAsmDiskGroupOfflineDisks) emit(metrics pmetric.MetricSlic
 
 func newMetricOracledbAsmDiskGroupOfflineDisks(cfg OracledbAsmDiskGroupOfflineDisksMetricConfig) metricOracledbAsmDiskGroupOfflineDisks {
 	m := metricOracledbAsmDiskGroupOfflineDisks{config: cfg}
-
-	if cfg.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricOracledbAsmDiskGroupTotal struct {
-	data          pmetric.Metric                        // data buffer for generated metric.
-	config        OracledbAsmDiskGroupTotalMetricConfig // metric config provided by user.
-	capacity      int                                   // max observed number of data points added to the metric.
-	aggDataPoints []int64                               // slice containing number of aggregated datapoints at each index
-}
-
-// init fills oracledb.asm.disk_group.total metric with initial data.
-func (m *metricOracledbAsmDiskGroupTotal) init() {
-	m.data.SetName("oracledb.asm.disk_group.total")
-	m.data.SetDescription("Total space in an ASM diskgroup.")
-	m.data.SetUnit("By")
-	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
-	m.aggDataPoints = m.aggDataPoints[:0]
-}
-
-func (m *metricOracledbAsmDiskGroupTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
-	if !m.config.Enabled {
-		return
-	}
-
-	dp := pmetric.NewNumberDataPoint()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	if slices.Contains(m.config.EnabledAttributes, OracledbAsmDiskGroupTotalMetricAttributeKeyOracledbAsmDiskGroupName) {
-		dp.Attributes().PutStr("oracledb.asm.disk_group.name", oracledbAsmDiskGroupNameAttributeValue)
-	}
-
-	var s string
-	dps := m.data.Gauge().DataPoints()
-	for i := 0; i < dps.Len(); i++ {
-		dpi := dps.At(i)
-		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
-			switch s = m.config.AggregationStrategy; s {
-			case AggregationStrategySum, AggregationStrategyAvg:
-				dpi.SetIntValue(dpi.IntValue() + val)
-				m.aggDataPoints[i] += 1
-				return
-			case AggregationStrategyMin:
-				if dpi.IntValue() > val {
-					dpi.SetIntValue(val)
-				}
-				return
-			case AggregationStrategyMax:
-				if dpi.IntValue() < val {
-					dpi.SetIntValue(val)
-				}
-				return
-			}
-		}
-	}
-
-	dp.SetIntValue(val)
-	m.aggDataPoints = append(m.aggDataPoints, 1)
-	dp.MoveTo(dps.AppendEmpty())
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricOracledbAsmDiskGroupTotal) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricOracledbAsmDiskGroupTotal) emit(metrics pmetric.MetricSlice) {
-	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		if m.config.AggregationStrategy == AggregationStrategyAvg {
-			for i, aggCount := range m.aggDataPoints {
-				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
-			}
-		}
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricOracledbAsmDiskGroupTotal(cfg OracledbAsmDiskGroupTotalMetricConfig) metricOracledbAsmDiskGroupTotal {
-	m := metricOracledbAsmDiskGroupTotal{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -11842,9 +11842,9 @@ type MetricsBuilder struct {
 	resourceAttributeIncludeFilter                      map[string]filter.Filter
 	resourceAttributeExcludeFilter                      map[string]filter.Filter
 	metricOracledbAsmDiskErrors                         metricOracledbAsmDiskErrors
+	metricOracledbAsmDiskGroupCapacity                  metricOracledbAsmDiskGroupCapacity
 	metricOracledbAsmDiskGroupFree                      metricOracledbAsmDiskGroupFree
 	metricOracledbAsmDiskGroupOfflineDisks              metricOracledbAsmDiskGroupOfflineDisks
-	metricOracledbAsmDiskGroupTotal                     metricOracledbAsmDiskGroupTotal
 	metricOracledbAsmDiskGroupUsableFree                metricOracledbAsmDiskGroupUsableFree
 	metricOracledbBufferInspected                       metricOracledbBufferInspected
 	metricOracledbBufferRequests                        metricOracledbBufferRequests
@@ -12002,9 +12002,9 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricsBuffer:                                       pmetric.NewMetrics(),
 		buildInfo:                                           settings.BuildInfo,
 		metricOracledbAsmDiskErrors:                         newMetricOracledbAsmDiskErrors(mbc.Metrics.OracledbAsmDiskErrors),
+		metricOracledbAsmDiskGroupCapacity:                  newMetricOracledbAsmDiskGroupCapacity(mbc.Metrics.OracledbAsmDiskGroupCapacity),
 		metricOracledbAsmDiskGroupFree:                      newMetricOracledbAsmDiskGroupFree(mbc.Metrics.OracledbAsmDiskGroupFree),
 		metricOracledbAsmDiskGroupOfflineDisks:              newMetricOracledbAsmDiskGroupOfflineDisks(mbc.Metrics.OracledbAsmDiskGroupOfflineDisks),
-		metricOracledbAsmDiskGroupTotal:                     newMetricOracledbAsmDiskGroupTotal(mbc.Metrics.OracledbAsmDiskGroupTotal),
 		metricOracledbAsmDiskGroupUsableFree:                newMetricOracledbAsmDiskGroupUsableFree(mbc.Metrics.OracledbAsmDiskGroupUsableFree),
 		metricOracledbBufferInspected:                       newMetricOracledbBufferInspected(mbc.Metrics.OracledbBufferInspected),
 		metricOracledbBufferRequests:                        newMetricOracledbBufferRequests(mbc.Metrics.OracledbBufferRequests),
@@ -12263,9 +12263,9 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricOracledbAsmDiskErrors.emit(ils.Metrics())
+	mb.metricOracledbAsmDiskGroupCapacity.emit(ils.Metrics())
 	mb.metricOracledbAsmDiskGroupFree.emit(ils.Metrics())
 	mb.metricOracledbAsmDiskGroupOfflineDisks.emit(ils.Metrics())
-	mb.metricOracledbAsmDiskGroupTotal.emit(ils.Metrics())
 	mb.metricOracledbAsmDiskGroupUsableFree.emit(ils.Metrics())
 	mb.metricOracledbBufferInspected.emit(ils.Metrics())
 	mb.metricOracledbBufferRequests.emit(ils.Metrics())
@@ -12438,6 +12438,11 @@ func (mb *MetricsBuilder) RecordOracledbAsmDiskErrorsDataPoint(ts pcommon.Timest
 	return nil
 }
 
+// RecordOracledbAsmDiskGroupCapacityDataPoint adds a data point to oracledb.asm.disk_group.capacity metric.
+func (mb *MetricsBuilder) RecordOracledbAsmDiskGroupCapacityDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
+	mb.metricOracledbAsmDiskGroupCapacity.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskGroupNameAttributeValue)
+}
+
 // RecordOracledbAsmDiskGroupFreeDataPoint adds a data point to oracledb.asm.disk_group.free metric.
 func (mb *MetricsBuilder) RecordOracledbAsmDiskGroupFreeDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
 	mb.metricOracledbAsmDiskGroupFree.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskGroupNameAttributeValue)
@@ -12446,11 +12451,6 @@ func (mb *MetricsBuilder) RecordOracledbAsmDiskGroupFreeDataPoint(ts pcommon.Tim
 // RecordOracledbAsmDiskGroupOfflineDisksDataPoint adds a data point to oracledb.asm.disk_group.offline_disks metric.
 func (mb *MetricsBuilder) RecordOracledbAsmDiskGroupOfflineDisksDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
 	mb.metricOracledbAsmDiskGroupOfflineDisks.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskGroupNameAttributeValue)
-}
-
-// RecordOracledbAsmDiskGroupTotalDataPoint adds a data point to oracledb.asm.disk_group.total metric.
-func (mb *MetricsBuilder) RecordOracledbAsmDiskGroupTotalDataPoint(ts pcommon.Timestamp, val int64, oracledbAsmDiskGroupNameAttributeValue string) {
-	mb.metricOracledbAsmDiskGroupTotal.recordDataPoint(mb.startTime, ts, val, oracledbAsmDiskGroupNameAttributeValue)
 }
 
 // RecordOracledbAsmDiskGroupUsableFreeDataPoint adds a data point to oracledb.asm.disk_group.usable_free metric.

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -1651,7 +1651,7 @@ type metricOracledbAsmDiskgroupUsableFree struct {
 // init fills oracledb.asm_diskgroup.usable_free metric with initial data.
 func (m *metricOracledbAsmDiskgroupUsableFree) init() {
 	m.data.SetName("oracledb.asm_diskgroup.usable_free")
-	m.data.SetDescription("Free space in an ASM diskgroup.")
+	m.data.SetDescription("Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.")
 	m.data.SetUnit("By")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -67,11 +67,11 @@ func TestMetricsBuilder(t *testing.T) {
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
-			aggMap["oracledb.asm_disk.errors"] = mb.metricOracledbAsmDiskErrors.config.AggregationStrategy
-			aggMap["oracledb.asm_diskgroup.free"] = mb.metricOracledbAsmDiskgroupFree.config.AggregationStrategy
-			aggMap["oracledb.asm_diskgroup.offline_disks"] = mb.metricOracledbAsmDiskgroupOfflineDisks.config.AggregationStrategy
-			aggMap["oracledb.asm_diskgroup.total"] = mb.metricOracledbAsmDiskgroupTotal.config.AggregationStrategy
-			aggMap["oracledb.asm_diskgroup.usable_free"] = mb.metricOracledbAsmDiskgroupUsableFree.config.AggregationStrategy
+			aggMap["oracledb.asm.disk.errors"] = mb.metricOracledbAsmDiskErrors.config.AggregationStrategy
+			aggMap["oracledb.asm.disk_group.free"] = mb.metricOracledbAsmDiskGroupFree.config.AggregationStrategy
+			aggMap["oracledb.asm.disk_group.offline_disks"] = mb.metricOracledbAsmDiskGroupOfflineDisks.config.AggregationStrategy
+			aggMap["oracledb.asm.disk_group.total"] = mb.metricOracledbAsmDiskGroupTotal.config.AggregationStrategy
+			aggMap["oracledb.asm.disk_group.usable_free"] = mb.metricOracledbAsmDiskGroupUsableFree.config.AggregationStrategy
 			aggMap["oracledb.buffer.inspected"] = mb.metricOracledbBufferInspected.config.AggregationStrategy
 			aggMap["oracledb.buffer_cache.block.changes.rate"] = mb.metricOracledbBufferCacheBlockChangesRate.config.AggregationStrategy
 			aggMap["oracledb.buffer_cache.utilization"] = mb.metricOracledbBufferCacheUtilization.config.AggregationStrategy
@@ -169,33 +169,33 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount := 0
 
 			allMetricsCount++
-			mb.RecordOracledbAsmDiskErrorsDataPoint(ts, "1", "oracledb.asm_diskgroup.name-val", "oracledb.asm_disk.name-val", AttributeDiskIoDirectionRead)
+			mb.RecordOracledbAsmDiskErrorsDataPoint(ts, "1", "oracledb.asm.disk_group.name-val", "oracledb.asm.disk.name-val", AttributeDiskIoDirectionRead)
 			if tt.name == "reaggregate_set" {
-				mb.RecordOracledbAsmDiskErrorsDataPoint(ts, "3", "oracledb.asm_diskgroup.name-val-2", "oracledb.asm_disk.name-val-2", AttributeDiskIoDirectionWrite)
+				mb.RecordOracledbAsmDiskErrorsDataPoint(ts, "3", "oracledb.asm.disk_group.name-val-2", "oracledb.asm.disk.name-val-2", AttributeDiskIoDirectionWrite)
 			}
 
 			allMetricsCount++
-			mb.RecordOracledbAsmDiskgroupFreeDataPoint(ts, 1, "oracledb.asm_diskgroup.name-val")
+			mb.RecordOracledbAsmDiskGroupFreeDataPoint(ts, 1, "oracledb.asm.disk_group.name-val")
 			if tt.name == "reaggregate_set" {
-				mb.RecordOracledbAsmDiskgroupFreeDataPoint(ts, 3, "oracledb.asm_diskgroup.name-val-2")
+				mb.RecordOracledbAsmDiskGroupFreeDataPoint(ts, 3, "oracledb.asm.disk_group.name-val-2")
 			}
 
 			allMetricsCount++
-			mb.RecordOracledbAsmDiskgroupOfflineDisksDataPoint(ts, 1, "oracledb.asm_diskgroup.name-val")
+			mb.RecordOracledbAsmDiskGroupOfflineDisksDataPoint(ts, 1, "oracledb.asm.disk_group.name-val")
 			if tt.name == "reaggregate_set" {
-				mb.RecordOracledbAsmDiskgroupOfflineDisksDataPoint(ts, 3, "oracledb.asm_diskgroup.name-val-2")
+				mb.RecordOracledbAsmDiskGroupOfflineDisksDataPoint(ts, 3, "oracledb.asm.disk_group.name-val-2")
 			}
 
 			allMetricsCount++
-			mb.RecordOracledbAsmDiskgroupTotalDataPoint(ts, 1, "oracledb.asm_diskgroup.name-val")
+			mb.RecordOracledbAsmDiskGroupTotalDataPoint(ts, 1, "oracledb.asm.disk_group.name-val")
 			if tt.name == "reaggregate_set" {
-				mb.RecordOracledbAsmDiskgroupTotalDataPoint(ts, 3, "oracledb.asm_diskgroup.name-val-2")
+				mb.RecordOracledbAsmDiskGroupTotalDataPoint(ts, 3, "oracledb.asm.disk_group.name-val-2")
 			}
 
 			allMetricsCount++
-			mb.RecordOracledbAsmDiskgroupUsableFreeDataPoint(ts, 1, "oracledb.asm_diskgroup.name-val")
+			mb.RecordOracledbAsmDiskGroupUsableFreeDataPoint(ts, 1, "oracledb.asm.disk_group.name-val")
 			if tt.name == "reaggregate_set" {
-				mb.RecordOracledbAsmDiskgroupUsableFreeDataPoint(ts, 3, "oracledb.asm_diskgroup.name-val-2")
+				mb.RecordOracledbAsmDiskGroupUsableFreeDataPoint(ts, 3, "oracledb.asm.disk_group.name-val-2")
 			}
 
 			allMetricsCount++
@@ -863,10 +863,10 @@ func TestMetricsBuilder(t *testing.T) {
 			metrics := mb.Emit(WithResource(res))
 			if tt.name == "reaggregate_set" {
 				assert.Empty(t, mb.metricOracledbAsmDiskErrors.aggDataPoints)
-				assert.Empty(t, mb.metricOracledbAsmDiskgroupFree.aggDataPoints)
-				assert.Empty(t, mb.metricOracledbAsmDiskgroupOfflineDisks.aggDataPoints)
-				assert.Empty(t, mb.metricOracledbAsmDiskgroupTotal.aggDataPoints)
-				assert.Empty(t, mb.metricOracledbAsmDiskgroupUsableFree.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbAsmDiskGroupFree.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbAsmDiskGroupOfflineDisks.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbAsmDiskGroupTotal.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbAsmDiskGroupUsableFree.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbBufferInspected.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbBufferCacheBlockChangesRate.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbBufferCacheUtilization.aggDataPoints)
@@ -981,10 +981,10 @@ func TestMetricsBuilder(t *testing.T) {
 			validatedMetrics := make(map[string]bool)
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
-				case "oracledb.asm_disk.errors":
+				case "oracledb.asm.disk.errors":
 					if tt.name != "reaggregate_set" {
-						assert.False(t, validatedMetrics["oracledb.asm_disk.errors"], "Found a duplicate in the metrics slice: oracledb.asm_disk.errors")
-						validatedMetrics["oracledb.asm_disk.errors"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk.errors"], "Found a duplicate in the metrics slice: oracledb.asm.disk.errors")
+						validatedMetrics["oracledb.asm.disk.errors"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 						assert.Equal(t, "Count of I/O errors on an ASM disk.", mi.Description())
@@ -996,18 +996,18 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						assert.Equal(t, int64(1), dp.IntValue())
-						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						oracledbAsmDiskGroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.True(t, ok)
-						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
-						oracledbAsmDiskNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_disk.name")
+						assert.Equal(t, "oracledb.asm.disk_group.name-val", oracledbAsmDiskGroupNameAttrVal.Str())
+						oracledbAsmDiskNameAttrVal, ok := dp.Attributes().Get("oracledb.asm.disk.name")
 						assert.True(t, ok)
-						assert.Equal(t, "oracledb.asm_disk.name-val", oracledbAsmDiskNameAttrVal.Str())
+						assert.Equal(t, "oracledb.asm.disk.name-val", oracledbAsmDiskNameAttrVal.Str())
 						diskIoDirectionAttrVal, ok := dp.Attributes().Get("disk.io.direction")
 						assert.True(t, ok)
 						assert.Equal(t, "read", diskIoDirectionAttrVal.Str())
 					} else {
-						assert.False(t, validatedMetrics["oracledb.asm_disk.errors"], "Found a duplicate in the metrics slice: oracledb.asm_disk.errors")
-						validatedMetrics["oracledb.asm_disk.errors"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk.errors"], "Found a duplicate in the metrics slice: oracledb.asm.disk.errors")
+						validatedMetrics["oracledb.asm.disk.errors"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
 						assert.Equal(t, "Count of I/O errors on an ASM disk.", mi.Description())
@@ -1018,7 +1018,7 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						switch aggMap["oracledb.asm_disk.errors"] {
+						switch aggMap["oracledb.asm.disk.errors"] {
 						case "sum":
 							assert.Equal(t, int64(4), dp.IntValue())
 						case "avg":
@@ -1028,17 +1028,17 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
-						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						_, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.False(t, ok)
-						_, ok = dp.Attributes().Get("oracledb.asm_disk.name")
+						_, ok = dp.Attributes().Get("oracledb.asm.disk.name")
 						assert.False(t, ok)
 						_, ok = dp.Attributes().Get("disk.io.direction")
 						assert.False(t, ok)
 					}
-				case "oracledb.asm_diskgroup.free":
+				case "oracledb.asm.disk_group.free":
 					if tt.name != "reaggregate_set" {
-						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.free"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.free")
-						validatedMetrics["oracledb.asm_diskgroup.free"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.free"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.free")
+						validatedMetrics["oracledb.asm.disk_group.free"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 						assert.Equal(t, "Free space in an ASM diskgroup.", mi.Description())
@@ -1048,12 +1048,12 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						assert.Equal(t, int64(1), dp.IntValue())
-						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						oracledbAsmDiskGroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.True(t, ok)
-						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
+						assert.Equal(t, "oracledb.asm.disk_group.name-val", oracledbAsmDiskGroupNameAttrVal.Str())
 					} else {
-						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.free"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.free")
-						validatedMetrics["oracledb.asm_diskgroup.free"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.free"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.free")
+						validatedMetrics["oracledb.asm.disk_group.free"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 						assert.Equal(t, "Free space in an ASM diskgroup.", mi.Description())
@@ -1062,7 +1062,7 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						switch aggMap["oracledb.asm_diskgroup.free"] {
+						switch aggMap["oracledb.asm.disk_group.free"] {
 						case "sum":
 							assert.Equal(t, int64(4), dp.IntValue())
 						case "avg":
@@ -1072,13 +1072,13 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
-						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						_, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.False(t, ok)
 					}
-				case "oracledb.asm_diskgroup.offline_disks":
+				case "oracledb.asm.disk_group.offline_disks":
 					if tt.name != "reaggregate_set" {
-						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.offline_disks"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.offline_disks")
-						validatedMetrics["oracledb.asm_diskgroup.offline_disks"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.offline_disks"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.offline_disks")
+						validatedMetrics["oracledb.asm.disk_group.offline_disks"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 						assert.Equal(t, "Count of disks currently offline within an ASM diskgroup.", mi.Description())
@@ -1088,12 +1088,12 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						assert.Equal(t, int64(1), dp.IntValue())
-						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						oracledbAsmDiskGroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.True(t, ok)
-						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
+						assert.Equal(t, "oracledb.asm.disk_group.name-val", oracledbAsmDiskGroupNameAttrVal.Str())
 					} else {
-						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.offline_disks"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.offline_disks")
-						validatedMetrics["oracledb.asm_diskgroup.offline_disks"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.offline_disks"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.offline_disks")
+						validatedMetrics["oracledb.asm.disk_group.offline_disks"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 						assert.Equal(t, "Count of disks currently offline within an ASM diskgroup.", mi.Description())
@@ -1102,7 +1102,7 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						switch aggMap["oracledb.asm_diskgroup.offline_disks"] {
+						switch aggMap["oracledb.asm.disk_group.offline_disks"] {
 						case "sum":
 							assert.Equal(t, int64(4), dp.IntValue())
 						case "avg":
@@ -1112,13 +1112,13 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
-						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						_, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.False(t, ok)
 					}
-				case "oracledb.asm_diskgroup.total":
+				case "oracledb.asm.disk_group.total":
 					if tt.name != "reaggregate_set" {
-						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.total"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.total")
-						validatedMetrics["oracledb.asm_diskgroup.total"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.total"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.total")
+						validatedMetrics["oracledb.asm.disk_group.total"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 						assert.Equal(t, "Total space in an ASM diskgroup.", mi.Description())
@@ -1128,12 +1128,12 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						assert.Equal(t, int64(1), dp.IntValue())
-						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						oracledbAsmDiskGroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.True(t, ok)
-						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
+						assert.Equal(t, "oracledb.asm.disk_group.name-val", oracledbAsmDiskGroupNameAttrVal.Str())
 					} else {
-						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.total"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.total")
-						validatedMetrics["oracledb.asm_diskgroup.total"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.total"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.total")
+						validatedMetrics["oracledb.asm.disk_group.total"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 						assert.Equal(t, "Total space in an ASM diskgroup.", mi.Description())
@@ -1142,7 +1142,7 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						switch aggMap["oracledb.asm_diskgroup.total"] {
+						switch aggMap["oracledb.asm.disk_group.total"] {
 						case "sum":
 							assert.Equal(t, int64(4), dp.IntValue())
 						case "avg":
@@ -1152,13 +1152,13 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
-						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						_, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.False(t, ok)
 					}
-				case "oracledb.asm_diskgroup.usable_free":
+				case "oracledb.asm.disk_group.usable_free":
 					if tt.name != "reaggregate_set" {
-						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.usable_free"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.usable_free")
-						validatedMetrics["oracledb.asm_diskgroup.usable_free"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.usable_free"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.usable_free")
+						validatedMetrics["oracledb.asm.disk_group.usable_free"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 						assert.Equal(t, "Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.", mi.Description())
@@ -1168,12 +1168,12 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						assert.Equal(t, int64(1), dp.IntValue())
-						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						oracledbAsmDiskGroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.True(t, ok)
-						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
+						assert.Equal(t, "oracledb.asm.disk_group.name-val", oracledbAsmDiskGroupNameAttrVal.Str())
 					} else {
-						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.usable_free"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.usable_free")
-						validatedMetrics["oracledb.asm_diskgroup.usable_free"] = true
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.usable_free"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.usable_free")
+						validatedMetrics["oracledb.asm.disk_group.usable_free"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
 						assert.Equal(t, "Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.", mi.Description())
@@ -1182,7 +1182,7 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, start, dp.StartTimestamp())
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						switch aggMap["oracledb.asm_diskgroup.usable_free"] {
+						switch aggMap["oracledb.asm.disk_group.usable_free"] {
 						case "sum":
 							assert.Equal(t, int64(4), dp.IntValue())
 						case "avg":
@@ -1192,7 +1192,7 @@ func TestMetricsBuilder(t *testing.T) {
 						case "max":
 							assert.Equal(t, int64(3), dp.IntValue())
 						}
-						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						_, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 						assert.False(t, ok)
 					}
 				case "oracledb.buffer.inspected":

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -67,6 +67,11 @@ func TestMetricsBuilder(t *testing.T) {
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["oracledb.asm_disk.errors"] = mb.metricOracledbAsmDiskErrors.config.AggregationStrategy
+			aggMap["oracledb.asm_diskgroup.free"] = mb.metricOracledbAsmDiskgroupFree.config.AggregationStrategy
+			aggMap["oracledb.asm_diskgroup.offline_disks"] = mb.metricOracledbAsmDiskgroupOfflineDisks.config.AggregationStrategy
+			aggMap["oracledb.asm_diskgroup.total"] = mb.metricOracledbAsmDiskgroupTotal.config.AggregationStrategy
+			aggMap["oracledb.asm_diskgroup.usable_free"] = mb.metricOracledbAsmDiskgroupUsableFree.config.AggregationStrategy
 			aggMap["oracledb.buffer.inspected"] = mb.metricOracledbBufferInspected.config.AggregationStrategy
 			aggMap["oracledb.buffer_cache.block.changes.rate"] = mb.metricOracledbBufferCacheBlockChangesRate.config.AggregationStrategy
 			aggMap["oracledb.buffer_cache.utilization"] = mb.metricOracledbBufferCacheUtilization.config.AggregationStrategy
@@ -162,6 +167,36 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
+
+			allMetricsCount++
+			mb.RecordOracledbAsmDiskErrorsDataPoint(ts, "1", "oracledb.asm_diskgroup.name-val", "oracledb.asm_disk.name-val", AttributeDiskIoDirectionRead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbAsmDiskErrorsDataPoint(ts, "3", "oracledb.asm_diskgroup.name-val-2", "oracledb.asm_disk.name-val-2", AttributeDiskIoDirectionWrite)
+			}
+
+			allMetricsCount++
+			mb.RecordOracledbAsmDiskgroupFreeDataPoint(ts, 1, "oracledb.asm_diskgroup.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbAsmDiskgroupFreeDataPoint(ts, 3, "oracledb.asm_diskgroup.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordOracledbAsmDiskgroupOfflineDisksDataPoint(ts, 1, "oracledb.asm_diskgroup.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbAsmDiskgroupOfflineDisksDataPoint(ts, 3, "oracledb.asm_diskgroup.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordOracledbAsmDiskgroupTotalDataPoint(ts, 1, "oracledb.asm_diskgroup.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbAsmDiskgroupTotalDataPoint(ts, 3, "oracledb.asm_diskgroup.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordOracledbAsmDiskgroupUsableFreeDataPoint(ts, 1, "oracledb.asm_diskgroup.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbAsmDiskgroupUsableFreeDataPoint(ts, 3, "oracledb.asm_diskgroup.name-val-2")
+			}
 
 			allMetricsCount++
 			mb.RecordOracledbBufferInspectedDataPoint(ts, "1", AttributeOracledbBufferStateFree)
@@ -827,6 +862,11 @@ func TestMetricsBuilder(t *testing.T) {
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
 			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricOracledbAsmDiskErrors.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbAsmDiskgroupFree.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbAsmDiskgroupOfflineDisks.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbAsmDiskgroupTotal.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbAsmDiskgroupUsableFree.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbBufferInspected.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbBufferCacheBlockChangesRate.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbBufferCacheUtilization.aggDataPoints)
@@ -941,6 +981,220 @@ func TestMetricsBuilder(t *testing.T) {
 			validatedMetrics := make(map[string]bool)
 			for _, mi := range allMetricsList {
 				switch mi.Name() {
+				case "oracledb.asm_disk.errors":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.asm_disk.errors"], "Found a duplicate in the metrics slice: oracledb.asm_disk.errors")
+						validatedMetrics["oracledb.asm_disk.errors"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Count of I/O errors on an ASM disk.", mi.Description())
+						assert.Equal(t, "{error}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.True(t, ok)
+						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
+						oracledbAsmDiskNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_disk.name")
+						assert.True(t, ok)
+						assert.Equal(t, "oracledb.asm_disk.name-val", oracledbAsmDiskNameAttrVal.Str())
+						diskIoDirectionAttrVal, ok := dp.Attributes().Get("disk.io.direction")
+						assert.True(t, ok)
+						assert.Equal(t, "read", diskIoDirectionAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.asm_disk.errors"], "Found a duplicate in the metrics slice: oracledb.asm_disk.errors")
+						validatedMetrics["oracledb.asm_disk.errors"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "Count of I/O errors on an ASM disk.", mi.Description())
+						assert.Equal(t, "{error}", mi.Unit())
+						assert.True(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.asm_disk.errors"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("oracledb.asm_disk.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("disk.io.direction")
+						assert.False(t, ok)
+					}
+				case "oracledb.asm_diskgroup.free":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.free"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.free")
+						validatedMetrics["oracledb.asm_diskgroup.free"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Free space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.True(t, ok)
+						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.free"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.free")
+						validatedMetrics["oracledb.asm_diskgroup.free"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Free space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.asm_diskgroup.free"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.False(t, ok)
+					}
+				case "oracledb.asm_diskgroup.offline_disks":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.offline_disks"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.offline_disks")
+						validatedMetrics["oracledb.asm_diskgroup.offline_disks"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Count of disks currently offline within an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "{disk}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.True(t, ok)
+						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.offline_disks"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.offline_disks")
+						validatedMetrics["oracledb.asm_diskgroup.offline_disks"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Count of disks currently offline within an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "{disk}", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.asm_diskgroup.offline_disks"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.False(t, ok)
+					}
+				case "oracledb.asm_diskgroup.total":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.total"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.total")
+						validatedMetrics["oracledb.asm_diskgroup.total"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Total space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.True(t, ok)
+						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.total"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.total")
+						validatedMetrics["oracledb.asm_diskgroup.total"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Total space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.asm_diskgroup.total"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.False(t, ok)
+					}
+				case "oracledb.asm_diskgroup.usable_free":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.usable_free"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.usable_free")
+						validatedMetrics["oracledb.asm_diskgroup.usable_free"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Free space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						oracledbAsmDiskgroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.True(t, ok)
+						assert.Equal(t, "oracledb.asm_diskgroup.name-val", oracledbAsmDiskgroupNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.asm_diskgroup.usable_free"], "Found a duplicate in the metrics slice: oracledb.asm_diskgroup.usable_free")
+						validatedMetrics["oracledb.asm_diskgroup.usable_free"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Free space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.asm_diskgroup.usable_free"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+						assert.False(t, ok)
+					}
 				case "oracledb.buffer.inspected":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["oracledb.buffer.inspected"], "Found a duplicate in the metrics slice: oracledb.buffer.inspected")

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -68,9 +68,9 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
 			aggMap["oracledb.asm.disk.errors"] = mb.metricOracledbAsmDiskErrors.config.AggregationStrategy
+			aggMap["oracledb.asm.disk_group.capacity"] = mb.metricOracledbAsmDiskGroupCapacity.config.AggregationStrategy
 			aggMap["oracledb.asm.disk_group.free"] = mb.metricOracledbAsmDiskGroupFree.config.AggregationStrategy
 			aggMap["oracledb.asm.disk_group.offline_disks"] = mb.metricOracledbAsmDiskGroupOfflineDisks.config.AggregationStrategy
-			aggMap["oracledb.asm.disk_group.total"] = mb.metricOracledbAsmDiskGroupTotal.config.AggregationStrategy
 			aggMap["oracledb.asm.disk_group.usable_free"] = mb.metricOracledbAsmDiskGroupUsableFree.config.AggregationStrategy
 			aggMap["oracledb.buffer.inspected"] = mb.metricOracledbBufferInspected.config.AggregationStrategy
 			aggMap["oracledb.buffer_cache.block.changes.rate"] = mb.metricOracledbBufferCacheBlockChangesRate.config.AggregationStrategy
@@ -175,6 +175,12 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
+			mb.RecordOracledbAsmDiskGroupCapacityDataPoint(ts, 1, "oracledb.asm.disk_group.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordOracledbAsmDiskGroupCapacityDataPoint(ts, 3, "oracledb.asm.disk_group.name-val-2")
+			}
+
+			allMetricsCount++
 			mb.RecordOracledbAsmDiskGroupFreeDataPoint(ts, 1, "oracledb.asm.disk_group.name-val")
 			if tt.name == "reaggregate_set" {
 				mb.RecordOracledbAsmDiskGroupFreeDataPoint(ts, 3, "oracledb.asm.disk_group.name-val-2")
@@ -184,12 +190,6 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordOracledbAsmDiskGroupOfflineDisksDataPoint(ts, 1, "oracledb.asm.disk_group.name-val")
 			if tt.name == "reaggregate_set" {
 				mb.RecordOracledbAsmDiskGroupOfflineDisksDataPoint(ts, 3, "oracledb.asm.disk_group.name-val-2")
-			}
-
-			allMetricsCount++
-			mb.RecordOracledbAsmDiskGroupTotalDataPoint(ts, 1, "oracledb.asm.disk_group.name-val")
-			if tt.name == "reaggregate_set" {
-				mb.RecordOracledbAsmDiskGroupTotalDataPoint(ts, 3, "oracledb.asm.disk_group.name-val-2")
 			}
 
 			allMetricsCount++
@@ -863,9 +863,9 @@ func TestMetricsBuilder(t *testing.T) {
 			metrics := mb.Emit(WithResource(res))
 			if tt.name == "reaggregate_set" {
 				assert.Empty(t, mb.metricOracledbAsmDiskErrors.aggDataPoints)
+				assert.Empty(t, mb.metricOracledbAsmDiskGroupCapacity.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbAsmDiskGroupFree.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbAsmDiskGroupOfflineDisks.aggDataPoints)
-				assert.Empty(t, mb.metricOracledbAsmDiskGroupTotal.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbAsmDiskGroupUsableFree.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbBufferInspected.aggDataPoints)
 				assert.Empty(t, mb.metricOracledbBufferCacheBlockChangesRate.aggDataPoints)
@@ -1035,6 +1035,46 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok = dp.Attributes().Get("disk.io.direction")
 						assert.False(t, ok)
 					}
+				case "oracledb.asm.disk_group.capacity":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.capacity"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.capacity")
+						validatedMetrics["oracledb.asm.disk_group.capacity"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Total space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						oracledbAsmDiskGroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
+						assert.True(t, ok)
+						assert.Equal(t, "oracledb.asm.disk_group.name-val", oracledbAsmDiskGroupNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["oracledb.asm.disk_group.capacity"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.capacity")
+						validatedMetrics["oracledb.asm.disk_group.capacity"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "Total space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "By", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["oracledb.asm.disk_group.capacity"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
+						assert.False(t, ok)
+					}
 				case "oracledb.asm.disk_group.free":
 					if tt.name != "reaggregate_set" {
 						assert.False(t, validatedMetrics["oracledb.asm.disk_group.free"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.free")
@@ -1103,46 +1143,6 @@ func TestMetricsBuilder(t *testing.T) {
 						assert.Equal(t, ts, dp.Timestamp())
 						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 						switch aggMap["oracledb.asm.disk_group.offline_disks"] {
-						case "sum":
-							assert.Equal(t, int64(4), dp.IntValue())
-						case "avg":
-							assert.Equal(t, int64(2), dp.IntValue())
-						case "min":
-							assert.Equal(t, int64(1), dp.IntValue())
-						case "max":
-							assert.Equal(t, int64(3), dp.IntValue())
-						}
-						_, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
-						assert.False(t, ok)
-					}
-				case "oracledb.asm.disk_group.total":
-					if tt.name != "reaggregate_set" {
-						assert.False(t, validatedMetrics["oracledb.asm.disk_group.total"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.total")
-						validatedMetrics["oracledb.asm.disk_group.total"] = true
-						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-						assert.Equal(t, "Total space in an ASM diskgroup.", mi.Description())
-						assert.Equal(t, "By", mi.Unit())
-						dp := mi.Gauge().DataPoints().At(0)
-						assert.Equal(t, start, dp.StartTimestamp())
-						assert.Equal(t, ts, dp.Timestamp())
-						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						assert.Equal(t, int64(1), dp.IntValue())
-						oracledbAsmDiskGroupNameAttrVal, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
-						assert.True(t, ok)
-						assert.Equal(t, "oracledb.asm.disk_group.name-val", oracledbAsmDiskGroupNameAttrVal.Str())
-					} else {
-						assert.False(t, validatedMetrics["oracledb.asm.disk_group.total"], "Found a duplicate in the metrics slice: oracledb.asm.disk_group.total")
-						validatedMetrics["oracledb.asm.disk_group.total"] = true
-						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
-						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-						assert.Equal(t, "Total space in an ASM diskgroup.", mi.Description())
-						assert.Equal(t, "By", mi.Unit())
-						dp := mi.Gauge().DataPoints().At(0)
-						assert.Equal(t, start, dp.StartTimestamp())
-						assert.Equal(t, ts, dp.Timestamp())
-						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-						switch aggMap["oracledb.asm.disk_group.total"] {
 						case "sum":
 							assert.Equal(t, int64(4), dp.IntValue())
 						case "avg":

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -1161,7 +1161,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.asm_diskgroup.usable_free"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-						assert.Equal(t, "Free space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.", mi.Description())
 						assert.Equal(t, "By", mi.Unit())
 						dp := mi.Gauge().DataPoints().At(0)
 						assert.Equal(t, start, dp.StartTimestamp())
@@ -1176,7 +1176,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["oracledb.asm_diskgroup.usable_free"] = true
 						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
 						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
-						assert.Equal(t, "Free space in an ASM diskgroup.", mi.Description())
+						assert.Equal(t, "Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.", mi.Description())
 						assert.Equal(t, "By", mi.Unit())
 						dp := mi.Gauge().DataPoints().At(0)
 						assert.Equal(t, start, dp.StartTimestamp())

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -1,6 +1,21 @@
 default:
 all_set:
   metrics:
+    oracledb.asm_disk.errors:
+      enabled: true
+      attributes: ["oracledb.asm_diskgroup.name","oracledb.asm_disk.name","disk.io.direction"]
+    oracledb.asm_diskgroup.free:
+      enabled: true
+      attributes: ["oracledb.asm_diskgroup.name"]
+    oracledb.asm_diskgroup.offline_disks:
+      enabled: true
+      attributes: ["oracledb.asm_diskgroup.name"]
+    oracledb.asm_diskgroup.total:
+      enabled: true
+      attributes: ["oracledb.asm_diskgroup.name"]
+    oracledb.asm_diskgroup.usable_free:
+      enabled: true
+      attributes: ["oracledb.asm_diskgroup.name"]
     oracledb.buffer.inspected:
       enabled: true
       attributes: ["oracledb.buffer.state"]
@@ -376,6 +391,21 @@ all_set:
       enabled: true
 reaggregate_set:
   metrics:
+    oracledb.asm_disk.errors:
+      enabled: true
+      attributes: []
+    oracledb.asm_diskgroup.free:
+      enabled: true
+      attributes: []
+    oracledb.asm_diskgroup.offline_disks:
+      enabled: true
+      attributes: []
+    oracledb.asm_diskgroup.total:
+      enabled: true
+      attributes: []
+    oracledb.asm_diskgroup.usable_free:
+      enabled: true
+      attributes: []
     oracledb.buffer.inspected:
       enabled: true
       attributes: []
@@ -751,6 +781,21 @@ reaggregate_set:
       enabled: true
 none_set:
   metrics:
+    oracledb.asm_disk.errors:
+      enabled: false
+      attributes: ["oracledb.asm_diskgroup.name","oracledb.asm_disk.name","disk.io.direction"]
+    oracledb.asm_diskgroup.free:
+      enabled: false
+      attributes: ["oracledb.asm_diskgroup.name"]
+    oracledb.asm_diskgroup.offline_disks:
+      enabled: false
+      attributes: ["oracledb.asm_diskgroup.name"]
+    oracledb.asm_diskgroup.total:
+      enabled: false
+      attributes: ["oracledb.asm_diskgroup.name"]
+    oracledb.asm_diskgroup.usable_free:
+      enabled: false
+      attributes: ["oracledb.asm_diskgroup.name"]
     oracledb.buffer.inspected:
       enabled: false
       attributes: ["oracledb.buffer.state"]

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -4,13 +4,13 @@ all_set:
     oracledb.asm.disk.errors:
       enabled: true
       attributes: ["oracledb.asm.disk_group.name","oracledb.asm.disk.name","disk.io.direction"]
+    oracledb.asm.disk_group.capacity:
+      enabled: true
+      attributes: ["oracledb.asm.disk_group.name"]
     oracledb.asm.disk_group.free:
       enabled: true
       attributes: ["oracledb.asm.disk_group.name"]
     oracledb.asm.disk_group.offline_disks:
-      enabled: true
-      attributes: ["oracledb.asm.disk_group.name"]
-    oracledb.asm.disk_group.total:
       enabled: true
       attributes: ["oracledb.asm.disk_group.name"]
     oracledb.asm.disk_group.usable_free:
@@ -394,13 +394,13 @@ reaggregate_set:
     oracledb.asm.disk.errors:
       enabled: true
       attributes: []
+    oracledb.asm.disk_group.capacity:
+      enabled: true
+      attributes: []
     oracledb.asm.disk_group.free:
       enabled: true
       attributes: []
     oracledb.asm.disk_group.offline_disks:
-      enabled: true
-      attributes: []
-    oracledb.asm.disk_group.total:
       enabled: true
       attributes: []
     oracledb.asm.disk_group.usable_free:
@@ -784,13 +784,13 @@ none_set:
     oracledb.asm.disk.errors:
       enabled: false
       attributes: ["oracledb.asm.disk_group.name","oracledb.asm.disk.name","disk.io.direction"]
+    oracledb.asm.disk_group.capacity:
+      enabled: false
+      attributes: ["oracledb.asm.disk_group.name"]
     oracledb.asm.disk_group.free:
       enabled: false
       attributes: ["oracledb.asm.disk_group.name"]
     oracledb.asm.disk_group.offline_disks:
-      enabled: false
-      attributes: ["oracledb.asm.disk_group.name"]
-    oracledb.asm.disk_group.total:
       enabled: false
       attributes: ["oracledb.asm.disk_group.name"]
     oracledb.asm.disk_group.usable_free:

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -1,21 +1,21 @@
 default:
 all_set:
   metrics:
-    oracledb.asm_disk.errors:
+    oracledb.asm.disk.errors:
       enabled: true
-      attributes: ["oracledb.asm_diskgroup.name","oracledb.asm_disk.name","disk.io.direction"]
-    oracledb.asm_diskgroup.free:
+      attributes: ["oracledb.asm.disk_group.name","oracledb.asm.disk.name","disk.io.direction"]
+    oracledb.asm.disk_group.free:
       enabled: true
-      attributes: ["oracledb.asm_diskgroup.name"]
-    oracledb.asm_diskgroup.offline_disks:
+      attributes: ["oracledb.asm.disk_group.name"]
+    oracledb.asm.disk_group.offline_disks:
       enabled: true
-      attributes: ["oracledb.asm_diskgroup.name"]
-    oracledb.asm_diskgroup.total:
+      attributes: ["oracledb.asm.disk_group.name"]
+    oracledb.asm.disk_group.total:
       enabled: true
-      attributes: ["oracledb.asm_diskgroup.name"]
-    oracledb.asm_diskgroup.usable_free:
+      attributes: ["oracledb.asm.disk_group.name"]
+    oracledb.asm.disk_group.usable_free:
       enabled: true
-      attributes: ["oracledb.asm_diskgroup.name"]
+      attributes: ["oracledb.asm.disk_group.name"]
     oracledb.buffer.inspected:
       enabled: true
       attributes: ["oracledb.buffer.state"]
@@ -391,19 +391,19 @@ all_set:
       enabled: true
 reaggregate_set:
   metrics:
-    oracledb.asm_disk.errors:
+    oracledb.asm.disk.errors:
       enabled: true
       attributes: []
-    oracledb.asm_diskgroup.free:
+    oracledb.asm.disk_group.free:
       enabled: true
       attributes: []
-    oracledb.asm_diskgroup.offline_disks:
+    oracledb.asm.disk_group.offline_disks:
       enabled: true
       attributes: []
-    oracledb.asm_diskgroup.total:
+    oracledb.asm.disk_group.total:
       enabled: true
       attributes: []
-    oracledb.asm_diskgroup.usable_free:
+    oracledb.asm.disk_group.usable_free:
       enabled: true
       attributes: []
     oracledb.buffer.inspected:
@@ -781,21 +781,21 @@ reaggregate_set:
       enabled: true
 none_set:
   metrics:
-    oracledb.asm_disk.errors:
+    oracledb.asm.disk.errors:
       enabled: false
-      attributes: ["oracledb.asm_diskgroup.name","oracledb.asm_disk.name","disk.io.direction"]
-    oracledb.asm_diskgroup.free:
+      attributes: ["oracledb.asm.disk_group.name","oracledb.asm.disk.name","disk.io.direction"]
+    oracledb.asm.disk_group.free:
       enabled: false
-      attributes: ["oracledb.asm_diskgroup.name"]
-    oracledb.asm_diskgroup.offline_disks:
+      attributes: ["oracledb.asm.disk_group.name"]
+    oracledb.asm.disk_group.offline_disks:
       enabled: false
-      attributes: ["oracledb.asm_diskgroup.name"]
-    oracledb.asm_diskgroup.total:
+      attributes: ["oracledb.asm.disk_group.name"]
+    oracledb.asm.disk_group.total:
       enabled: false
-      attributes: ["oracledb.asm_diskgroup.name"]
-    oracledb.asm_diskgroup.usable_free:
+      attributes: ["oracledb.asm.disk_group.name"]
+    oracledb.asm.disk_group.usable_free:
       enabled: false
-      attributes: ["oracledb.asm_diskgroup.name"]
+      attributes: ["oracledb.asm.disk_group.name"]
     oracledb.buffer.inspected:
       enabled: false
       attributes: ["oracledb.buffer.state"]

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -490,6 +490,14 @@ metrics:
       value_type: int
       input_type: string
     unit: "{error}"
+  oracledb.asm.disk_group.capacity:
+    attributes: [oracledb.asm.disk_group.name]
+    description: Total space in an ASM diskgroup.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: int
+    unit: By
   oracledb.asm.disk_group.free:
     attributes: [oracledb.asm.disk_group.name]
     description: Free space in an ASM diskgroup.
@@ -506,14 +514,6 @@ metrics:
     gauge:
       value_type: int
     unit: "{disk}"
-  oracledb.asm.disk_group.total:
-    attributes: [oracledb.asm.disk_group.name]
-    description: Total space in an ASM diskgroup.
-    enabled: false
-    stability: development
-    gauge:
-      value_type: int
-    unit: By
   oracledb.asm.disk_group.usable_free:
     attributes: [oracledb.asm.disk_group.name]
     description: Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -111,10 +111,10 @@ attributes:
   oracledb.application_wait_time:
     description: The total time (in seconds) a query spent waiting on the application before it could proceed with execution (reporting delta).
     type: double
-  oracledb.asm_disk.name:
+  oracledb.asm.disk.name:
     description: The name of the ASM disk.
     type: string
-  oracledb.asm_diskgroup.name:
+  oracledb.asm.disk_group.name:
     description: The name of the ASM diskgroup.
     type: string
   oracledb.blocking.blocker.root_sid:
@@ -479,8 +479,8 @@ events:
       - oracledb.plan.first_load
       - oracledb.plan.last_load
 metrics:
-  oracledb.asm_disk.errors:
-    attributes: [oracledb.asm_diskgroup.name, oracledb.asm_disk.name, disk.io.direction]
+  oracledb.asm.disk.errors:
+    attributes: [oracledb.asm.disk_group.name, oracledb.asm.disk.name, disk.io.direction]
     description: Count of I/O errors on an ASM disk.
     enabled: false
     stability: development
@@ -490,32 +490,32 @@ metrics:
       value_type: int
       input_type: string
     unit: "{error}"
-  oracledb.asm_diskgroup.free:
-    attributes: [oracledb.asm_diskgroup.name]
+  oracledb.asm.disk_group.free:
+    attributes: [oracledb.asm.disk_group.name]
     description: Free space in an ASM diskgroup.
     enabled: false
     stability: development
     gauge:
       value_type: int
     unit: By
-  oracledb.asm_diskgroup.offline_disks:
-    attributes: [oracledb.asm_diskgroup.name]
+  oracledb.asm.disk_group.offline_disks:
+    attributes: [oracledb.asm.disk_group.name]
     description: Count of disks currently offline within an ASM diskgroup.
     enabled: false
     stability: development
     gauge:
       value_type: int
     unit: "{disk}"
-  oracledb.asm_diskgroup.total:
-    attributes: [oracledb.asm_diskgroup.name]
+  oracledb.asm.disk_group.total:
+    attributes: [oracledb.asm.disk_group.name]
     description: Total space in an ASM diskgroup.
     enabled: false
     stability: development
     gauge:
       value_type: int
     unit: By
-  oracledb.asm_diskgroup.usable_free:
-    attributes: [oracledb.asm_diskgroup.name]
+  oracledb.asm.disk_group.usable_free:
+    attributes: [oracledb.asm.disk_group.name]
     description: Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.
     enabled: false
     stability: development

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -516,7 +516,7 @@ metrics:
     unit: By
   oracledb.asm_diskgroup.usable_free:
     attributes: [oracledb.asm_diskgroup.name]
-    description: Free space in an ASM diskgroup.
+    description: Free space that can safely be used for files after accounting for ASM redundancy and required mirror recovery capacity.
     enabled: false
     stability: development
     gauge:

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -111,6 +111,12 @@ attributes:
   oracledb.application_wait_time:
     description: The total time (in seconds) a query spent waiting on the application before it could proceed with execution (reporting delta).
     type: double
+  oracledb.asm_disk.name:
+    description: The name of the ASM disk.
+    type: string
+  oracledb.asm_diskgroup.name:
+    description: The name of the ASM diskgroup.
+    type: string
   oracledb.blocking.blocker.root_sid:
     description: The session ID (SID) of the root/head blocker at the top of the blocking chain. Empty string when there is no blocking.
     type: string
@@ -473,6 +479,49 @@ events:
       - oracledb.plan.first_load
       - oracledb.plan.last_load
 metrics:
+  oracledb.asm_disk.errors:
+    attributes: [oracledb.asm_diskgroup.name, oracledb.asm_disk.name, disk.io.direction]
+    description: Count of I/O errors on an ASM disk.
+    enabled: false
+    stability: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{error}"
+  oracledb.asm_diskgroup.free:
+    attributes: [oracledb.asm_diskgroup.name]
+    description: Free space in an ASM diskgroup.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: int
+    unit: By
+  oracledb.asm_diskgroup.offline_disks:
+    attributes: [oracledb.asm_diskgroup.name]
+    description: Count of disks currently offline within an ASM diskgroup.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: int
+    unit: "{disk}"
+  oracledb.asm_diskgroup.total:
+    attributes: [oracledb.asm_diskgroup.name]
+    description: Total space in an ASM diskgroup.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: int
+    unit: By
+  oracledb.asm_diskgroup.usable_free:
+    attributes: [oracledb.asm_diskgroup.name]
+    description: Free space in an ASM diskgroup.
+    enabled: false
+    stability: development
+    gauge:
+      value_type: int
+    unit: By
   oracledb.buffer.inspected:
     description: Number of buffers inspected from the end of the LRU queue while a process searched for a reusable buffer, grouped by buffer state.
     enabled: false

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -237,6 +237,16 @@ const (
 		SELECT s.name AS NAME, s.value AS VALUE, c.name AS PDB_NAME
 		FROM v$con_sysstat s
 		JOIN v$containers c ON s.con_id = c.con_id`
+	// asmDiskgroupSQL and asmDiskSQL are queried from the regular RDBMS connection (no +ASM instance
+	// connection required) and return zero rows, not an error, on instances that don't use ASM.
+	asmDiskgroupSQL = `
+		SELECT NAME, TOTAL_MB, FREE_MB, USABLE_FILE_MB, OFFLINE_DISKS
+		FROM V$ASM_DISKGROUP_STAT`
+	asmDiskSQL = `
+		SELECT dg.NAME AS DISKGROUP_NAME, d.NAME AS DISK_NAME,
+		       d.READ_ERRS, d.WRITE_ERRS
+		FROM V$ASM_DISK_STAT d
+		JOIN V$ASM_DISKGROUP_STAT dg ON d.GROUP_NUMBER = dg.GROUP_NUMBER`
 	dataDictHitRatioSQL = "SELECT (1-(SUM(getmisses)/SUM(gets))) * 100 as DATA_DICTIONARY_HIT_RATIO FROM v$rowcache WHERE getmisses + gets <> 0"
 	osStatSQL           = "SELECT STAT_NAME, VALUE FROM v$osstat WHERE STAT_NAME IN ('LOAD', 'NUM_CPUS', 'PHYSICAL_MEMORY_BYTES')"
 	recycleBinSizeSQL   = "SELECT nvl(SUM(SPACE*(SELECT value FROM v$parameter WHERE name = 'db_block_size')),0) as RECYCLE_BIN_SIZE_BYTES FROM dba_recyclebin"
@@ -247,16 +257,25 @@ const (
 	osStatNameNumCPUs        = "NUM_CPUS"
 	osStatNamePhysicalMemory = "PHYSICAL_MEMORY_BYTES"
 
-	colAllocatedDBSize     = "ALLOCATED_DB_SIZE"
-	colDataDictHitRatio    = "DATA_DICTIONARY_HIT_RATIO"
-	colMetricName          = "METRIC_NAME"
-	colName                = "NAME"
-	colOSStatName          = "STAT_NAME"
-	colRecycleBinSizeBytes = "RECYCLE_BIN_SIZE_BYTES"
-	colSGAInfoBytes        = "BYTES"
-	colSGAInfoName         = "NAME"
-	colUsedDBSize          = "USED_DB_SIZE"
-	colValue               = "VALUE"
+	colAllocatedDBSize      = "ALLOCATED_DB_SIZE"
+	colASMDiskgroupName     = "NAME"
+	colASMFreeMB            = "FREE_MB"
+	colASMTotalMB           = "TOTAL_MB"
+	colASMUsableFreeMB      = "USABLE_FILE_MB"
+	colASMOfflineDisks      = "OFFLINE_DISKS"
+	colASMDiskDiskgroupName = "DISKGROUP_NAME"
+	colASMDiskName          = "DISK_NAME"
+	colASMDiskReadErrs      = "READ_ERRS"
+	colASMDiskWriteErrs     = "WRITE_ERRS"
+	colDataDictHitRatio     = "DATA_DICTIONARY_HIT_RATIO"
+	colMetricName           = "METRIC_NAME"
+	colName                 = "NAME"
+	colOSStatName           = "STAT_NAME"
+	colRecycleBinSizeBytes  = "RECYCLE_BIN_SIZE_BYTES"
+	colSGAInfoBytes         = "BYTES"
+	colSGAInfoName          = "NAME"
+	colUsedDBSize           = "USED_DB_SIZE"
+	colValue                = "VALUE"
 
 	// sgaMaxSize is the row name routed to oracledb.sga.limit; other rows
 	// are looked up in sgaComponentNames.
@@ -352,6 +371,8 @@ type oracleScraper struct {
 	recycleBinSizeClient     dbClient
 	sgaInfoClient            dbClient
 	storageUsageClient       dbClient
+	asmDiskgroupClient       dbClient
+	asmDiskClient            dbClient
 	sysmetricClient          dbClient
 	sysmetricCDBClient       dbClient
 	db                       *sql.DB
@@ -476,6 +497,8 @@ func (s *oracleScraper) start(ctx context.Context, _ component.Host) error {
 	s.recycleBinSizeClient = s.clientProviderFunc(s.db, recycleBinSizeSQL, s.logger)
 	s.sgaInfoClient = s.clientProviderFunc(s.db, sgaInfoSQL, s.logger)
 	s.storageUsageClient = s.clientProviderFunc(s.db, storageUsageSQL, s.logger)
+	s.asmDiskgroupClient = s.clientProviderFunc(s.db, asmDiskgroupSQL, s.logger)
+	s.asmDiskClient = s.clientProviderFunc(s.db, asmDiskSQL, s.logger)
 	s.sysmetricClient = s.clientProviderFunc(s.db, sysmetricSQL, s.logger)
 	if s.isCDBRoot {
 		s.sysmetricCDBClient = s.clientProviderFunc(s.db, sysmetricCDBSQL, s.logger)
@@ -1203,6 +1226,8 @@ func (s *oracleScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		s.collectSGAInfo(ctx, &scrapeErrors)
 	}
 	s.collectStorageUsage(ctx, &scrapeErrors)
+	s.collectASMDiskgroupMetrics(ctx, &scrapeErrors)
+	s.collectASMDiskMetrics(ctx, &scrapeErrors)
 	s.collectSysMetrics(ctx, &scrapeErrors)
 
 	rb := s.setupResourceBuilder(s.mb.NewResourceBuilder())
@@ -1356,6 +1381,90 @@ func (s *oracleScraper) collectStorageUsage(ctx context.Context, scrapeErrors *[
 		if s.metricsBuilderConfig.Metrics.OracledbStorageUtilization.Enabled && allocatedBytes > 0 {
 			utilization := usedBytes / allocatedBytes
 			s.mb.RecordOracledbStorageUtilizationDataPoint(now, utilization)
+		}
+	}
+}
+
+// collectASMDiskgroupMetrics collects Automatic Storage Management diskgroup capacity and health
+// metrics. Returns zero rows, not an error, on instances that don't use ASM.
+func (s *oracleScraper) collectASMDiskgroupMetrics(ctx context.Context, scrapeErrors *[]error) {
+	if !s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupFree.Enabled &&
+		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupTotal.Enabled &&
+		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupUsableFree.Enabled &&
+		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupOfflineDisks.Enabled {
+		return
+	}
+	now := pcommon.NewTimestampFromTime(time.Now())
+	rows, err := s.asmDiskgroupClient.metricRows(ctx)
+	if err != nil {
+		*scrapeErrors = append(*scrapeErrors, fmt.Errorf("error executing %s: %w", asmDiskgroupSQL, err))
+		return
+	}
+	for _, row := range rows {
+		diskgroupName := row[colASMDiskgroupName]
+
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupFree.Enabled {
+			freeMB, err := strconv.ParseInt(row[colASMFreeMB], 10, 64)
+			if err != nil {
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskgroupFree, value was %s: %w", row[colASMFreeMB], err))
+			} else {
+				s.mb.RecordOracledbAsmDiskgroupFreeDataPoint(now, freeMB*1024*1024, diskgroupName)
+			}
+		}
+
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupTotal.Enabled {
+			totalMB, err := strconv.ParseInt(row[colASMTotalMB], 10, 64)
+			if err != nil {
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskgroupTotal, value was %s: %w", row[colASMTotalMB], err))
+			} else {
+				s.mb.RecordOracledbAsmDiskgroupTotalDataPoint(now, totalMB*1024*1024, diskgroupName)
+			}
+		}
+
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupUsableFree.Enabled {
+			usableFreeMB, err := strconv.ParseInt(row[colASMUsableFreeMB], 10, 64)
+			if err != nil {
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskgroupUsableFree, value was %s: %w", row[colASMUsableFreeMB], err))
+			} else {
+				s.mb.RecordOracledbAsmDiskgroupUsableFreeDataPoint(now, usableFreeMB*1024*1024, diskgroupName)
+			}
+		}
+
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupOfflineDisks.Enabled {
+			offlineDisks, err := strconv.ParseInt(row[colASMOfflineDisks], 10, 64)
+			if err != nil {
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskgroupOfflineDisks, value was %s: %w", row[colASMOfflineDisks], err))
+			} else {
+				s.mb.RecordOracledbAsmDiskgroupOfflineDisksDataPoint(now, offlineDisks, diskgroupName)
+			}
+		}
+
+	}
+}
+
+// collectASMDiskMetrics collects Automatic Storage Management disk-level health metrics. Returns
+// zero rows, not an error, on instances that don't use ASM.
+func (s *oracleScraper) collectASMDiskMetrics(ctx context.Context, scrapeErrors *[]error) {
+	if !s.metricsBuilderConfig.Metrics.OracledbAsmDiskErrors.Enabled {
+		return
+	}
+	now := pcommon.NewTimestampFromTime(time.Now())
+	rows, err := s.asmDiskClient.metricRows(ctx)
+	if err != nil {
+		*scrapeErrors = append(*scrapeErrors, fmt.Errorf("error executing %s: %w", asmDiskSQL, err))
+		return
+	}
+	for _, row := range rows {
+		diskgroupName := row[colASMDiskDiskgroupName]
+		diskName := row[colASMDiskName]
+
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskErrors.Enabled {
+			if err := s.mb.RecordOracledbAsmDiskErrorsDataPoint(now, row[colASMDiskReadErrs], diskgroupName, diskName, metadata.AttributeDiskIoDirectionRead); err != nil {
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to record OracledbAsmDiskErrors (read), value was %s: %w", row[colASMDiskReadErrs], err))
+			}
+			if err := s.mb.RecordOracledbAsmDiskErrorsDataPoint(now, row[colASMDiskWriteErrs], diskgroupName, diskName, metadata.AttributeDiskIoDirectionWrite); err != nil {
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to record OracledbAsmDiskErrors (write), value was %s: %w", row[colASMDiskWriteErrs], err))
+			}
 		}
 	}
 }

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -1438,7 +1438,6 @@ func (s *oracleScraper) collectASMDiskgroupMetrics(ctx context.Context, scrapeEr
 				s.mb.RecordOracledbAsmDiskgroupOfflineDisksDataPoint(now, offlineDisks, diskgroupName)
 			}
 		}
-
 	}
 }
 

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -1388,10 +1388,10 @@ func (s *oracleScraper) collectStorageUsage(ctx context.Context, scrapeErrors *[
 // collectASMDiskgroupMetrics collects Automatic Storage Management diskgroup capacity and health
 // metrics. Returns zero rows, not an error, on instances that don't use ASM.
 func (s *oracleScraper) collectASMDiskgroupMetrics(ctx context.Context, scrapeErrors *[]error) {
-	if !s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupFree.Enabled &&
-		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupTotal.Enabled &&
-		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupUsableFree.Enabled &&
-		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupOfflineDisks.Enabled {
+	if !s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupFree.Enabled &&
+		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupTotal.Enabled &&
+		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupUsableFree.Enabled &&
+		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupOfflineDisks.Enabled {
 		return
 	}
 	now := pcommon.NewTimestampFromTime(time.Now())
@@ -1403,39 +1403,39 @@ func (s *oracleScraper) collectASMDiskgroupMetrics(ctx context.Context, scrapeEr
 	for _, row := range rows {
 		diskgroupName := row[colASMDiskgroupName]
 
-		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupFree.Enabled {
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupFree.Enabled {
 			freeMB, err := strconv.ParseInt(row[colASMFreeMB], 10, 64)
 			if err != nil {
-				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskgroupFree, value was %s: %w", row[colASMFreeMB], err))
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskGroupFree, value was %s: %w", row[colASMFreeMB], err))
 			} else {
-				s.mb.RecordOracledbAsmDiskgroupFreeDataPoint(now, freeMB*1024*1024, diskgroupName)
+				s.mb.RecordOracledbAsmDiskGroupFreeDataPoint(now, freeMB*1024*1024, diskgroupName)
 			}
 		}
 
-		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupTotal.Enabled {
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupTotal.Enabled {
 			totalMB, err := strconv.ParseInt(row[colASMTotalMB], 10, 64)
 			if err != nil {
-				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskgroupTotal, value was %s: %w", row[colASMTotalMB], err))
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskGroupTotal, value was %s: %w", row[colASMTotalMB], err))
 			} else {
-				s.mb.RecordOracledbAsmDiskgroupTotalDataPoint(now, totalMB*1024*1024, diskgroupName)
+				s.mb.RecordOracledbAsmDiskGroupTotalDataPoint(now, totalMB*1024*1024, diskgroupName)
 			}
 		}
 
-		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupUsableFree.Enabled {
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupUsableFree.Enabled {
 			usableFreeMB, err := strconv.ParseInt(row[colASMUsableFreeMB], 10, 64)
 			if err != nil {
-				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskgroupUsableFree, value was %s: %w", row[colASMUsableFreeMB], err))
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskGroupUsableFree, value was %s: %w", row[colASMUsableFreeMB], err))
 			} else {
-				s.mb.RecordOracledbAsmDiskgroupUsableFreeDataPoint(now, usableFreeMB*1024*1024, diskgroupName)
+				s.mb.RecordOracledbAsmDiskGroupUsableFreeDataPoint(now, usableFreeMB*1024*1024, diskgroupName)
 			}
 		}
 
-		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskgroupOfflineDisks.Enabled {
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupOfflineDisks.Enabled {
 			offlineDisks, err := strconv.ParseInt(row[colASMOfflineDisks], 10, 64)
 			if err != nil {
-				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskgroupOfflineDisks, value was %s: %w", row[colASMOfflineDisks], err))
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskGroupOfflineDisks, value was %s: %w", row[colASMOfflineDisks], err))
 			} else {
-				s.mb.RecordOracledbAsmDiskgroupOfflineDisksDataPoint(now, offlineDisks, diskgroupName)
+				s.mb.RecordOracledbAsmDiskGroupOfflineDisksDataPoint(now, offlineDisks, diskgroupName)
 			}
 		}
 	}

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -1389,7 +1389,7 @@ func (s *oracleScraper) collectStorageUsage(ctx context.Context, scrapeErrors *[
 // metrics. Returns zero rows, not an error, on instances that don't use ASM.
 func (s *oracleScraper) collectASMDiskgroupMetrics(ctx context.Context, scrapeErrors *[]error) {
 	if !s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupFree.Enabled &&
-		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupTotal.Enabled &&
+		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupCapacity.Enabled &&
 		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupUsableFree.Enabled &&
 		!s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupOfflineDisks.Enabled {
 		return
@@ -1412,12 +1412,12 @@ func (s *oracleScraper) collectASMDiskgroupMetrics(ctx context.Context, scrapeEr
 			}
 		}
 
-		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupTotal.Enabled {
+		if s.metricsBuilderConfig.Metrics.OracledbAsmDiskGroupCapacity.Enabled {
 			totalMB, err := strconv.ParseInt(row[colASMTotalMB], 10, 64)
 			if err != nil {
-				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskGroupTotal, value was %s: %w", row[colASMTotalMB], err))
+				*scrapeErrors = append(*scrapeErrors, fmt.Errorf("failed to parse int64 for OracledbAsmDiskGroupCapacity, value was %s: %w", row[colASMTotalMB], err))
 			} else {
-				s.mb.RecordOracledbAsmDiskGroupTotalDataPoint(now, totalMB*1024*1024, diskgroupName)
+				s.mb.RecordOracledbAsmDiskGroupCapacityDataPoint(now, totalMB*1024*1024, diskgroupName)
 			}
 		}
 

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -500,10 +500,10 @@ func TestScraper_ScrapeTablespaceHealthMetrics_BadMaxBytes(t *testing.T) {
 // TestScraper_ScrapeASMMetrics covers the 5 new opt-in ASM diskgroup/disk metrics.
 func TestScraper_ScrapeASMMetrics(t *testing.T) {
 	cfg := metadata.NewDefaultMetricsBuilderConfig()
-	cfg.Metrics.OracledbAsmDiskgroupFree.Enabled = true
-	cfg.Metrics.OracledbAsmDiskgroupTotal.Enabled = true
-	cfg.Metrics.OracledbAsmDiskgroupUsableFree.Enabled = true
-	cfg.Metrics.OracledbAsmDiskgroupOfflineDisks.Enabled = true
+	cfg.Metrics.OracledbAsmDiskGroupFree.Enabled = true
+	cfg.Metrics.OracledbAsmDiskGroupTotal.Enabled = true
+	cfg.Metrics.OracledbAsmDiskGroupUsableFree.Enabled = true
+	cfg.Metrics.OracledbAsmDiskGroupOfflineDisks.Enabled = true
 	cfg.Metrics.OracledbAsmDiskErrors.Enabled = true
 
 	scrpr := oracleScraper{
@@ -532,25 +532,25 @@ func TestScraper_ScrapeASMMetrics(t *testing.T) {
 	for i := 0; i < metrics.Len(); i++ {
 		metric := metrics.At(i)
 		switch metric.Name() {
-		case "oracledb.asm_diskgroup.free":
+		case "oracledb.asm.disk_group.free":
 			found["free"] = true
 			dp := metric.Gauge().DataPoints().At(0)
 			assert.Equal(t, int64(40960*1024*1024), dp.IntValue())
-			name, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+			name, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 			require.True(t, ok)
 			assert.Equal(t, "DATA", name.Str())
-		case "oracledb.asm_diskgroup.total":
+		case "oracledb.asm.disk_group.total":
 			found["total"] = true
 			assert.Equal(t, int64(102400*1024*1024), metric.Gauge().DataPoints().At(0).IntValue())
-		case "oracledb.asm_diskgroup.usable_free":
+		case "oracledb.asm.disk_group.usable_free":
 			found["usable_free"] = true
 			assert.Equal(t, int64(20480*1024*1024), metric.Gauge().DataPoints().At(0).IntValue())
-		case "oracledb.asm_diskgroup.offline_disks":
+		case "oracledb.asm.disk_group.offline_disks":
 			found["offline_disks"] = true
 			assert.Equal(t, int64(0), metric.Gauge().DataPoints().At(0).IntValue())
-		case "oracledb.asm_disk.errors":
+		case "oracledb.asm.disk.errors":
 			found["disk_errors"] = true
-			assert.True(t, metric.Sum().IsMonotonic(), "oracledb.asm_disk.errors must be a monotonic sum")
+			assert.True(t, metric.Sum().IsMonotonic(), "oracledb.asm.disk.errors must be a monotonic sum")
 			assert.Equal(t, 2, metric.Sum().DataPoints().Len(), "expected one data point per direction (read, write)")
 		}
 	}
@@ -563,7 +563,7 @@ func TestScraper_ScrapeASMMetrics(t *testing.T) {
 // (a non-ASM instance), the scraper no-ops cleanly instead of erroring.
 func TestScraper_ScrapeASMMetrics_NonASMInstance(t *testing.T) {
 	cfg := metadata.NewDefaultMetricsBuilderConfig()
-	cfg.Metrics.OracledbAsmDiskgroupFree.Enabled = true
+	cfg.Metrics.OracledbAsmDiskGroupFree.Enabled = true
 	cfg.Metrics.OracledbAsmDiskErrors.Enabled = true
 
 	scrpr := oracleScraper{
@@ -592,8 +592,8 @@ func TestScraper_ScrapeASMMetrics_NonASMInstance(t *testing.T) {
 	metrics := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	for i := 0; i < metrics.Len(); i++ {
 		name := metrics.At(i).Name()
-		assert.NotEqual(t, "oracledb.asm_diskgroup.free", name)
-		assert.NotEqual(t, "oracledb.asm_disk.errors", name)
+		assert.NotEqual(t, "oracledb.asm.disk_group.free", name)
+		assert.NotEqual(t, "oracledb.asm.disk.errors", name)
 	}
 }
 
@@ -602,7 +602,7 @@ func TestScraper_ScrapeASMMetrics_NonASMInstance(t *testing.T) {
 // or later in the same scrape from being emitted.
 func TestScraper_ScrapeASMMetrics_ErrorDoesNotBlockOtherMetrics(t *testing.T) {
 	cfg := metadata.NewDefaultMetricsBuilderConfig()
-	cfg.Metrics.OracledbAsmDiskgroupFree.Enabled = true
+	cfg.Metrics.OracledbAsmDiskGroupFree.Enabled = true
 	cfg.Metrics.OracledbConsistentGets.Enabled = true
 
 	scrpr := oracleScraper{
@@ -635,7 +635,7 @@ func TestScraper_ScrapeASMMetrics_ErrorDoesNotBlockOtherMetrics(t *testing.T) {
 		if metrics.At(i).Name() == "oracledb.consistent_gets" {
 			found = true
 		}
-		assert.NotEqual(t, "oracledb.asm_diskgroup.free", metrics.At(i).Name(),
+		assert.NotEqual(t, "oracledb.asm.disk_group.free", metrics.At(i).Name(),
 			"the failed ASM metric itself must not appear")
 	}
 	assert.True(t, found, "oracledb.consistent_gets must still be emitted despite the ASM error")

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -501,7 +501,7 @@ func TestScraper_ScrapeTablespaceHealthMetrics_BadMaxBytes(t *testing.T) {
 func TestScraper_ScrapeASMMetrics(t *testing.T) {
 	cfg := metadata.NewDefaultMetricsBuilderConfig()
 	cfg.Metrics.OracledbAsmDiskGroupFree.Enabled = true
-	cfg.Metrics.OracledbAsmDiskGroupTotal.Enabled = true
+	cfg.Metrics.OracledbAsmDiskGroupCapacity.Enabled = true
 	cfg.Metrics.OracledbAsmDiskGroupUsableFree.Enabled = true
 	cfg.Metrics.OracledbAsmDiskGroupOfflineDisks.Enabled = true
 	cfg.Metrics.OracledbAsmDiskErrors.Enabled = true
@@ -539,8 +539,8 @@ func TestScraper_ScrapeASMMetrics(t *testing.T) {
 			name, ok := dp.Attributes().Get("oracledb.asm.disk_group.name")
 			require.True(t, ok)
 			assert.Equal(t, "DATA", name.Str())
-		case "oracledb.asm.disk_group.total":
-			found["total"] = true
+		case "oracledb.asm.disk_group.capacity":
+			found["capacity"] = true
 			assert.Equal(t, int64(102400*1024*1024), metric.Gauge().DataPoints().At(0).IntValue())
 		case "oracledb.asm.disk_group.usable_free":
 			found["usable_free"] = true
@@ -555,7 +555,7 @@ func TestScraper_ScrapeASMMetrics(t *testing.T) {
 		}
 	}
 	assert.True(t,
-		found["free"] && found["total"] && found["usable_free"] && found["offline_disks"] && found["disk_errors"],
+		found["free"] && found["capacity"] && found["usable_free"] && found["offline_disks"] && found["disk_errors"],
 		"expected all 5 ASM metrics to be present, got: %v", found)
 }
 

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -146,6 +146,8 @@ var queryResponses = map[string][]metricRow{
 	},
 	tablespaceUsageSQL:        {{"TABLESPACE_NAME": "SYS", "USED_SPACE": "111288", "TABLESPACE_SIZE": "3518587", "BLOCK_SIZE": "8192", "STATUS": "ONLINE"}},
 	tablespaceUsageWithMaxSQL: {{"TABLESPACE_NAME": "SYS", "USED_SPACE": "111288", "TABLESPACE_SIZE": "3518587", "BLOCK_SIZE": "8192", "STATUS": "ONLINE", "MAX_BYTES": "1073741824"}},
+	asmDiskgroupSQL:           {{"NAME": "DATA", "TOTAL_MB": "102400", "FREE_MB": "40960", "USABLE_FILE_MB": "20480", "OFFLINE_DISKS": "0"}},
+	asmDiskSQL:                {{"DISKGROUP_NAME": "DATA", "DISK_NAME": "DATA_0000", "READ_ERRS": "0", "WRITE_ERRS": "0"}},
 	dataDictHitRatioSQL:       {{"DATA_DICTIONARY_HIT_RATIO": "98.75"}},
 	osStatSQL: {
 		{"STAT_NAME": "NUM_CPUS", "VALUE": "8"},
@@ -493,6 +495,150 @@ func TestScraper_ScrapeTablespaceHealthMetrics_BadMaxBytes(t *testing.T) {
 	_, err = scrpr.scrape(t.Context())
 	require.True(t, scrapererror.IsPartialScrapeError(err))
 	require.EqualError(t, err, `failed to parse int64 for OracledbTablespaceLimit, value was not-a-number: strconv.ParseInt: parsing "not-a-number": invalid syntax`)
+}
+
+// TestScraper_ScrapeASMMetrics covers the 5 new opt-in ASM diskgroup/disk metrics.
+func TestScraper_ScrapeASMMetrics(t *testing.T) {
+	cfg := metadata.NewDefaultMetricsBuilderConfig()
+	cfg.Metrics.OracledbAsmDiskgroupFree.Enabled = true
+	cfg.Metrics.OracledbAsmDiskgroupTotal.Enabled = true
+	cfg.Metrics.OracledbAsmDiskgroupUsableFree.Enabled = true
+	cfg.Metrics.OracledbAsmDiskgroupOfflineDisks.Enabled = true
+	cfg.Metrics.OracledbAsmDiskErrors.Enabled = true
+
+	scrpr := oracleScraper{
+		logger: zap.NewNop(),
+		mb:     metadata.NewMetricsBuilder(cfg, receivertest.NewNopSettings(metadata.Type)),
+		dbProviderFunc: func() (*sql.DB, error) {
+			return nil, nil
+		},
+		clientProviderFunc: func(_ *sql.DB, s string, _ *zap.Logger) dbClient {
+			return &fakeDbClient{Responses: [][]metricRow{queryResponses[s]}}
+		},
+		id:                   component.ID{},
+		metricsBuilderConfig: cfg,
+	}
+
+	err := scrpr.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, scrpr.shutdown(t.Context())) }()
+
+	m, err := scrpr.scrape(t.Context())
+	require.NoError(t, err)
+
+	metrics := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+
+	found := map[string]bool{}
+	for i := 0; i < metrics.Len(); i++ {
+		metric := metrics.At(i)
+		switch metric.Name() {
+		case "oracledb.asm_diskgroup.free":
+			found["free"] = true
+			dp := metric.Gauge().DataPoints().At(0)
+			assert.Equal(t, int64(40960*1024*1024), dp.IntValue())
+			name, ok := dp.Attributes().Get("oracledb.asm_diskgroup.name")
+			require.True(t, ok)
+			assert.Equal(t, "DATA", name.Str())
+		case "oracledb.asm_diskgroup.total":
+			found["total"] = true
+			assert.Equal(t, int64(102400*1024*1024), metric.Gauge().DataPoints().At(0).IntValue())
+		case "oracledb.asm_diskgroup.usable_free":
+			found["usable_free"] = true
+			assert.Equal(t, int64(20480*1024*1024), metric.Gauge().DataPoints().At(0).IntValue())
+		case "oracledb.asm_diskgroup.offline_disks":
+			found["offline_disks"] = true
+			assert.Equal(t, int64(0), metric.Gauge().DataPoints().At(0).IntValue())
+		case "oracledb.asm_disk.errors":
+			found["disk_errors"] = true
+			assert.True(t, metric.Sum().IsMonotonic(), "oracledb.asm_disk.errors must be a monotonic sum")
+			assert.Equal(t, 2, metric.Sum().DataPoints().Len(), "expected one data point per direction (read, write)")
+		}
+	}
+	assert.True(t,
+		found["free"] && found["total"] && found["usable_free"] && found["offline_disks"] && found["disk_errors"],
+		"expected all 5 ASM metrics to be present, got: %v", found)
+}
+
+// TestScraper_ScrapeASMMetrics_NonASMInstance verifies that when the ASM views return zero rows
+// (a non-ASM instance), the scraper no-ops cleanly instead of erroring.
+func TestScraper_ScrapeASMMetrics_NonASMInstance(t *testing.T) {
+	cfg := metadata.NewDefaultMetricsBuilderConfig()
+	cfg.Metrics.OracledbAsmDiskgroupFree.Enabled = true
+	cfg.Metrics.OracledbAsmDiskErrors.Enabled = true
+
+	scrpr := oracleScraper{
+		logger: zap.NewNop(),
+		mb:     metadata.NewMetricsBuilder(cfg, receivertest.NewNopSettings(metadata.Type)),
+		dbProviderFunc: func() (*sql.DB, error) {
+			return nil, nil
+		},
+		clientProviderFunc: func(_ *sql.DB, s string, _ *zap.Logger) dbClient {
+			if s == asmDiskgroupSQL || s == asmDiskSQL {
+				return &fakeDbClient{Responses: [][]metricRow{{}}}
+			}
+			return &fakeDbClient{Responses: [][]metricRow{queryResponses[s]}}
+		},
+		id:                   component.ID{},
+		metricsBuilderConfig: cfg,
+	}
+
+	err := scrpr.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, scrpr.shutdown(t.Context())) }()
+
+	m, err := scrpr.scrape(t.Context())
+	require.NoError(t, err)
+
+	metrics := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	for i := 0; i < metrics.Len(); i++ {
+		name := metrics.At(i).Name()
+		assert.NotEqual(t, "oracledb.asm_diskgroup.free", name)
+		assert.NotEqual(t, "oracledb.asm_disk.errors", name)
+	}
+}
+
+// TestScraper_ScrapeASMMetrics_ErrorDoesNotBlockOtherMetrics verifies that an ASM query error
+// surfaces as a partial scrape error, without preventing an unrelated metric collected earlier
+// or later in the same scrape from being emitted.
+func TestScraper_ScrapeASMMetrics_ErrorDoesNotBlockOtherMetrics(t *testing.T) {
+	cfg := metadata.NewDefaultMetricsBuilderConfig()
+	cfg.Metrics.OracledbAsmDiskgroupFree.Enabled = true
+	cfg.Metrics.OracledbConsistentGets.Enabled = true
+
+	scrpr := oracleScraper{
+		logger: zap.NewNop(),
+		mb:     metadata.NewMetricsBuilder(cfg, receivertest.NewNopSettings(metadata.Type)),
+		dbProviderFunc: func() (*sql.DB, error) {
+			return nil, nil
+		},
+		clientProviderFunc: func(_ *sql.DB, s string, _ *zap.Logger) dbClient {
+			if s == asmDiskgroupSQL {
+				return &fakeDbClient{Err: errors.New("connection reset by peer")}
+			}
+			return &fakeDbClient{Responses: [][]metricRow{queryResponses[s]}}
+		},
+		id:                   component.ID{},
+		metricsBuilderConfig: cfg,
+	}
+
+	err := scrpr.start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, scrpr.shutdown(t.Context())) }()
+
+	m, err := scrpr.scrape(t.Context())
+	require.Error(t, err)
+	assert.True(t, scrapererror.IsPartialScrapeError(err), "an ASM error must be a partial scrape error, not a total failure")
+
+	metrics := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	found := false
+	for i := 0; i < metrics.Len(); i++ {
+		if metrics.At(i).Name() == "oracledb.consistent_gets" {
+			found = true
+		}
+		assert.NotEqual(t, "oracledb.asm_diskgroup.free", metrics.At(i).Name(),
+			"the failed ASM metric itself must not appear")
+	}
+	assert.True(t, found, "oracledb.consistent_gets must still be emitted despite the ASM error")
 }
 
 // TestScraper_ScrapeCDBRoot verifies that when the scraper is in CDB-root mode (isCDBRoot=true)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Added asm support for oracle this can help receiver to identify asm metrics like:
- oracledb.asm_diskgroup.free — free space in an ASM diskgroup
- oracledb.asm_diskgroup.total — total space in an ASM diskgroup
- oracledb.asm_diskgroup.usable_free — free space after accounting for mirroring overhead
- oracledb.asm_diskgroup.offline_disks — count of offline disks within a diskgroup
- oracledb.asm_disk.errors — I/O error count per disk, with a disk.io.direction attribute

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes  #50487

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Testing: Updated test file names in scraper_test.go:
- TestScraper_ScrapeASMMetrics
- TestScraper_ScrapeASMMetrics_NonASMInstance
- TestScraper_ScrapeASMMetrics_ErrorDoesNotBlockOtherMetrics

Manually verified against a self-managed Oracle 19c instance with ASM (real diskgroup data returned), Amazon RDS for Oracle (clean empty result, no error), and Oracle Autonomous Database (diskgroup data returned, disk-level query empty).

<!--Describe the documentation added.-->
#### Documentation
Updated documentation.md (auto-generated via mdatagen from metadata.yaml) and added a new "ASM metrics" grants section in README.md with the two required GRANT SELECT statements.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
