### PR TITLE
Fix/datadogreceiver unpadded link span

### DIFF
--- a/.chloggen/datadogreceiver-unpadded-span-link-id.yaml
+++ b/.chloggen/datadogreceiver-unpadded-span-link-id.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: receiver/datadog
+
+note: Left-pad short hexadecimal span IDs from dd-trace-java so linked spans retain their intended IDs instead of an all-zero span ID.
+
+issues: [50531]
+
+subtext:
+
+change_logs: [user]

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -515,7 +515,16 @@ func decodeLinkSpanID(spanID json.RawMessage) (pcommon.SpanID, error) {
 		if err := json.Unmarshal(spanID, &s); err != nil {
 			return pcommon.SpanID{}, err
 		}
-		raw, err := oteltrace.SpanIDFromHex(s)
+		// dd-trace-java serializes link span IDs with Long.toHexString, which drops
+		// leading zeroes. Its IDs are 63-bit, so the leading nibble is 0-7 and
+		// roughly one in eight arrives shorter than the canonical 16 characters
+		// SpanIDFromHex requires. Link trace IDs are unaffected: those are padded
+		// to the full 32 characters even when 128-bit generation is off.
+		padded := s
+		if len(padded) < 16 {
+			padded = strings.Repeat("0", 16-len(padded)) + padded
+		}
+		raw, err := oteltrace.SpanIDFromHex(padded)
 		if err != nil {
 			return pcommon.SpanID{}, fmt.Errorf("error converting span id (%s) from hex: %w", s, err)
 		}

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -1172,6 +1172,71 @@ func translateSingleSpan(t *testing.T, span *pb.Span) ptrace.Span {
 	return traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 }
 
+func TestMetaSpanLinksHexSpanID(t *testing.T) {
+	const traceID = "11223344556677889900aabbccddeeff"
+
+	tests := []struct {
+		name        string
+		spanID      string
+		want        pcommon.SpanID
+		wantErrText string
+	}{
+		{
+			// The wire form dd-trace-java actually produces: Long.toHexString drops
+			// leading zeroes, and its 63-bit IDs lose at most the top nibble.
+			name:   "unpadded",
+			spanID: "123456789abcdef",
+			want:   pcommon.SpanID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
+		},
+		{
+			name:   "canonical",
+			spanID: "0123456789abcdef",
+			want:   pcommon.SpanID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
+		},
+		{
+			// The next two are lengths dd-trace-java never emits. They exercise the
+			// padding arithmetic away from the 15-of-16 boundary above, where an
+			// off-by-one would still look right.
+			name:   "half length",
+			spanID: "89abcdef",
+			want:   pcommon.SpanID{0x00, 0x00, 0x00, 0x00, 0x89, 0xab, 0xcd, 0xef},
+		},
+		{
+			name:   "single char",
+			spanID: "f",
+			want:   pcommon.SpanID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f},
+		},
+		{
+			name:        "too long",
+			spanID:      "10123456789abcdef",
+			wantErrText: "must have length equals to 16",
+		},
+		{
+			name:        "invalid hex",
+			spanID:      "not-hex",
+			wantErrText: "can only contain [0-9a-f]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dest := ptrace.NewSpanLinkSlice()
+			err := metaSpanLinks(
+				`[{"trace_id":"`+traceID+`","span_id":"`+tt.spanID+`"}]`,
+				dest,
+			)
+			if tt.wantErrText != "" {
+				require.ErrorContains(t, err, tt.wantErrText)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, 1, dest.Len())
+			require.Equal(t, tt.want, dest.At(0).SpanID())
+		})
+	}
+}
+
 func TestSetSpanLinks(t *testing.T) {
 	// A 128-bit linked trace id split as Datadog stores it, so it can be reassembled either from the
 	// native trace_id_high field or from the decimal _dd.span_links meta form.


### PR DESCRIPTION
Left-pad short hexadecimal span IDs from dd-trace-java so linked spans retain
their intended IDs while malformed values remain rejected.

#### Description

dd-trace-java writes link span ids as bare hex and drops leading zeroes, so
0a1b2c3d4e5f6a7b goes out as a1b2c3d4e5f6a7b. The OTEL Datadog
receiver only accepts the canonical 16-character form, so it rejects the id and
stores the link with an all-zero span id.

Error logs:
```
error parsing _dd.span_links
  {"error": "error converting span id (a1b2c3d4e5f6a7b) from hex: hex encoded span-id must have length equals to 16"}
```

Co-authored with GPT-5.6 Sol

#### Testing

- Unit tests
- Deployed patch to internal environment and verified span link IDs stopped being dropped

#### Authorship

- [X] I, a human, wrote this pull request description myself.
