### PR TITLE
[processor/adaptive_tail_sampling] add span_limit to bound per-trace buffering

### DIFF
--- a/.chloggen/adaptivetailsampling-span-limit.yaml
+++ b/.chloggen/adaptivetailsampling-span-limit.yaml
@@ -1,0 +1,34 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/adaptive_tail_sampling
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `span_limit` (default 10000) to bound per-trace buffering. A trace reaching the limit is decided immediately over the spans buffered so far, and later spans are stamped from the decision cache instead of being buffered.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49311]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `num_traces` and eviction bound how many traces are buffered, not how large any one
+  of them grows, so a single giant trace could previously exhaust memory. Set
+  `span_limit: 0` to disable the cap. Also adds decision observability: a new
+  `trace_span_count` histogram records buffered span counts per trace at decision
+  time (for sizing `span_limit`), every kept span now carries an
+  `otelcol.processor.adaptive_tail_sampling.trigger` attribute recording which event
+  triggered the decision, and limit-triggered decisions are counted on the
+  decision-triggers metric under `trigger="span_limit"`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -21,18 +21,20 @@ The Adaptive Tail Sampling Processor performs adaptive tail-based trace sampling
 ## How it works
 
 1. Spans are accumulated in memory, grouped by trace ID.
-2. A trace becomes ready for evaluation when **either** of two triggers fires (whichever comes first):
-   - a root span arrives (any span with an empty `ParentSpanID`), or
-   - `trace_timeout` elapses since the first span of the trace arrived. This timer is set on first-seen and is never extended by subsequent spans, ensuring a predictable upper bound on buffer occupancy.
-3. After the trigger fires, the processor pauses for `decision_delay` to let in-flight straggler spans land. The same delay applies regardless of which trigger fired.
+2. A trace becomes ready for evaluation when **any** of three triggers fires (whichever comes first):
+   - a root span arrives (any span with an empty `ParentSpanID`),
+   - `trace_timeout` elapses since the first span of the trace arrived. This timer is set on first-seen and is never extended by subsequent spans, ensuring a predictable upper bound on buffer occupancy, or
+   - the trace accumulates `span_limit` spans (10000 by default; 0 disables). This bounds the memory a single giant trace can hold; the decision is made over the spans buffered so far, and spans arriving afterwards are stamped from the decision cache instead of being buffered.
+3. After the trigger fires, the processor pauses for `decision_delay` to let in-flight straggler spans land. The root-span and trace-timeout triggers share the same delay; the span-limit trigger decides immediately, since the trace is at its memory peak and waiting would let it keep growing.
 4. Rules are then evaluated in order against the accumulated trace. The first rule whose conditions all match selects the sampler; once a rule is selected, its sampler's keep/drop decision is final and no later rules are considered. A rule with no conditions is a catch-all.
 5. The matched sampler produces a sample rate (1-in-N). Samplers only ever produce rates; no sampler makes a keep/drop decision itself.
 6. The processor converts the rate to a threshold (a rate of N becomes the threshold encoding probability 1/N) and makes the keep/drop decision by comparing that threshold against the trace's randomness (`ot=rv` when present, otherwise derived from the trace ID), using the [OTel consistent probability sampling](https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/) algorithm.
 
 > [!NOTE]
 > The adaptive samplers come from [dynsampler-go](https://github.com/honeycombio/dynsampler-go), which the processor uses **only** to compute rates. dynsampler-go's own samplers can make keep/drop decisions internally (its `DeterministicSampler` applies its own hash-based check, for example), but this processor never uses that path: the rate-to-threshold conversion and the randomness comparison in step 6 are the single decision mechanism for every sampler type, including this processor's `probabilistic` type. This is what makes decisions reproducible for a given trace and correctly weighted downstream via `ot=th`.
-7. Sampled traces are forwarded with two annotations on every span:
+7. Sampled traces are forwarded with annotations on every span:
    - `otelcol.processor.adaptive_tail_sampling.rule`: the name of the matched rule
+   - `otelcol.processor.adaptive_tail_sampling.trigger`: which event triggered the decision (see [Output attributes](#output-attributes))
    - W3C TraceState `ot=th:<hex>`: the threshold encoding the effective sample rate
 8. The decision (sampled or dropped) is recorded in a per-trace LRU cache so that any late-arriving spans for the same trace ID are handled consistently with the original decision (see [Decision cache](#decision-cache) below).
 
@@ -52,6 +54,12 @@ processors:
 
     # Maximum number of traces held in the in-memory buffer.
     num_traces: 50000
+
+    # Maximum spans a single trace may accumulate before it is decided
+    # immediately over the spans buffered so far. Bounds the memory one giant
+    # trace can hold; num_traces and eviction only bound the trace count.
+    # Defaults to 10000; 0 disables the cap.
+    span_limit: 10000
 
     decision_cache:
       sampled_cache_size: 10000      # 0 disables the sampled cache
@@ -397,7 +405,7 @@ processors:
           weight: 0.5
 ```
 
-Sizing guidance: `num_traces` bounds memory and should cover the number of traces that start within one `trace_timeout` window at peak. The decision caches should be a small multiple of that, since they only store trace IDs and outcomes; undersizing them turns late spans of decided traces back into new partial traces.
+Sizing guidance: `num_traces` bounds memory and should cover the number of traces that start within one `trace_timeout` window at peak. The decision caches should be a small multiple of that, since they only store trace IDs and outcomes; undersizing them turns late spans of decided traces back into new partial traces. `num_traces` bounds how many traces are buffered, not how large any one of them grows; `span_limit` (10000 by default) covers that dimension. Keep it well above your largest legitimate trace so a single runaway trace cannot exhaust memory while normal traces are never truncated.
 
 ### Throughput-bounded fleet
 
@@ -631,7 +639,8 @@ Future work on shared trace context across collector instances (tracked under "C
 | `otelcol_processor_adaptive_tail_sampling_traces_sampled` | Counter  | `rule`   | Traces kept, attributed to the rule that selected them.                     |
 | `otelcol_processor_adaptive_tail_sampling_traces_dropped` | Counter  | `rule`   | Traces dropped, attributed to the rule that selected them.                  |
 | `otelcol_processor_adaptive_tail_sampling_decision_sample_rate` | Histogram | `rule` | Distribution of effective sample rates produced per rule.                  |
-| `otelcol_processor_adaptive_tail_sampling_decision_triggers` | Counter  | `trigger` | Number of trace decisions made, labelled by which event triggered them (`root_span`, `trace_timeout`, `eviction`, `shutdown`). |
+| `otelcol_processor_adaptive_tail_sampling_decision_triggers` | Counter  | `trigger` | Number of trace decisions made, labelled by which event triggered them (`root_span`, `trace_timeout`, `eviction`, `shutdown`, `span_limit`). |
+| `otelcol_processor_adaptive_tail_sampling_trace_span_count` | Histogram | `rule` | Distribution of buffered span counts per trace at decision time. Useful for sizing `span_limit` against the real trace-size distribution. |
 | `otelcol_processor_adaptive_tail_sampling_fingerprint_duration` | Histogram | `rule` | Time spent extracting a rule's fingerprint per decision (microseconds). A relative signal for spotting expensive fingerprints, eg wide `any.` scopes on large traces. |
 | `otelcol_processor_adaptive_tail_sampling_traces_evicted` | Counter  |          | Traces evicted from the buffer under pressure. Each still receives a decision per the eviction policy. |
 | `otelcol_processor_adaptive_tail_sampling_incoming_tracestate_unparseable` | Counter |     | Spans whose incoming W3C tracestate could not be parsed while applying the sampling threshold. |
@@ -654,6 +663,7 @@ Every span in a sampled trace is annotated with:
 |------------------------------------------------------|---------|--------------|--------------------------------------------------------|
 | `otelcol.processor.adaptive_tail_sampling.rule`            | string  | `keep-errors`| Name of the rule that selected this trace.             |
 | `otelcol.processor.adaptive_tail_sampling.fingerprint`     | string  | `9f86d081884c7d65` | The matched rule's fingerprint, raw or hashed, when `record_fingerprint` is enabled. |
+| `otelcol.processor.adaptive_tail_sampling.trigger`         | string  | `root_span`  | What caused the decision (`root_span`, `trace_timeout`, `eviction`, `shutdown`, `span_limit`). Eviction and shutdown override the original trigger on traces they decide mid-delay, so the attribute always names the event that produced the decision, while the decision-triggers metric counts the event that first made the trace decision-eligible. Values other than `root_span` mean the decision may have seen an incomplete trace. |
 
 ### Recording the fingerprint
 

--- a/processor/adaptivetailsamplingprocessor/cache.go
+++ b/processor/adaptivetailsamplingprocessor/cache.go
@@ -21,6 +21,9 @@ type cachedDecision struct {
 	// record_fingerprint), empty when recording is disabled or the rule has
 	// no fingerprint. Stored so late spans receive the same attribute.
 	fingerprint string
+	// trigger records which event triggered the decision, stored so late
+	// spans carry the same trigger attribution as the decided trace.
+	trigger triggerSource
 }
 
 // decisionCache holds two independent LRU caches: one tracks traces that have

--- a/processor/adaptivetailsamplingprocessor/config.go
+++ b/processor/adaptivetailsamplingprocessor/config.go
@@ -80,6 +80,15 @@ type Config struct {
 	// NumTraces is the maximum number of traces held in the in-memory buffer at
 	// any time. Older traces are evicted when this limit is exceeded.
 	NumTraces int `mapstructure:"num_traces"`
+	// SpanLimit caps how many spans a single trace may accumulate in the
+	// buffer. A trace reaching the limit is scheduled for an immediate
+	// decision (no decision_delay), evaluated over the spans buffered so
+	// far; spans arriving after the decision follow the late-span path
+	// (stamped from the decision cache) instead of being buffered. This
+	// bounds the memory a single giant trace can hold, which num_traces and
+	// eviction cannot (they bound trace count, not spans per trace).
+	// Defaults to 10000. 0 disables the cap.
+	SpanLimit int `mapstructure:"span_limit"`
 	// DecisionCache configures the LRU caches that record decisions for already
 	// decided traces, so late-arriving spans receive the same treatment as the
 	// original trace.
@@ -279,6 +288,9 @@ func (c *Config) Validate() error {
 	}
 	if c.NumTraces <= 0 {
 		return errors.New("num_traces must be greater than zero")
+	}
+	if c.SpanLimit < 0 {
+		return errors.New("span_limit must be non-negative")
 	}
 	if c.DecisionCache.SampledCacheSize < 0 {
 		return errors.New("decision_cache.sampled_cache_size must be non-negative")

--- a/processor/adaptivetailsamplingprocessor/config_test.go
+++ b/processor/adaptivetailsamplingprocessor/config_test.go
@@ -75,6 +75,17 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: "at least one rule",
 		},
 		{
+			name: "negative_span_limit",
+			cfg: Config{
+				TraceTimeout:  time.Second,
+				DecisionDelay: time.Second,
+				NumTraces:     100,
+				SpanLimit:     -1,
+				Rules:         []RuleConfig{{Name: "r", Sampler: SamplerConfig{Type: AlwaysSample}}},
+			},
+			wantErr: "span_limit must be non-negative",
+		},
+		{
 			name: "negative_sampled_cache_size",
 			cfg: Config{
 				TraceTimeout:  time.Second,

--- a/processor/adaptivetailsamplingprocessor/documentation.md
+++ b/processor/adaptivetailsamplingprocessor/documentation.md
@@ -16,7 +16,7 @@ Distribution of effective sample rates produced per rule. Useful for detecting a
 
 ### otelcol_processor_adaptive_tail_sampling_decision_triggers
 
-Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction, shutdown).
+Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction, shutdown, span_limit).
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
@@ -45,6 +45,14 @@ Number of OTTL condition evaluation errors, labelled by the rule the condition b
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |
 | {errors} | Sum | Int | true | Development |
+
+### otelcol_processor_adaptive_tail_sampling_trace_span_count
+
+Distribution of buffered span counts per trace at decision time, labelled by rule. Useful for sizing span_limit against the real trace-size distribution.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {spans} | Histogram | Int | Development |
 
 ### otelcol_processor_adaptive_tail_sampling_traces_active
 

--- a/processor/adaptivetailsamplingprocessor/factory.go
+++ b/processor/adaptivetailsamplingprocessor/factory.go
@@ -28,6 +28,7 @@ func createDefaultConfig() component.Config {
 		TraceTimeout:  30 * time.Second,
 		DecisionDelay: 2 * time.Second,
 		NumTraces:     50_000,
+		SpanLimit:     10_000,
 		DecisionCache: DecisionCacheConfig{
 			SampledCacheSize:    10_000,
 			NonSampledCacheSize: 10_000,

--- a/processor/adaptivetailsamplingprocessor/factory_test.go
+++ b/processor/adaptivetailsamplingprocessor/factory_test.go
@@ -25,6 +25,7 @@ func TestFactory_DefaultConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, cfg.TraceTimeout)
 	assert.Equal(t, 2*time.Second, cfg.DecisionDelay)
 	assert.Equal(t, 50_000, cfg.NumTraces)
+	assert.Equal(t, 10_000, cfg.SpanLimit)
 	assert.Equal(t, 10_000, cfg.DecisionCache.SampledCacheSize)
 	assert.Equal(t, 10_000, cfg.DecisionCache.NonSampledCacheSize)
 	assert.Empty(t, cfg.Rules)

--- a/processor/adaptivetailsamplingprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/adaptivetailsamplingprocessor/internal/metadata/generated_telemetry.go
@@ -30,6 +30,7 @@ type TelemetryBuilder struct {
 	ProcessorAdaptiveTailSamplingFingerprintDuration           metric.Int64Histogram
 	ProcessorAdaptiveTailSamplingIncomingTracestateUnparseable metric.Int64Counter
 	ProcessorAdaptiveTailSamplingOttlEvalErrors                metric.Int64Counter
+	ProcessorAdaptiveTailSamplingTraceSpanCount                metric.Int64Histogram
 	ProcessorAdaptiveTailSamplingTracesActive                  metric.Int64Gauge
 	ProcessorAdaptiveTailSamplingTracesDropped                 metric.Int64Counter
 	ProcessorAdaptiveTailSamplingTracesEvicted                 metric.Int64Counter
@@ -73,7 +74,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ProcessorAdaptiveTailSamplingDecisionTriggers, err = builder.meter.Int64Counter(
 		"otelcol_processor_adaptive_tail_sampling_decision_triggers",
-		metric.WithDescription("Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction, shutdown). [Development]"),
+		metric.WithDescription("Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction, shutdown, span_limit). [Development]"),
 		metric.WithUnit("{decisions}"),
 	)
 	errs = errors.Join(errs, err)
@@ -93,6 +94,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_processor_adaptive_tail_sampling_ottl_eval_errors",
 		metric.WithDescription("Number of OTTL condition evaluation errors, labelled by the rule the condition belongs to (_root_span_condition for the root-span condition). [Development]"),
 		metric.WithUnit("{errors}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ProcessorAdaptiveTailSamplingTraceSpanCount, err = builder.meter.Int64Histogram(
+		"otelcol_processor_adaptive_tail_sampling_trace_span_count",
+		metric.WithDescription("Distribution of buffered span counts per trace at decision time, labelled by rule. Useful for sizing span_limit against the real trace-size distribution. [Development]"),
+		metric.WithUnit("{spans}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorAdaptiveTailSamplingTracesActive, err = builder.meter.Int64Gauge(

--- a/processor/adaptivetailsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/adaptivetailsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -39,7 +39,7 @@ func AssertEqualProcessorAdaptiveTailSamplingDecisionSampleRate(t *testing.T, tt
 func AssertEqualProcessorAdaptiveTailSamplingDecisionTriggers(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_adaptive_tail_sampling_decision_triggers",
-		Description: "Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction, shutdown). [Development]",
+		Description: "Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction, shutdown, span_limit). [Development]",
 		Unit:        "{decisions}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -95,6 +95,21 @@ func AssertEqualProcessorAdaptiveTailSamplingOttlEvalErrors(t *testing.T, tt *co
 		},
 	}
 	got, err := tt.GetMetric("otelcol_processor_adaptive_tail_sampling_ottl_eval_errors")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualProcessorAdaptiveTailSamplingTraceSpanCount(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_processor_adaptive_tail_sampling_trace_span_count",
+		Description: "Distribution of buffered span counts per trace at decision time, labelled by rule. Useful for sizing span_limit against the real trace-size distribution. [Development]",
+		Unit:        "{spans}",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_processor_adaptive_tail_sampling_trace_span_count")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/processor/adaptivetailsamplingprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -24,6 +24,7 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ProcessorAdaptiveTailSamplingFingerprintDuration.Record(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingIncomingTracestateUnparseable.Add(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingOttlEvalErrors.Add(context.Background(), 1)
+	tb.ProcessorAdaptiveTailSamplingTraceSpanCount.Record(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingTracesActive.Record(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingTracesDropped.Add(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingTracesEvicted.Add(context.Background(), 1)
@@ -42,6 +43,9 @@ func TestSetupTelemetry(t *testing.T) {
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorAdaptiveTailSamplingOttlEvalErrors(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualProcessorAdaptiveTailSamplingTraceSpanCount(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorAdaptiveTailSamplingTracesActive(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},

--- a/processor/adaptivetailsamplingprocessor/metadata.yaml
+++ b/processor/adaptivetailsamplingprocessor/metadata.yaml
@@ -27,7 +27,7 @@ telemetry:
       stability: development
     processor_adaptive_tail_sampling_decision_triggers:
       enabled: true
-      description: Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction, shutdown).
+      description: Number of trace decisions made, labelled by which event triggered the decision (root_span, trace_timeout, eviction, shutdown, span_limit).
       unit: "{decisions}"
       sum:
         value_type: int
@@ -55,6 +55,13 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+      stability: development
+    processor_adaptive_tail_sampling_trace_span_count:
+      enabled: true
+      description: Distribution of buffered span counts per trace at decision time, labelled by rule. Useful for sizing span_limit against the real trace-size distribution.
+      unit: "{spans}"
+      histogram:
+        value_type: int
       stability: development
     processor_adaptive_tail_sampling_traces_active:
       enabled: true

--- a/processor/adaptivetailsamplingprocessor/processor.go
+++ b/processor/adaptivetailsamplingprocessor/processor.go
@@ -45,6 +45,16 @@ const ruleAttributeKey = "otelcol.processor.adaptive_tail_sampling.rule"
 // hashed, per record_fingerprint) on every span of a kept trace.
 const fingerprintAttributeKey = "otelcol.processor.adaptive_tail_sampling.fingerprint"
 
+// triggerAttributeKey records on every span of a kept trace what actually
+// caused its decision, using the same value set as the decision-triggers
+// metric's trigger label (root_span, trace_timeout, eviction, shutdown,
+// span_limit). Unlike the metric, which counts the event that first made a
+// trace decision-eligible, eviction and shutdown override the original
+// reason on traces they decide mid-delay, so the attribute always names the
+// event that produced the decision. Non-root_span values indicate the
+// decision may have seen an incomplete trace.
+const triggerAttributeKey = "otelcol.processor.adaptive_tail_sampling.trigger"
+
 // triggerSource identifies which event caused a pending trace to transition
 // from the buffering phase to the decision-delay phase. Reported on the
 // decision-trigger counter.
@@ -55,6 +65,7 @@ const (
 	triggerTraceTimeout triggerSource = "trace_timeout"
 	triggerEviction     triggerSource = "eviction"
 	triggerShutdown     triggerSource = "shutdown"
+	triggerSpanLimit    triggerSource = "span_limit"
 )
 
 // evictionRuleLabel is the sentinel `rule` label used on decision metrics for
@@ -76,6 +87,7 @@ var (
 	triggerTraceTimeoutAttr = metric.WithAttributes(attribute.String("trigger", string(triggerTraceTimeout)))
 	triggerEvictionAttr     = metric.WithAttributes(attribute.String("trigger", string(triggerEviction)))
 	triggerShutdownAttr     = metric.WithAttributes(attribute.String("trigger", string(triggerShutdown)))
+	triggerSpanLimitAttr    = metric.WithAttributes(attribute.String("trigger", string(triggerSpanLimit)))
 )
 
 func triggerAttr(source triggerSource) metric.MeasurementOption {
@@ -86,6 +98,8 @@ func triggerAttr(source triggerSource) metric.MeasurementOption {
 		return triggerTraceTimeoutAttr
 	case triggerShutdown:
 		return triggerShutdownAttr
+	case triggerSpanLimit:
+		return triggerSpanLimitAttr
 	default:
 		return triggerEvictionAttr
 	}
@@ -100,6 +114,9 @@ type pendingTrace struct {
 	firstSeen   time.Time
 	hasRootSpan bool
 	triggered   bool
+	// triggerReason records which event moved the trace out of buffering,
+	// stamped on kept spans and mirrored by the decision-triggers metric.
+	triggerReason triggerSource
 }
 
 // adaptiveTailSamplingProcessor implements processor.Traces. It accumulates spans by
@@ -330,10 +347,13 @@ func (p *adaptiveTailSamplingProcessor) Shutdown(ctx context.Context) error {
 	// so the next consumer still accepts the forwarded traces.
 	for _, pt := range pending {
 		// A trace already in its decision_delay window was counted when its
-		// trigger fired; shutdown merely completes that decision early.
+		// trigger fired; shutdown merely completes that decision early. As
+		// with eviction, the trigger attribute reports what actually caused
+		// this decision, so shutdown overrides the original reason.
 		if !pt.triggered {
 			p.telemetry.ProcessorAdaptiveTailSamplingDecisionTriggers.Add(ctx, 1, triggerShutdownAttr)
 		}
+		pt.triggerReason = triggerShutdown
 		p.decideTrace(ctx, pt)
 	}
 
@@ -443,6 +463,16 @@ func (p *adaptiveTailSamplingProcessor) ConsumeTraces(ctx context.Context, td pt
 		for id, copied := range pendingBuckets {
 			if pt, ok := p.traces[id]; ok {
 				pt.spans = append(pt.spans, copied)
+				// The span-limit check runs before the root-span check so a
+				// trace that crosses the limit decides immediately rather
+				// than waiting decision_delay; the check sits after the
+				// batch attach so the decision covers every span already
+				// received, including the ones in this batch.
+				if p.cfg.SpanLimit > 0 && !pt.triggered && pt.spanCount >= p.cfg.SpanLimit {
+					if p.trigger(id, triggerSpanLimit) {
+						triggered[id] = struct{}{}
+					}
+				}
 				if pt.hasRootSpan && !pt.triggered {
 					if p.trigger(id, triggerRootSpan) {
 						triggered[id] = struct{}{}
@@ -639,6 +669,7 @@ func (p *adaptiveTailSamplingProcessor) trigger(id pcommon.TraceID, source trigg
 		return false
 	}
 	pt.triggered = true
+	pt.triggerReason = source
 	p.telemetry.ProcessorAdaptiveTailSamplingDecisionTriggers.Add(context.Background(), 1, triggerAttr(source))
 	// Cancel the existing timer (trace_timeout). If Stop returns false, the
 	// timer's callback is already running or queued; that callback will re-enter
@@ -648,11 +679,32 @@ func (p *adaptiveTailSamplingProcessor) trigger(id pcommon.TraceID, source trigg
 	}
 	p.wg.Add(1)
 	traceID := id
-	p.timers[id] = time.AfterFunc(p.cfg.DecisionDelay, func() {
+	// A trace at its span limit is already at peak memory, so its decision
+	// runs immediately; waiting decision_delay would let a hot trace keep
+	// growing for the whole delay. Other sources keep the straggler grace.
+	delay := p.cfg.DecisionDelay
+	if source == triggerSpanLimit {
+		delay = 0
+	}
+	p.timers[id] = time.AfterFunc(delay, func() {
 		defer p.wg.Done()
 		p.decide(traceID)
 	})
 	return true
+}
+
+// stampSpanAttributes applies the decision attributes shared by freshly
+// decided and late spans: rule attribution, the fingerprint when recording is
+// enabled, and the decision trigger. Both stamping paths must stay identical
+// so late spans never diverge from the originally decided trace.
+func stampSpanAttributes(span ptrace.Span, ruleName, fingerprint string, trigger triggerSource) {
+	span.Attributes().PutStr(ruleAttributeKey, ruleName)
+	if fingerprint != "" {
+		span.Attributes().PutStr(fingerprintAttributeKey, fingerprint)
+	}
+	if trigger != "" {
+		span.Attributes().PutStr(triggerAttributeKey, string(trigger))
+	}
 }
 
 // stampLateBatch stamps every span in a late batch with the original rule
@@ -662,10 +714,7 @@ func (p *adaptiveTailSamplingProcessor) stampLateBatch(ctx context.Context, td p
 	for _, rs := range td.ResourceSpans().All() {
 		for _, ss := range rs.ScopeSpans().All() {
 			for _, span := range ss.Spans().All() {
-				span.Attributes().PutStr(ruleAttributeKey, md.ruleName)
-				if md.fingerprint != "" {
-					span.Attributes().PutStr(fingerprintAttributeKey, md.fingerprint)
-				}
+				stampSpanAttributes(span, md.ruleName, md.fingerprint, md.trigger)
 				p.updateTraceState(ctx, span, md.threshold, emptyTS)
 			}
 		}
@@ -759,15 +808,18 @@ func (p *adaptiveTailSamplingProcessor) finishDecision(ctx context.Context, pt *
 	// rate: under equalizing, an upstream stricter than the sampler's rate caps
 	// what we emit, and the histogram should reflect that.
 	p.telemetry.ProcessorAdaptiveTailSamplingDecisionSampleRate.Record(ctx, int64(effectiveTh.AdjustedCount()), ruleAttr)
+	// Buffered span count at decision time, for sizing span_limit against the
+	// real trace-size distribution.
+	p.telemetry.ProcessorAdaptiveTailSamplingTraceSpanCount.Record(ctx, int64(pt.spanCount), ruleAttr)
 	if !effectiveTh.ShouldSample(randomness) {
 		p.telemetry.ProcessorAdaptiveTailSamplingTracesDropped.Add(ctx, 1, ruleAttr)
 		p.cache.recordNotSampled(pt.traceID)
 		return
 	}
 
-	p.cache.recordSampled(pt.traceID, cachedDecision{ruleName: ruleName, threshold: effectiveTh, fingerprint: fingerprint})
+	p.cache.recordSampled(pt.traceID, cachedDecision{ruleName: ruleName, threshold: effectiveTh, fingerprint: fingerprint, trigger: pt.triggerReason})
 	// assembleTrace consumes pt.spans; nothing may read them after this call.
-	annotated := p.assembleTrace(ctx, pt.spans, ruleName, effectiveTh, fingerprint)
+	annotated := p.assembleTrace(ctx, pt.spans, ruleName, effectiveTh, fingerprint, pt.triggerReason)
 	pt.spans = nil
 	p.telemetry.ProcessorAdaptiveTailSamplingTracesSampled.Add(ctx, 1, ruleAttr)
 	if err := p.next.ConsumeTraces(ctx, annotated); err != nil {
@@ -781,10 +833,13 @@ func (p *adaptiveTailSamplingProcessor) finishDecision(ctx context.Context, pt *
 func (p *adaptiveTailSamplingProcessor) decideEvicted(ctx context.Context, pt *pendingTrace) {
 	// Same rule as the shutdown drain: a trace already in its decision_delay
 	// window was counted when its trigger fired, so eviction of a mid-delay
-	// trace must not count the decision twice.
+	// trace must not count the decision twice. The trigger attribute is
+	// different: it reports what actually caused this decision, so eviction
+	// overrides the original reason even for mid-delay traces.
 	if !pt.triggered {
 		p.telemetry.ProcessorAdaptiveTailSamplingDecisionTriggers.Add(ctx, 1, triggerEvictionAttr)
 	}
+	pt.triggerReason = triggerEviction
 	if p.cfg.Eviction.Policy == EvictionProbabilistic {
 		p.decideEvictedProbabilistic(ctx, pt)
 		return
@@ -926,7 +981,7 @@ func effectiveThreshold(upstream sampling.Threshold, rate int) (sampling.Thresho
 // processor-owned (created fresh in ConsumeTraces) and the pendingTrace is
 // discarded after the decision, so the sources are left empty deliberately.
 // readIncomingSampling must run before this (it reads the same spans).
-func (p *adaptiveTailSamplingProcessor) assembleTrace(ctx context.Context, spans []ptrace.ResourceSpans, ruleName string, threshold sampling.Threshold, fingerprint string) ptrace.Traces {
+func (p *adaptiveTailSamplingProcessor) assembleTrace(ctx context.Context, spans []ptrace.ResourceSpans, ruleName string, threshold sampling.Threshold, fingerprint string, trigger triggerSource) ptrace.Traces {
 	emptyTS := serializedEmptyTraceState(threshold)
 	out := ptrace.NewTraces()
 	for _, rs := range spans {
@@ -934,10 +989,7 @@ func (p *adaptiveTailSamplingProcessor) assembleTrace(ctx context.Context, spans
 		rs.MoveTo(dst)
 		for _, ss := range dst.ScopeSpans().All() {
 			for _, span := range ss.Spans().All() {
-				span.Attributes().PutStr(ruleAttributeKey, ruleName)
-				if fingerprint != "" {
-					span.Attributes().PutStr(fingerprintAttributeKey, fingerprint)
-				}
+				stampSpanAttributes(span, ruleName, fingerprint, trigger)
 				p.updateTraceState(ctx, span, threshold, emptyTS)
 			}
 		}

--- a/processor/adaptivetailsamplingprocessor/processor_test.go
+++ b/processor/adaptivetailsamplingprocessor/processor_test.go
@@ -1101,6 +1101,168 @@ func TestProcessor_ShutdownDrain_TriggeredTraceNotDoubleCounted(t *testing.T) {
 	)
 }
 
+// newNonRootSpans builds a batch of n non-root spans for one trace, with
+// span IDs offset by base so batches don't collide.
+func newNonRootSpans(traceID pcommon.TraceID, n int, base byte) ptrace.Traces {
+	td := ptrace.NewTraces()
+	ss := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty()
+	for i := range n {
+		span := ss.Spans().AppendEmpty()
+		span.SetTraceID(traceID)
+		span.SetSpanID([8]byte{base, byte(i + 1), 3, 4, 5, 6, 7, 8})
+		span.SetParentSpanID([8]byte{9, 9, 9, 9, 9, 9, 9, 9})
+		span.SetName("op")
+	}
+	return td
+}
+
+func TestProcessor_SpanLimit_TriggersImmediateDecision(t *testing.T) {
+	tt := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, tt.Shutdown(context.Background())) //nolint:usetesting // cleanup after ctx cancel
+	})
+
+	sink := &consumertest.TracesSink{}
+	// TraceTimeout and DecisionDelay are both far beyond the test window, so a
+	// decision can only come from the span-limit trigger's immediate path.
+	cfg := &Config{
+		TraceTimeout:  time.Hour,
+		DecisionDelay: time.Hour,
+		NumTraces:     10,
+		SpanLimit:     3,
+		DecisionCache: DecisionCacheConfig{SampledCacheSize: 10, NonSampledCacheSize: 10},
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p, err := newProcessor(metadatatest.NewSettings(tt), cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, p.Start(t.Context(), nil))
+	t.Cleanup(func() { require.NoError(t, p.Shutdown(t.Context())) })
+
+	id := pcommon.TraceID([16]byte{0xC1})
+
+	// Two spans stay below the limit: no decision.
+	require.NoError(t, p.ConsumeTraces(t.Context(), newNonRootSpans(id, 2, 0xA)))
+	require.Equal(t, 0, sink.SpanCount(), "below the limit the trace keeps buffering")
+
+	// Two more cross the limit (4 >= 3): the decision fires immediately and
+	// covers every span buffered so far, including this batch.
+	require.NoError(t, p.ConsumeTraces(t.Context(), newNonRootSpans(id, 2, 0xB)))
+	assert.Eventually(t, func() bool { return sink.SpanCount() == 4 }, time.Second, 10*time.Millisecond,
+		"decision must not wait for decision_delay or trace_timeout")
+
+	metadatatest.AssertEqualProcessorAdaptiveTailSamplingDecisionTriggers(t, tt,
+		[]metricdata.DataPoint[int64]{{
+			Value:      1,
+			Attributes: attribute.NewSet(attribute.String("trigger", "span_limit")),
+		}},
+		metricdatatest.IgnoreTimestamp(),
+		metricdatatest.IgnoreExemplars(),
+	)
+	// The span-count histogram records the buffered count at decision time.
+	metadatatest.AssertEqualProcessorAdaptiveTailSamplingTraceSpanCount(t, tt,
+		[]metricdata.HistogramDataPoint[int64]{{
+			Attributes: attribute.NewSet(attribute.String("rule", "default")),
+			Count:      1,
+			Sum:        4,
+		}},
+		metricdatatest.IgnoreTimestamp(),
+		metricdatatest.IgnoreExemplars(),
+		metricdatatest.IgnoreValue(),
+	)
+
+	// Every span of the decided trace carries the trigger attribution.
+	first := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	v, ok := first.Attributes().Get(triggerAttributeKey)
+	require.True(t, ok, "spans of a span-limited trace must carry the trigger attribute")
+	assert.Equal(t, "span_limit", v.Str())
+
+	// Spans arriving after the decision follow the late-span path: stamped
+	// from the decision cache and forwarded without buffering a new trace.
+	require.NoError(t, p.ConsumeTraces(t.Context(), newNonRootSpans(id, 1, 0xC)))
+	assert.Eventually(t, func() bool { return sink.SpanCount() == 5 }, time.Second, 10*time.Millisecond)
+	late := sink.AllTraces()[len(sink.AllTraces())-1].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	_, ok = late.Attributes().Get(ruleAttributeKey)
+	assert.True(t, ok, "late span must carry the original decision's rule attribution")
+	lv, ok := late.Attributes().Get(triggerAttributeKey)
+	require.True(t, ok, "late spans must carry the same trigger attribution")
+	assert.Equal(t, "span_limit", lv.Str())
+}
+
+// The trigger attribute is stamped on every kept trace, not just span-limited
+// ones, and the span-count histogram records every decision.
+func TestProcessor_TriggerAttribution(t *testing.T) {
+	tt := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, tt.Shutdown(context.Background())) //nolint:usetesting // cleanup after ctx cancel
+	})
+
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:  time.Hour,
+		DecisionDelay: time.Millisecond,
+		NumTraces:     1,
+		DecisionCache: DecisionCacheConfig{SampledCacheSize: 10, NonSampledCacheSize: 10},
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p, err := newProcessor(metadatatest.NewSettings(tt), cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, p.Start(t.Context(), nil))
+	t.Cleanup(func() { require.NoError(t, p.Shutdown(t.Context())) })
+
+	// A root-triggered trace carries trigger=root_span.
+	require.NoError(t, p.ConsumeTraces(t.Context(), newRootTrace(pcommon.TraceID([16]byte{0xD1}))))
+	assert.Eventually(t, func() bool { return sink.SpanCount() == 1 }, time.Second, 10*time.Millisecond)
+	span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	v, ok := span.Attributes().Get(triggerAttributeKey)
+	require.True(t, ok, "every kept span must carry the trigger attribute")
+	assert.Equal(t, "root_span", v.Str())
+
+	// An untriggered trace displaced by buffer overflow carries trigger=eviction:
+	// two non-root traces with NumTraces=1 evict the first.
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(pcommon.TraceID([16]byte{0xD2}), ptrace.StatusCodeUnset)))
+	require.NoError(t, p.ConsumeTraces(t.Context(), newTrace(pcommon.TraceID([16]byte{0xD3}), ptrace.StatusCodeUnset)))
+	assert.Eventually(t, func() bool { return sink.SpanCount() >= 2 }, time.Second, 10*time.Millisecond)
+	evicted := sink.AllTraces()[1].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	require.Equal(t, pcommon.TraceID([16]byte{0xD2}), evicted.TraceID())
+	ev, ok := evicted.Attributes().Get(triggerAttributeKey)
+	require.True(t, ok)
+	assert.Equal(t, "eviction", ev.Str())
+
+	// The span-count histogram records every decision, not just span-limited ones.
+	metadatatest.AssertEqualProcessorAdaptiveTailSamplingTraceSpanCount(t, tt,
+		[]metricdata.HistogramDataPoint[int64]{{
+			Attributes: attribute.NewSet(attribute.String("rule", "default")),
+		}},
+		metricdatatest.IgnoreTimestamp(),
+		metricdatatest.IgnoreExemplars(),
+		metricdatatest.IgnoreValue(),
+	)
+}
+
+// span_limit: 0 disables the cap: a trace may buffer past any small count
+// without being decided.
+func TestProcessor_SpanLimitDisabled(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	cfg := &Config{
+		TraceTimeout:  time.Hour,
+		DecisionDelay: time.Hour,
+		NumTraces:     10,
+		SpanLimit:     0,
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{Type: AlwaysSample}},
+		},
+	}
+	p := newTestProcessor(t, cfg, sink)
+
+	require.NoError(t, p.ConsumeTraces(t.Context(), newNonRootSpans(pcommon.TraceID([16]byte{0xD4}), 50, 0xA)))
+	assert.Never(t, func() bool { return sink.SpanCount() > 0 }, 200*time.Millisecond, 20*time.Millisecond,
+		"with span_limit disabled the trace must keep buffering")
+}
+
 func TestProcessor_Eviction_TriggeredTraceNotDoubleCounted(t *testing.T) {
 	tt := componenttest.NewTelemetry()
 	t.Cleanup(func() {
@@ -1136,6 +1298,12 @@ func TestProcessor_Eviction_TriggeredTraceNotDoubleCounted(t *testing.T) {
 		metricdatatest.IgnoreTimestamp(),
 		metricdatatest.IgnoreExemplars(),
 	)
+	// The metric keeps the original trigger (no double count), but the span
+	// attribute reports what actually caused the decision: the eviction.
+	span := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	v, ok := span.Attributes().Get(triggerAttributeKey)
+	require.True(t, ok)
+	assert.Equal(t, "eviction", v.Str(), "mid-delay eviction must override the trigger attribute")
 	metadatatest.AssertEqualProcessorAdaptiveTailSamplingTracesEvicted(t, tt,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp(),


### PR DESCRIPTION
#### Description

Adds `span_limit` (default 10000, `0` disables), which caps how many spans a single trace may buffer. A trace reaching the limit is decided immediately over the spans buffered so far, skipping `decision_delay` since the trace is at its memory peak, and later spans follow the existing late-span path (stamped from the decision cache) instead of being buffered. Load testing showed `num_traces` and eviction protect against many small traces but not a single giant one, since they bound the trace count, not spans per trace.

Also adds decision observability. Every kept span now carries `otelcol.processor.adaptive_tail_sampling.trigger` recording what caused the decision (`root_span`, `trace_timeout`, `eviction`, `shutdown`, `span_limit`); eviction and shutdown override the original reason on traces they decide mid-delay, so the attribute names the event that actually produced the decision, while the decision-triggers metric keeps counting the event that first made the trace eligible (no double counting). A new `trace_span_count` histogram records buffered span counts per decision for sizing `span_limit`.

On the default, there is no universally accepted consensus for a per-trace span cap (vendors bound by view limits or trace bytes instead), so we start conservative at 10,000 and can raise it later. Raising a default is painless where lowering one is a breaking change.

#### Link to tracking issue

Refs #49311

#### Testing

- Span-limit trigger: immediate decision covering the whole batch, late spans stamped from cache, `trigger="span_limit"` on the decision-triggers metric
- Trigger attribution: root_span and eviction values, the mid-delay eviction override (metric keeps the original trigger, attribute reports eviction), and the histogram on non-limited decisions
- Disabled cap (`span_limit: 0`) keeps buffering past small counts; negative value rejected at validation; factory default pinned

#### Documentation

- README: trigger list, config block, output-attributes and metrics tables, sizing guidance
- metadata.yaml: `trace_span_count` histogram, `span_limit` added to the decision-triggers label set
- Changelog entry (enhancement)

#### Authorship

- [x] I, a human, wrote this pull request description myself.
