### PR TITLE
[exporter/elasticsearch] Remove deprecated batching settings

### DIFF
--- a/.chloggen/elasticsearch-remove-deprecated-batch-settings.yaml
+++ b/.chloggen/elasticsearch-remove-deprecated-batch-settings.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the deprecated `flush` and `num_workers` configuration settings.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42718]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Migrate `num_workers` to `sending_queue::num_consumers`, `flush::interval` to
+  `sending_queue::batch::flush_timeout`, and `flush::bytes` to
+  `sending_queue::batch::max_size` with `sending_queue::batch::sizer` set to `bytes`.
+  This also removes `Config.NumWorkers`, `Config.Flush`, and `FlushSettings` from
+  the exported Go API.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -355,10 +355,14 @@ This can be configured through the following settings:
 The Elasticsearch exporter uses the [Elasticsearch Bulk API] for indexing documents.
 The behaviour of this bulk indexing can be configured with the following settings:
 
-- `num_workers` (DEPRECATED, use `sending_queue::num_consumers` instead): This config is deprecated and will be used to configure `sending_queue::num_consumers` if `sending_queue::num_consumers` is not explicitly defined. Number of workers publishing bulk requests concurrently.
-- `flush` (DEPRECATED, use `sending_queue` instead): This config is deprecated and will be used to configure different options for `sending_queue` if `sending_queue` options are not explicitly defined. Event bulk indexer buffer flush settings
-  - `bytes` (DEPRECATED, use `sending_queue::batch::max_size` instead): This config is deprecated and will be used to configure `sending_queue::batch::max_size` if `sending_queue::batch::max_size` is not explicitly defined. See the `sending_queue::batch::max_size` for more details.
-  - `interval` (DEPRECATED, use `sending_queue::batch::flush_timeout` instead): This config is deprecated and will be used to configure `sending_queue::batch::flush_timeout` if `sending_queue::batch::flush_timeout` is not explicitly defined. See the `sending_queue::batch::flush_timeout` for more details.
+The deprecated `num_workers` and `flush` settings have been removed. Existing configurations should use these replacements:
+
+| Removed setting | Replacement |
+| --- | --- |
+| `num_workers` | `sending_queue::num_consumers` |
+| `flush::interval` | `sending_queue::batch::flush_timeout` |
+| `flush::bytes` | `sending_queue::batch::max_size` with `sending_queue::batch::sizer` set to `bytes` |
+
 - `retry`: Elasticsearch bulk request retry settings
   - `enabled` (default=true): Enable/Disable request retry on error. Failed requests are retried with exponential backoff.
   - `max_requests` (DEPRECATED, use retry::max_retries instead): Number of HTTP request retries including the initial attempt. If used, `retry::max_retries` will be set to `max_requests - 1`.

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -40,13 +40,6 @@ type Config struct {
 	// This setting is required if no URL is configured.
 	CloudID string `mapstructure:"cloudid"`
 
-	// NumWorkers configures the number of workers publishing bulk requests.
-	//
-	// Deprecated: [v0.136.0] This config is now deprecated. Use `sending_queue::num_consumers`
-	// instead. If this config is defined and `sending_queue::num_consumers` is not defined then
-	// it will be used to set `sending_queue::num_consumers`.
-	NumWorkers int `mapstructure:"num_workers"`
-
 	// LogsIndex configures the static index used for document routing for logs.
 	// It should be empty if dynamic document routing is preferred.
 	LogsIndex        string              `mapstructure:"logs_index"`
@@ -82,10 +75,6 @@ type Config struct {
 	Discovery      DiscoverySettings       `mapstructure:"discover"`
 	Retry          RetrySettings           `mapstructure:"retry"`
 
-	// Deprecated: [v0.136.0] This config is now deprecated. Use `sending_queue::batch` instead.
-	// If this config is defined then it will be used to configure sending queue's batch provided
-	// sending queue's config are not explicitly defined.
-	Flush          FlushSettings          `mapstructure:"flush"`
 	Mapping        MappingsSettings       `mapstructure:"mapping"`
 	LogstashFormat LogstashFormatSettings `mapstructure:"logstash_format"`
 
@@ -113,13 +102,11 @@ type Config struct {
 	IncludeSourceOnError *bool `mapstructure:"include_source_on_error"`
 
 	// Experimental: MetadataKeys defines a list of client.Metadata keys that
-	// will be used as partition keys for when batcher is enabled and will be
-	// added to the exporter's telemetry if defined. The config only applies
-	// when `sending_queue::batch` is defined or when the, now deprecated, batcher
-	// is used (set to `true` or `false`). The metadata keys are converted to
-	// lower case as key lookups for client metadata is case insensitive. This
-	// means that the metric produced by internal telemetry will also have the
-	// attribute in lower case.
+	// will be used as partition keys when `sending_queue::batch` is enabled and
+	// will be added to the exporter's telemetry if defined. The metadata keys
+	// are converted to lower case because client metadata key lookups are case
+	// insensitive. This means that the metric produced by internal telemetry
+	// will also have the attribute in lower case.
 	//
 	// Keys are case-insensitive and duplicates will trigger a validation error.
 	MetadataKeys []string `mapstructure:"metadata_keys"`
@@ -224,33 +211,6 @@ type DiscoverySettings struct {
 	_ struct{}
 }
 
-// FlushSettings defines settings for configuring the write buffer flushing
-// policy in the Elasticsearch exporter. The exporter sends a bulk request with
-// all events already serialized into the send-buffer.
-//
-// Deprecated: [v0.136.0] This config is now deprecated. Use `sending_queue::batch` instead.
-// If this config is defined then it will be used to configure sending queue's batch provided
-// sending queue's config are not explicitly defined.
-type FlushSettings struct {
-	// Bytes sets the send buffer flushing limit.
-	// Bytes is now deprecated. Use `sending_queue::batch::{min, max}_size` with `bytes`
-	// sizer to configure batching based on bytes.
-	//
-	// If this config option is defined then it will be used to configure `sending_queue::batch::max_size`
-	// provided it is not explcitly defined.
-	Bytes int `mapstructure:"bytes"`
-
-	// Interval configures the max age of a document in the send buffer.
-	// Interval is now deprecated. Use `sending-queue::batch::flush_timeout` instead.
-	//
-	// If this config option is defined then it will be used to configure `sending_queue::batch::flush_timeout`
-	// provided it is not explcitly defined.
-	Interval time.Duration `mapstructure:"interval"`
-
-	// prevent unkeyed literal initialization
-	_ struct{}
-}
-
 // RetrySettings defines settings for the HTTP request retries in the Elasticsearch exporter.
 // Failed sends are retried with exponential backoff.
 type RetrySettings struct {
@@ -338,20 +298,20 @@ var (
 const defaultElasticsearchEnvName = "ELASTICSEARCH_URL"
 
 func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
+	// ClientConfig is squashed and implements custom unmarshaling, so confmap
+	// does not report unused top-level keys here. Reject the removed settings explicitly.
+	var invalidKeys []string
+	for _, key := range []string{"flush", "num_workers"} {
+		if conf.IsSet(key) {
+			invalidKeys = append(invalidKeys, key)
+		}
+	}
+	if len(invalidKeys) > 0 {
+		return fmt.Errorf("has invalid keys: %s", strings.Join(invalidKeys, ", "))
+	}
+
 	if err := conf.Unmarshal(cfg); err != nil {
 		return err
-	}
-	if !conf.IsSet("sending_queue::num_consumers") && conf.IsSet("num_workers") {
-		cfg.QueueBatchConfig.Get().NumConsumers = cfg.NumWorkers
-	}
-	if cfg.QueueBatchConfig.HasValue() && cfg.QueueBatchConfig.Get().Batch.HasValue() {
-		qbCfg := cfg.QueueBatchConfig.Get().Batch.Get()
-		if !conf.IsSet("sending_queue::batch::flush_timeout") && conf.IsSet("flush::interval") {
-			qbCfg.FlushTimeout = cfg.Flush.Interval
-		}
-		if !conf.IsSet("sending_queue::batch::max_size") && conf.IsSet("flush::bytes") {
-			qbCfg.MaxSize = int64(cfg.Flush.Bytes)
-		}
 	}
 
 	if !conf.IsSet("retry::retry_on_document_status") {
@@ -537,12 +497,6 @@ func handleDeprecatedConfig(cfg *Config, logger *zap.Logger) {
 	}
 	if cfg.TracesDynamicIndex.Enabled {
 		logger.Warn("traces_dynamic_index::enabled has been deprecated, and will be removed in a future version. It is now a no-op. Dynamic document routing is now the default. See Elasticsearch Exporter README.")
-	}
-	if cfg.Flush.Bytes > 0 || cfg.Flush.Interval > 0 {
-		logger.Warn("flush settings are now deprecated and ignored. Use `sending_queue` instead.")
-	}
-	if cfg.NumWorkers > 0 {
-		logger.Warn("num_workers is now deprecated and ignored. Use `sending_queue` instead.")
 	}
 }
 

--- a/exporter/elasticsearchexporter/config.schema.yaml
+++ b/exporter/elasticsearchexporter/config.schema.yaml
@@ -39,17 +39,6 @@ $defs:
     properties:
       enabled:
         type: boolean
-  flush_settings:
-    description: 'FlushSettings defines settings for configuring the write buffer flushing policy in the Elasticsearch exporter. The exporter sends a bulk request with all events already serialized into the send-buffer. Deprecated: [v0.136.0] This config is now deprecated. Use `sending_queue::batch` instead. If this config is defined then it will be used to configure sending queue''s batch provided sending queue''s config are not explicitly defined.'
-    type: object
-    properties:
-      bytes:
-        description: Bytes sets the send buffer flushing limit. Bytes is now deprecated. Use `sending_queue::batch::{min, max}_size` with `bytes` sizer to configure batching based on bytes. If this config option is defined then it will be used to configure `sending_queue::batch::max_size` provided it is not explcitly defined.
-        type: integer
-      interval:
-        description: Interval configures the max age of a document in the send buffer. Interval is now deprecated. Use `sending-queue::batch::flush_timeout` instead. If this config option is defined then it will be used to configure `sending_queue::batch::flush_timeout` provided it is not explcitly defined.
-        type: string
-        format: duration
   logstash_format_settings:
     type: object
     properties:
@@ -129,9 +118,6 @@ properties:
     type: array
     items:
       type: string
-  flush:
-    description: 'Deprecated: [v0.136.0] This config is now deprecated. Use `sending_queue::batch` instead. If this config is defined then it will be used to configure sending queue''s batch provided sending queue''s config are not explicitly defined.'
-    $ref: flush_settings
   include_source_on_error:
     description: 'IncludeSourceOnError configures whether the bulk index responses include a part of the source document on error. Defaults to nil. This setting requires Elasticsearch 8.18+. Using it in prior versions have no effect. NOTE: The default behavior if this configuration is not set, is to discard the error reason entirely, i.e. only the error type is returned. WARNING: If set to true, the exporter may log error responses containing request payload, causing potential sensitive data to be exposed in logs. Users are expected to sanitize the responses themselves.'
     x-pointer: true
@@ -152,7 +138,7 @@ properties:
   mapping:
     $ref: mappings_settings
   metadata_keys:
-    description: 'Experimental: MetadataKeys defines a list of client.Metadata keys that will be used as partition keys for when batcher is enabled and will be added to the exporter''s telemetry if defined. The config only applies when `sending_queue::batch` is defined or when the, now deprecated, batcher is used (set to `true` or `false`). The metadata keys are converted to lower case as key lookups for client metadata is case insensitive. This means that the metric produced by internal telemetry will also have the attribute in lower case. Keys are case-insensitive and duplicates will trigger a validation error.'
+    description: 'Experimental: MetadataKeys defines a list of client.Metadata keys that will be used as partition keys when `sending_queue::batch` is enabled and will be added to the exporter''s telemetry if defined. The metadata keys are converted to lower case because client metadata key lookups are case insensitive. This means that the metric produced by internal telemetry will also have the attribute in lower case. Keys are case-insensitive and duplicates will trigger a validation error.'
     type: array
     items:
       type: string
@@ -161,9 +147,6 @@ properties:
   metrics_index:
     description: MetricsIndex configures the static index used for document routing for metrics. It should be empty if dynamic document routing is preferred.
     type: string
-  num_workers:
-    description: 'NumWorkers configures the number of workers publishing bulk requests. Deprecated: [v0.136.0] This config is now deprecated. Use `sending_queue::num_consumers` instead. If this config is defined and `sending_queue::num_consumers` is not defined then it will be used to set `sending_queue::num_consumers`.'
-    type: integer
   pipeline:
     description: Pipeline configures the ingest node pipeline name that should be used to process the events. https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html
     type: string

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -389,44 +389,6 @@ func TestConfig(t *testing.T) {
 			}),
 		},
 		{
-			id:         component.NewIDWithName(metadata.Type, "backward_compat_for_deprecated_cfgs/new_config_takes_priority"),
-			configFile: "config.yaml",
-			expected: withDefaultConfig(func(cfg *Config) {
-				cfg.ClientConfig.Endpoint = "https://elastic.example.com:9200"
-
-				cfg.NumWorkers = 11
-				cfg.Flush = FlushSettings{
-					Bytes:    1001,
-					Interval: 11 * time.Second,
-				}
-				cfg.QueueBatchConfig.Get().NumConsumers = 111
-				// QueueBatchConfig is set by default
-				qbCfg := cfg.QueueBatchConfig.Get().Batch.Get()
-				qbCfg.FlushTimeout = 111 * time.Second
-				qbCfg.MaxSize = 1_000_001
-				qbCfg.Sizer = exporterhelper.RequestSizerTypeBytes
-			}),
-		},
-		{
-			id:         component.NewIDWithName(metadata.Type, "backward_compat_for_deprecated_cfgs/fallback_to_old_cfg"),
-			configFile: "config.yaml",
-			expected: withDefaultConfig(func(cfg *Config) {
-				cfg.ClientConfig.Endpoint = "https://elastic.example.com:9200"
-
-				cfg.NumWorkers = 11
-				cfg.Flush = FlushSettings{
-					Bytes:    1_000_001,
-					Interval: 11 * time.Second,
-				}
-				cfg.QueueBatchConfig.Get().NumConsumers = 11
-				// QueueBatchConfig is set by default
-				qbCfg := cfg.QueueBatchConfig.Get().Batch.Get()
-				qbCfg.FlushTimeout = 11 * time.Second
-				qbCfg.MaxSize = 1_000_001
-				qbCfg.Sizer = exporterhelper.RequestSizerTypeBytes
-			}),
-		},
-		{
 			id:         component.NewIDWithName(metadata.Type, "suppress_conflict_errors"),
 			configFile: "config.yaml",
 			expected: withDefaultConfig(func(cfg *Config) {
@@ -470,6 +432,32 @@ func TestConfig(t *testing.T) {
 			assert.NoError(t, confmap.Validate(cfg))
 
 			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}
+
+func TestConfigRejectsRemovedBatchSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]map[string]any{
+		"flush": {
+			"flush": map[string]any{
+				"bytes":    1001,
+				"interval": "11s",
+			},
+		},
+		"num_workers": {
+			"num_workers": 11,
+		},
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := createDefaultConfig()
+			err := confmap.NewFromStringMap(input).Unmarshal(cfg)
+			require.ErrorContains(t, err, "has invalid keys: "+name)
 		})
 	}
 }

--- a/exporter/elasticsearchexporter/testdata/config.yaml
+++ b/exporter/elasticsearchexporter/testdata/config.yaml
@@ -116,34 +116,6 @@ elasticsearch/sendingqueue_enabled:
       sizer: items
       min_size: 1000
       max_size: 5000
-elasticsearch/backward_compat_for_deprecated_cfgs/new_config_takes_priority:
-  endpoint: https://elastic.example.com:9200
-  # Should be ignored and left as-is
-  num_workers: 11
-  flush:
-    interval: 11s
-    bytes: 1001
-  # Should take precedence
-  sending_queue:
-    enabled: true
-    sizer: requests
-    num_consumers: 111
-    batch:
-      flush_timeout: 111s
-      max_size: 1_000_001
-      sizer: bytes
-elasticsearch/backward_compat_for_deprecated_cfgs/fallback_to_old_cfg:
-  endpoint: https://elastic.example.com:9200
-  # Should be used to set sending_queue config
-  num_workers: 11
-  flush:
-    interval: 11s
-    bytes: 1_000_001
-  sending_queue:
-    enabled: true
-    sizer: requests
-    batch:
-      sizer: bytes
 elasticsearch/suppress_conflict_errors:
   endpoint: https://elastic.example.com:9200
   suppress_conflict_errors: true


### PR DESCRIPTION
## Description

This change removes the deprecated `flush` and `num_workers` configuration options. Configurations that still use these legacy keys are now rejected as invalid instead of being migrated automatically. It also removes the exported `Config.Flush`, `Config.NumWorkers`, and `FlushSettings` Go APIs. The defaults and runtime behavior of `sending_queue` remain unchanged.

## Link to tracking issue

Closes #42718

This completes the remaining cleanup tracked by the issue.

## Testing

* Added focused configuration tests covering rejection of `flush` and `num_workers`
* Ran the component-level `make test`: all 537 race-enabled tests passed
* Ran `make lint`
* Ran `go mod tidy -diff`
* Ran `make chlog-validate`
* Ran `make chlog-preview`
* Ran `make checkapi`
* Regenerated `config.schema.yaml` and verified that regeneration is idempotent
* Ran `git diff --check`

## Documentation

The README retains the migration mappings from the removed options to their `sending_queue` equivalents. `config.schema.yaml` has been regenerated, and a breaking `.chloggen` entry has been added for both the `user` and `api` change logs.

#### Authorship

- [x] I, a human, wrote this pull request description myself.