### PR TITLE
[receiver/statsd] Fix max_size handling for histogram and distribution mappings

### DIFF
--- a/.chloggen/50533-statsd-histogram-max-size.yaml
+++ b/.chloggen/50533-statsd-histogram-max-size.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/statsd
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix `histogram.max_size` being ignored for `histogram` and `distribution` statsd_type mappings.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50533]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Users who set `max_size` on these mappings were silently getting the default size of 160.
+  After this fix, the configured size applies which changes bucket boundaries for those metrics.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/statsdreceiver/internal/parser/statsd_parser.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser.go
@@ -223,7 +223,7 @@ func (p *StatsDParser) Initialize(enableMetricType, enableSimpleTags, isMonotoni
 			if eachMap.Histogram.ExplicitBuckets != nil {
 				p.histogramEvents.explicitBucketConfigs = explicitBucketInitializeRegex(eachMap.Histogram)
 			}
-			p.timerEvents.histogramConfig = expoHistogramConfig(eachMap.Histogram)
+			p.histogramEvents.histogramConfig = expoHistogramConfig(eachMap.Histogram)
 			p.histogramEvents.summaryPercentiles = eachMap.Summary.Percentiles
 		case protocol.TimingTypeName, protocol.TimingAltTypeName:
 			p.timerEvents.method = eachMap.ObserverType

--- a/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
@@ -2385,3 +2385,47 @@ func TestStatsDParser_DiscardInvalidValues(t *testing.T) {
 	assert.Equal(t, 1, gaugeMetrics.Len())
 	assert.Equal(t, "test.valid", gaugeMetrics.At(0).Name())
 }
+
+func TestStatsDParser_HistogramMaxSize(t *testing.T) {
+	originalTimeNowFunc := timeNowFunc
+	timeNowFunc = func() time.Time {
+		return time.Unix(711, 0)
+	}
+	t.Cleanup(func() {
+		timeNowFunc = originalTimeNowFunc
+	})
+
+	// A max size of 10 over a range of 2**10 forces scale 0. Without the
+	// configured max size the go-expohisto default (160) keeps a higher scale.
+	for _, statsdType := range []string{"histogram", "distribution"} {
+		t.Run(statsdType, func(t *testing.T) {
+			p := &StatsDParser{}
+			require.NoError(t, p.Initialize(false, false, false, false, false, []protocol.TimerHistogramMapping{
+				{
+					StatsdType:   protocol.TypeName(statsdType),
+					ObserverType: "histogram",
+					Histogram: protocol.HistogramConfig{
+						MaxSize: 10,
+					},
+				},
+			}, protocol.CounterTypeInt))
+
+			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
+			unit := "h"
+			if statsdType == "distribution" {
+				unit = "d"
+			}
+			for _, value := range []string{"1.5", "2.5", "4.5", "8.5", "16.5", "32.5", "64.5", "128.5", "256.5", "512.5"} {
+				require.NoError(t, p.Aggregate("expohisto:"+value+"|"+unit, addr))
+			}
+
+			metrics := p.GetMetrics()
+			require.Len(t, metrics, 1)
+			m := metrics[0].Metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+			require.Equal(t, pmetric.MetricTypeExponentialHistogram, m.Type())
+			dp := m.ExponentialHistogram().DataPoints().At(0)
+			assert.Equal(t, int32(0), dp.Scale())
+			assert.LessOrEqual(t, dp.Positive().BucketCounts().Len(), 10)
+		})
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Previously in `receiver/statsd`, StatsDParser.Initialize set expoHistogramConfig to timerEvents not histogramEvents
which results in ignoring max_size for histogram and distribution mappings.

Fix it by setting proper histogramEvents

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50533

<!--Describe what testing was performed and which tests were added.-->
#### Testing

1. Reach expected result in #50533 with a locally built binary
2. Add test for verifying configuration

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
