### PR TITLE
[chore] Update k8s versions in e2e-tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -119,8 +119,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - "v1.34.0"
           - "v1.35.0"
+          - "v1.36.0"
         component:
           - receiver/k8sclusterreceiver
           - processor/k8sattributesprocessor


### PR DESCRIPTION
#### Description
We now support k8s 1.36.0: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47953

#### Authorship

- [x] I, a human, wrote this pull request description myself.
