### PR TITLE
[pgk/ottl]: fix malform lists parsing

### DIFF
--- a/.chloggen/ottl-list-require-commas.yaml
+++ b/.chloggen/ottl-list-require-commas.yaml
@@ -10,7 +10,7 @@ component: pkg/ottl
 note: Reject malformed list literals that are missing commas between elements or have a leading comma.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [50525]
+issues: [50530]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/ottl-list-require-commas.yaml
+++ b/.chloggen/ottl-list-require-commas.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject malformed list literals that are missing commas between elements or have a leading comma.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50525]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -385,7 +385,7 @@ func (k *key) accept(v grammarVisitor) {
 
 // list represents a literal list of values.
 type list struct {
-	Values []value `parser:"'[' (@@)* (',' @@)* ']'"`
+	Values []value `parser:"'[' (@@ (',' @@)*)? ']'"`
 }
 
 // mapValue represents a literal map of key/value pairs.

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -2329,6 +2329,66 @@ func Test_ParseValueExpression_full(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:            "int list",
+			valueExpression: `[1, 2, 3]`,
+			expected: func() any {
+				return []any{int64(1), int64(2), int64(3)}
+			},
+		},
+		{
+			name:            "float list",
+			valueExpression: `[1.5, 2.5]`,
+			expected: func() any {
+				return []any{1.5, 2.5}
+			},
+		},
+		{
+			name:            "bool list",
+			valueExpression: `[true, false, true]`,
+			expected: func() any {
+				return []any{true, false, true}
+			},
+		},
+		{
+			name:            "nil list",
+			valueExpression: `[nil, nil]`,
+			expected: func() any {
+				return []any{nil, nil}
+			},
+		},
+		{
+			name:            "enum list",
+			valueExpression: `[TEST_ENUM_ONE, TEST_ENUM_TWO]`,
+			expected: func() any {
+				return []any{int64(1), int64(2)}
+			},
+		},
+		{
+			name:            "math expression list",
+			valueExpression: `[1 + 1, 2 * 3]`,
+			expected: func() any {
+				return []any{int64(2), int64(6)}
+			},
+		},
+		{
+			name:            "map list",
+			valueExpression: `[{"a": 1}, {"b": 2}]`,
+			expected: func() any {
+				m1 := pcommon.NewMap()
+				m1.PutInt("a", 1)
+				m2 := pcommon.NewMap()
+				m2.PutInt("b", 2)
+				return []any{m1, m2}
+			},
+		},
+		{
+			name:            "mixed type list",
+			valueExpression: `[1, "two", true, nil, 3.5]`,
+			expected: func() any {
+				return []any{int64(1), "two", true, nil, 3.5}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2550,6 +2610,28 @@ func Test_parseStatement(t *testing.T) {
 		{statement: `Test()`, wantErr: true},
 		{statement: `set() where test(foo)["key"] == "bar"`, wantErrContaining: converterNameErrorPrefix},
 		{statement: `set() where test(foo)["key"] == "bar"`, wantErrContaining: editorWithIndexErrorPrefix},
+		{statement: `set(attributes["test"], [1 2 3])`, wantErr: true},
+		{statement: `set(attributes["test"], [1 2, 3])`, wantErr: true},
+		{statement: `set(attributes["test"], [,1,2])`, wantErr: true},
+		{statement: `set(attributes["test"], [1, 2,])`, wantErr: true},
+		{statement: `set(attributes["test"], [1,,2])`, wantErr: true},
+		{statement: `set(attributes["test"], [1.5 2.5])`, wantErr: true},
+		{statement: `set(attributes["test"], ["a" "b"])`, wantErr: true},
+		{statement: `set(attributes["test"], [true false])`, wantErr: true},
+		{statement: `set(attributes["test"], [nil nil])`, wantErr: true},
+		{statement: `set(attributes["test"], [{"a": 1} {"b": 2}])`, wantErr: true},
+		{statement: `set(attributes["test"], [[1, 2] [3, 4]])`, wantErr: true},
+		{statement: `set(attributes["test"], [1 "two"])`, wantErr: true},
+		{statement: `set(attributes["test"], [1, 2, 3])`},
+		{statement: `set(attributes["test"], [1.5, 2.5])`},
+		{statement: `set(attributes["test"], ["a", "b"])`},
+		{statement: `set(attributes["test"], [true, false])`},
+		{statement: `set(attributes["test"], [nil, nil])`},
+		{statement: `set(attributes["test"], [{"a": 1}, {"b": 2}])`},
+		{statement: `set(attributes["test"], [[1, 2], [3, 4]])`},
+		{statement: `set(attributes["test"], [1, "two", true, nil, 3.5])`},
+		{statement: `set(attributes["test"], [])`},
+		{statement: `set(attributes["test"], [1])`},
 	}
 	pat := regexp.MustCompile("[^a-zA-Z0-9]+")
 	for _, tt := range tests {


### PR DESCRIPTION
#### Description

Fix bug where ottl would parse malformed syntax

#### Link to tracking issue

- Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50525

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added lots of tests

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
