### PR TITLE
[exporter/opensearchexporter] Add ISM rollover and custom index-template mapping support for otel-v1 mode

### DIFF
--- a/.chloggen/opensearchexporter-ism-and-custom-mappings.yaml
+++ b/.chloggen/opensearchexporter-ism-and-custom-mappings.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: opensearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add opt-in ISM rollover and custom index-template mapping support for otel-v1 mode.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [48585]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `mapping.ism.enabled` provisions an Index State Management rollover policy and an initial
+  write-aliased index on startup so otel-v1 indices roll over by size/age. `mapping.index_template_file`
+  deep-merges a user-supplied JSON overlay over the built-in otel-v1 template, letting operators uplift
+  attributes to typed fields or keep them un-indexed to avoid mapping explosion. Both options are
+  best-effort and only valid with `mapping.mode: otel-v1`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/opensearchexporter-ism-and-custom-mappings.yaml
+++ b/.chloggen/opensearchexporter-ism-and-custom-mappings.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: opensearchexporter
+component: exporter/opensearch
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add opt-in ISM rollover and custom index-template mapping support for otel-v1 mode.

--- a/exporter/opensearchexporter/README.md
+++ b/exporter/opensearchexporter/README.md
@@ -112,6 +112,12 @@ The OpenSearch exporter supports several document schemas and preprocessing beha
     - `bodymap`: uses the "body" of a log record as the exact content of the OpenSearch document, without any transformation. This mapping mode is intended for use cases where the client wishes to have complete control over the OpenSearch document structure.
     - `otel-v1`: exports logs and traces using the Data Prepper OTel v1 schema, compatible with OpenSearch Observability dashboards.
   - `manage_index_template`: (optional, default=`false`) When `true`, creates composable index templates on startup. Only valid with `otel-v1` mode.
+  - `index_template_file`: (optional) Path to a JSON file whose contents are deep-merged over the built-in `otel-v1` index template before it is created. Requires `manage_index_template: true` and `otel-v1` mode. See [Custom index mappings](#custom-index-mappings).
+  - `ism`: (optional) Opt-in [Index State Management](#index-state-management-ism-rollover) rollover for `otel-v1` indices. Only valid with `otel-v1` mode.
+    - `enabled`: (optional, default=`false`) When `true`, creates a rollover policy and an initial write-aliased index on startup.
+    - `policy_file`: (optional) Path to a JSON file containing a full ISM policy body. When set, it is used verbatim and the `rollover_*` options are ignored.
+    - `rollover_min_size`: (optional, default=`50gb`) Minimum index size before rollover. Used only by the built-in policy.
+    - `rollover_min_index_age`: (optional, default=`24h`) Minimum index age before rollover. Used only by the built-in policy.
   - `timestamp_field`: (optional) Field to store the timestamp in. If not set, uses the default `@timestamp`.
   - `unix_timestamp`: (optional) Whether to store the timestamp in epoch milliseconds.
   - `dedup`: (optional) removes fields from the document, that have duplicate keys. The filtering only keeps the last value for a key.
@@ -201,6 +207,78 @@ exporters:
       manage_index_template: true
     sending_queue:
       batch:
+```
+
+##### Custom index mappings
+
+The built-in `otel-v1` template maps every unique attribute key as its own field via
+`dynamic_templates`. On high-cardinality data this can lead to *mapping explosion* — a large field
+count that strains the cluster, and where a single bad key can produce a mapping conflict that
+affects unrelated documents. Rather than hardcoding one attribute shape for everyone, the exporter
+lets you supply your own mapping overlay so you can tune how attributes land in your cluster.
+
+Set `index_template_file` to a JSON file that is **deep-merged over the built-in template** (requires
+`manage_index_template: true`). Object values are merged recursively; array and scalar values in your
+file replace the built-in ones. This lets you, for example, uplift common attributes to typed fields
+for aggregations, or keep the free-form `attributes` object un-indexed to bound the field count —
+without restating the whole template. The overlay is applied to both the span and logs templates, so
+include only keys valid for both (extra keys are harmless).
+
+```yaml
+exporters:
+  opensearch:
+    http:
+      endpoint: http://opensearch.example.com:9200
+    mapping:
+      mode: "otel-v1"
+      manage_index_template: true
+      index_template_file: /etc/otelcol/otel-v1-overlay.json
+```
+
+Example overlay that keeps span `attributes` un-indexed (stored but not searchable) to avoid mapping
+explosion, while uplifting one common attribute to a typed field:
+
+```json
+{
+  "template": {
+    "mappings": {
+      "properties": {
+        "attributes": { "type": "object", "enabled": false },
+        "http.response.status_code": { "type": "integer" }
+      }
+    }
+  }
+}
+```
+
+Merging is best-effort: if the file cannot be read or parsed, the exporter logs a warning and falls
+back to the built-in template.
+
+##### Index State Management (ISM) rollover
+
+For `otel-v1` mode, `mapping.ism.enabled: true` makes the exporter provision an
+[Index State Management](https://opensearch.org/docs/latest/im-plugin/ism/index/) rollover policy and
+an initial write-aliased index (`<alias>-000001` with the write alias `<alias>`) on startup, so
+indices roll over by size/age instead of growing unbounded. The default policy rolls over at
+`rollover_min_size` (default `50gb`) or `rollover_min_index_age` (default `24h`), whichever comes
+first. Provide `policy_file` to use a full custom ISM policy instead.
+
+ISM is incompatible with dynamic index placeholders (`%{...}`) in `logs_index`/`traces_index`, since
+rollover writes through a fixed alias. Like template management, ISM setup is best-effort and does not
+fail `Start()`.
+
+```yaml
+exporters:
+  opensearch:
+    http:
+      endpoint: http://opensearch.example.com:9200
+    mapping:
+      mode: "otel-v1"
+      manage_index_template: true
+      ism:
+        enabled: true
+        rollover_min_size: 50gb
+        rollover_min_index_age: 24h
 ```
 
 ### HTTP Connection Options

--- a/exporter/opensearchexporter/README.md
+++ b/exporter/opensearchexporter/README.md
@@ -118,6 +118,7 @@ The OpenSearch exporter supports several document schemas and preprocessing beha
     - `policy_file`: (optional) Path to a JSON file containing a full ISM policy body. When set, it is used verbatim and the `rollover_*` options are ignored.
     - `rollover_min_size`: (optional, default=`50gb`) Minimum index size before rollover. Used only by the built-in policy.
     - `rollover_min_index_age`: (optional, default=`24h`) Minimum index age before rollover. Used only by the built-in policy.
+    - `rollover_priority`: (optional, default=`100`) ISM template priority used to claim the `<alias>-*` index pattern. Increase it if the cluster already has an ISM policy managing the same pattern — OpenSearch rejects overlapping ISM templates that share a priority. Used only by the built-in policy.
   - `timestamp_field`: (optional) Field to store the timestamp in. If not set, uses the default `@timestamp`.
   - `unix_timestamp`: (optional) Whether to store the timestamp in epoch milliseconds.
   - `dedup`: (optional) removes fields from the document, that have duplicate keys. The filtering only keeps the last value for a key.

--- a/exporter/opensearchexporter/README.md
+++ b/exporter/opensearchexporter/README.md
@@ -252,8 +252,15 @@ explosion, while uplifting one common attribute to a typed field:
 }
 ```
 
-Merging is best-effort: if the file cannot be read or parsed, the exporter logs a warning and falls
-back to the built-in template.
+> [!NOTE]
+> The overlay is a deep merge: nested objects are merged, but arrays (including `dynamic_templates`)
+> replace the built-in ones wholesale. To adjust dynamic attribute typing, either restate the full
+> `dynamic_templates` array or override specific fields under `properties` as shown above.
+
+A configured-but-unreadable or non-JSON `index_template_file` fails startup (`Start()` returns an
+error) rather than silently falling back to the built-in template — a path you set is honored or
+surfaced, never quietly ignored. The cluster-side template creation itself remains best-effort (see
+above).
 
 ##### Index State Management (ISM) rollover
 
@@ -264,9 +271,20 @@ indices roll over by size/age instead of growing unbounded. The default policy r
 `rollover_min_size` (default `50gb`) or `rollover_min_index_age` (default `24h`), whichever comes
 first. Provide `policy_file` to use a full custom ISM policy instead.
 
+`ism.enabled` works independently of `manage_index_template`. Rollover functions on its own, but
+without a managed (or pre-existing) `otel-v1` index template, rolled-over backing indices
+(`<alias>-000002`, …) fall back to dynamic mapping — timestamps become `date` instead of `date_nanos`
+and typed fields are lost, degrading Data Prepper–compatible dashboards. Enable
+`manage_index_template: true` (or install the template out-of-band) for full mapping fidelity.
+
+The built-in policy claims the `<alias>-*` index pattern at `rollover_priority` (default `100`). If
+the target cluster already manages the same pattern with another ISM policy — for example a Data
+Prepper deployment, whose `raw-span-policy` also owns `otel-v1-apm-span-*` — OpenSearch rejects the
+overlapping template unless the priority differs; set a distinct `rollover_priority` in that case.
+
 ISM is incompatible with dynamic index placeholders (`%{...}`) in `logs_index`/`traces_index`, since
-rollover writes through a fixed alias. Like template management, ISM setup is best-effort and does not
-fail `Start()`.
+rollover writes through a fixed alias. A configured-but-invalid `policy_file` fails startup; the
+cluster-side policy and index calls are best-effort and do not fail `Start()`.
 
 ```yaml
 exporters:

--- a/exporter/opensearchexporter/config.go
+++ b/exporter/opensearchexporter/config.go
@@ -74,6 +74,9 @@ var (
 	errTracesIndexTimeFormatInvalid   = errors.New("traces_index_time_format contains unsupported or invalid tokens")
 	errOTelV1DatasetNamespaceUnused   = errors.New(`dataset and namespace are not used by mapping.mode "otel-v1"; remove them or pick a different mode`)
 	errManageIndexTemplateInvalidMode = errors.New("mapping.manage_index_template is only supported with mapping.mode \"otel-v1\"")
+	errISMInvalidMode                 = errors.New("mapping.ism.enabled is only supported with mapping.mode \"otel-v1\"")
+	errISMDynamicIndex                = errors.New("mapping.ism.enabled is incompatible with dynamic index placeholders (%{...}) in logs_index/traces_index")
+	errIndexTemplateFileInvalidMode   = errors.New("mapping.index_template_file requires mapping.manage_index_template to be true with mapping.mode \"otel-v1\"")
 )
 
 type MappingsSettings struct {
@@ -108,6 +111,18 @@ type MappingsSettings struct {
 	// Only supported when Mode is "otel-v1". Validation will reject this option with other modes.
 	ManageIndexTemplate bool `mapstructure:"manage_index_template"`
 
+	// IndexTemplateFile is an optional path to a JSON file whose contents are deep-merged
+	// over the built-in otel-v1 index template before it is created. Use it to uplift common
+	// attributes to typed fields or to keep high-cardinality attributes un-indexed, without
+	// forking the exporter. Object values are merged recursively; array and scalar values in
+	// the file replace the built-in ones. Only used when ManageIndexTemplate is true and Mode
+	// is "otel-v1".
+	IndexTemplateFile string `mapstructure:"index_template_file"`
+
+	// ISM configures opt-in Index State Management (rollover) policy creation on startup.
+	// Only supported when Mode is "otel-v1".
+	ISM ISMConfig `mapstructure:"ism"`
+
 	// Additional field mappings.
 	Fields map[string]string `mapstructure:"fields"`
 
@@ -124,6 +139,27 @@ type MappingsSettings struct {
 	Dedup bool `mapstructure:"dedup"`
 
 	Dedot bool `mapstructure:"dedot"`
+}
+
+// ISMConfig configures opt-in Index State Management (ISM) policy creation for otel-v1 indices.
+// When enabled, the exporter creates a rollover policy and an initial write-aliased index on
+// startup so otel-v1 indices roll over by size/age instead of growing unbounded.
+type ISMConfig struct {
+	// Enabled controls whether an ISM rollover policy is created on startup.
+	Enabled bool `mapstructure:"enabled"`
+
+	// PolicyFile is an optional path to a JSON file containing a full ISM policy body.
+	// When set, it is used verbatim instead of the built-in rollover policy, and the
+	// RolloverMinSize/RolloverMinIndexAge options are ignored.
+	PolicyFile string `mapstructure:"policy_file"`
+
+	// RolloverMinSize is the minimum primary-shard-inclusive index size before rollover
+	// (e.g. "50gb"). Used only by the built-in policy. Defaults to "50gb" when empty.
+	RolloverMinSize string `mapstructure:"rollover_min_size"`
+
+	// RolloverMinIndexAge is the minimum index age before rollover (e.g. "24h").
+	// Used only by the built-in policy. Defaults to "24h" when empty.
+	RolloverMinIndexAge string `mapstructure:"rollover_min_index_age"`
 }
 
 type MappingMode int
@@ -220,6 +256,24 @@ func (cfg *Config) Validate() error {
 
 	if cfg.MappingsSettings.ManageIndexTemplate && cfg.MappingsSettings.Mode != MappingOTelV1.String() {
 		multiErr = append(multiErr, errManageIndexTemplateInvalidMode)
+	}
+
+	// A custom index-template overlay is only meaningful when the exporter is managing the
+	// otel-v1 template. Reject it otherwise so the option never silently does nothing.
+	if cfg.MappingsSettings.IndexTemplateFile != "" &&
+		(!cfg.MappingsSettings.ManageIndexTemplate || cfg.MappingsSettings.Mode != MappingOTelV1.String()) {
+		multiErr = append(multiErr, errIndexTemplateFileInvalidMode)
+	}
+
+	if cfg.MappingsSettings.ISM.Enabled {
+		if cfg.MappingsSettings.Mode != MappingOTelV1.String() {
+			multiErr = append(multiErr, errISMInvalidMode)
+		}
+		// ISM manages a fixed rollover alias for the otel-v1 base index; dynamic per-record
+		// index names (%{...}) would bypass the alias, so the two are mutually exclusive.
+		if strings.Contains(cfg.LogsIndex, "%{") || strings.Contains(cfg.TracesIndex, "%{") {
+			multiErr = append(multiErr, errISMDynamicIndex)
+		}
 	}
 
 	return errors.Join(multiErr...)

--- a/exporter/opensearchexporter/config.go
+++ b/exporter/opensearchexporter/config.go
@@ -75,7 +75,8 @@ var (
 	errOTelV1DatasetNamespaceUnused   = errors.New(`dataset and namespace are not used by mapping.mode "otel-v1"; remove them or pick a different mode`)
 	errManageIndexTemplateInvalidMode = errors.New("mapping.manage_index_template is only supported with mapping.mode \"otel-v1\"")
 	errISMInvalidMode                 = errors.New("mapping.ism.enabled is only supported with mapping.mode \"otel-v1\"")
-	errISMDynamicIndex                = errors.New("mapping.ism.enabled is incompatible with dynamic index placeholders (%{...}) in logs_index/traces_index")
+	errISMDynamicLogsIndex            = errors.New("mapping.ism.enabled is incompatible with dynamic index placeholders (%{...}) in logs_index")
+	errISMDynamicTracesIndex          = errors.New("mapping.ism.enabled is incompatible with dynamic index placeholders (%{...}) in traces_index")
 	errIndexTemplateFileInvalidMode   = errors.New("mapping.index_template_file requires mapping.manage_index_template to be true with mapping.mode \"otel-v1\"")
 )
 
@@ -113,10 +114,9 @@ type MappingsSettings struct {
 
 	// IndexTemplateFile is an optional path to a JSON file whose contents are deep-merged
 	// over the built-in otel-v1 index template before it is created. Use it to uplift common
-	// attributes to typed fields or to keep high-cardinality attributes un-indexed, without
-	// forking the exporter. Object values are merged recursively; array and scalar values in
-	// the file replace the built-in ones. Only used when ManageIndexTemplate is true and Mode
-	// is "otel-v1".
+	// attributes to typed fields or to keep high-cardinality attributes un-indexed. Object
+	// values are merged recursively; array and scalar values in the file replace the built-in
+	// ones. Only used when ManageIndexTemplate is true and Mode is "otel-v1".
 	IndexTemplateFile string `mapstructure:"index_template_file"`
 
 	// ISM configures opt-in Index State Management (rollover) policy creation on startup.
@@ -153,8 +153,9 @@ type ISMConfig struct {
 	// RolloverMinSize/RolloverMinIndexAge options are ignored.
 	PolicyFile string `mapstructure:"policy_file"`
 
-	// RolloverMinSize is the minimum primary-shard-inclusive index size before rollover
-	// (e.g. "50gb"). Used only by the built-in policy. Defaults to "50gb" when empty.
+	// RolloverMinSize is the minimum total index size (across primary shards) before rollover
+	// (e.g. "50gb"); maps to the ISM rollover action's min_size. Used only by the built-in
+	// policy. Defaults to "50gb" when empty.
 	RolloverMinSize string `mapstructure:"rollover_min_size"`
 
 	// RolloverMinIndexAge is the minimum index age before rollover (e.g. "24h").
@@ -277,8 +278,11 @@ func (cfg *Config) Validate() error {
 		}
 		// ISM manages a fixed rollover alias for the otel-v1 base index; dynamic per-record
 		// index names (%{...}) would bypass the alias, so the two are mutually exclusive.
-		if strings.Contains(cfg.LogsIndex, "%{") || strings.Contains(cfg.TracesIndex, "%{") {
-			multiErr = append(multiErr, errISMDynamicIndex)
+		if strings.Contains(cfg.LogsIndex, "%{") {
+			multiErr = append(multiErr, errISMDynamicLogsIndex)
+		}
+		if strings.Contains(cfg.TracesIndex, "%{") {
+			multiErr = append(multiErr, errISMDynamicTracesIndex)
 		}
 	}
 

--- a/exporter/opensearchexporter/config.go
+++ b/exporter/opensearchexporter/config.go
@@ -160,6 +160,12 @@ type ISMConfig struct {
 	// RolloverMinIndexAge is the minimum index age before rollover (e.g. "24h").
 	// Used only by the built-in policy. Defaults to "24h" when empty.
 	RolloverMinIndexAge string `mapstructure:"rollover_min_index_age"`
+
+	// RolloverPriority is the ISM template priority used by the built-in policy to claim the
+	// `<alias>-*` index pattern. Increase it if the cluster already has an ISM policy managing
+	// the same pattern (OpenSearch rejects overlapping templates that share a priority).
+	// Used only by the built-in policy. Defaults to 100 when zero.
+	RolloverPriority int `mapstructure:"rollover_priority"`
 }
 
 type MappingMode int

--- a/exporter/opensearchexporter/config.schema.yaml
+++ b/exporter/opensearchexporter/config.schema.yaml
@@ -1,4 +1,20 @@
 $defs:
+  ism_config:
+    description: ISMConfig configures opt-in Index State Management (ISM) policy creation for otel-v1 indices. When enabled, the exporter creates a rollover policy and an initial write-aliased index on startup so otel-v1 indices roll over by size/age instead of growing unbounded.
+    type: object
+    properties:
+      enabled:
+        description: Enabled controls whether an ISM rollover policy is created on startup.
+        type: boolean
+      policy_file:
+        description: PolicyFile is an optional path to a JSON file containing a full ISM policy body. When set, it is used verbatim instead of the built-in rollover policy, and the RolloverMinSize/RolloverMinIndexAge options are ignored.
+        type: string
+      rollover_min_index_age:
+        description: RolloverMinIndexAge is the minimum index age before rollover (e.g. "24h"). Used only by the built-in policy. Defaults to "24h" when empty.
+        type: string
+      rollover_min_size:
+        description: RolloverMinSize is the minimum primary-shard-inclusive index size before rollover (e.g. "50gb"). Used only by the built-in policy. Defaults to "50gb" when empty.
+        type: string
   mappings_settings:
     type: object
     properties:
@@ -15,6 +31,12 @@ $defs:
       file:
         description: File to read additional fields mappings from.
         type: string
+      index_template_file:
+        description: IndexTemplateFile is an optional path to a JSON file whose contents are deep-merged over the built-in otel-v1 index template before it is created. Use it to uplift common attributes to typed fields or to keep high-cardinality attributes un-indexed, without forking the exporter. Object values are merged recursively; array and scalar values in the file replace the built-in ones. Only used when ManageIndexTemplate is true and Mode is "otel-v1".
+        type: string
+      ism:
+        description: ISM configures opt-in Index State Management (rollover) policy creation on startup. Only supported when Mode is "otel-v1".
+        $ref: ism_config
       manage_index_template:
         description: ManageIndexTemplate controls whether the exporter creates index templates on startup. Only supported when Mode is "otel-v1". Validation will reject this option with other modes.
         type: boolean

--- a/exporter/opensearchexporter/config.schema.yaml
+++ b/exporter/opensearchexporter/config.schema.yaml
@@ -13,7 +13,7 @@ $defs:
         description: RolloverMinIndexAge is the minimum index age before rollover (e.g. "24h"). Used only by the built-in policy. Defaults to "24h" when empty.
         type: string
       rollover_min_size:
-        description: RolloverMinSize is the minimum primary-shard-inclusive index size before rollover (e.g. "50gb"). Used only by the built-in policy. Defaults to "50gb" when empty.
+        description: RolloverMinSize is the minimum total index size (across primary shards) before rollover (e.g. "50gb"); maps to the ISM rollover action's min_size. Used only by the built-in policy. Defaults to "50gb" when empty.
         type: string
       rollover_priority:
         description: RolloverPriority is the ISM template priority used by the built-in policy to claim the `<alias>-*` index pattern. Increase it if the cluster already has an ISM policy managing the same pattern (OpenSearch rejects overlapping templates that share a priority). Used only by the built-in policy. Defaults to 100 when zero.
@@ -35,7 +35,7 @@ $defs:
         description: File to read additional fields mappings from.
         type: string
       index_template_file:
-        description: IndexTemplateFile is an optional path to a JSON file whose contents are deep-merged over the built-in otel-v1 index template before it is created. Use it to uplift common attributes to typed fields or to keep high-cardinality attributes un-indexed, without forking the exporter. Object values are merged recursively; array and scalar values in the file replace the built-in ones. Only used when ManageIndexTemplate is true and Mode is "otel-v1".
+        description: IndexTemplateFile is an optional path to a JSON file whose contents are deep-merged over the built-in otel-v1 index template before it is created. Use it to uplift common attributes to typed fields or to keep high-cardinality attributes un-indexed. Object values are merged recursively; array and scalar values in the file replace the built-in ones. Only used when ManageIndexTemplate is true and Mode is "otel-v1".
         type: string
       ism:
         description: ISM configures opt-in Index State Management (rollover) policy creation on startup. Only supported when Mode is "otel-v1".

--- a/exporter/opensearchexporter/config.schema.yaml
+++ b/exporter/opensearchexporter/config.schema.yaml
@@ -15,6 +15,9 @@ $defs:
       rollover_min_size:
         description: RolloverMinSize is the minimum primary-shard-inclusive index size before rollover (e.g. "50gb"). Used only by the built-in policy. Defaults to "50gb" when empty.
         type: string
+      rollover_priority:
+        description: RolloverPriority is the ISM template priority used by the built-in policy to claim the `<alias>-*` index pattern. Increase it if the cluster already has an ISM policy managing the same pattern (OpenSearch rejects overlapping templates that share a priority). Used only by the built-in policy. Defaults to 100 when zero.
+        type: integer
   mappings_settings:
     type: object
     properties:

--- a/exporter/opensearchexporter/config_test.go
+++ b/exporter/opensearchexporter/config_test.go
@@ -359,3 +359,77 @@ func TestOTelV1MappingModeValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestISMAndCustomMappingValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(*Config)
+		expectError string
+	}{
+		{
+			name: "ism enabled with otel-v1 is valid",
+			mutate: func(c *Config) {
+				c.MappingsSettings.Mode = "otel-v1"
+				c.MappingsSettings.ISM.Enabled = true
+			},
+		},
+		{
+			name: "ism enabled with ss4o is invalid",
+			mutate: func(c *Config) {
+				c.MappingsSettings.Mode = "ss4o"
+				c.MappingsSettings.ISM.Enabled = true
+			},
+			expectError: errISMInvalidMode.Error(),
+		},
+		{
+			name: "ism enabled with dynamic logs_index is invalid",
+			mutate: func(c *Config) {
+				c.MappingsSettings.Mode = "otel-v1"
+				c.MappingsSettings.ISM.Enabled = true
+				c.LogsIndex = "otel-logs-%{service.name}"
+			},
+			expectError: errISMDynamicIndex.Error(),
+		},
+		{
+			name: "ism enabled with dynamic traces_index is invalid",
+			mutate: func(c *Config) {
+				c.MappingsSettings.Mode = "otel-v1"
+				c.MappingsSettings.ISM.Enabled = true
+				c.TracesIndex = "otel-traces-%{service.name}"
+			},
+			expectError: errISMDynamicIndex.Error(),
+		},
+		{
+			name: "index_template_file with otel-v1 and manage_index_template is valid",
+			mutate: func(c *Config) {
+				c.MappingsSettings.Mode = "otel-v1"
+				c.MappingsSettings.ManageIndexTemplate = true
+				c.MappingsSettings.IndexTemplateFile = "/tmp/custom.json"
+			},
+		},
+		{
+			name: "index_template_file without manage_index_template is invalid",
+			mutate: func(c *Config) {
+				c.MappingsSettings.Mode = "otel-v1"
+				c.MappingsSettings.ManageIndexTemplate = false
+				c.MappingsSettings.IndexTemplateFile = "/tmp/custom.json"
+			},
+			expectError: errIndexTemplateFileInvalidMode.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := withDefaultConfig(func(config *Config) {
+				config.ClientConfig.Endpoint = "http://localhost:9200"
+				tt.mutate(config)
+			})
+			err := cfg.Validate()
+			if tt.expectError != "" {
+				assert.ErrorContains(t, err, tt.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/exporter/opensearchexporter/config_test.go
+++ b/exporter/opensearchexporter/config_test.go
@@ -118,6 +118,25 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			id: component.NewIDWithName(metadata.Type, "otel_v1_ism"),
+			expected: withDefaultConfig(func(config *Config) {
+				config.ClientConfig.Endpoint = sampleEndpoint
+				config.BulkAction = defaultBulkAction
+				config.MappingsSettings = MappingsSettings{
+					Mode:                "otel-v1",
+					ManageIndexTemplate: true,
+					IndexTemplateFile:   "/etc/otelcol/otel-v1-overlay.json",
+					ISM: ISMConfig{
+						Enabled:             true,
+						RolloverMinSize:     "25gb",
+						RolloverMinIndexAge: "12h",
+						RolloverPriority:    200,
+					},
+				}
+			}),
+			configValidateAssert: assert.NoError,
+		},
+		{
 			id: component.NewIDWithName(metadata.Type, "dynamic_log_indexing"),
 			expected: withDefaultConfig(func(config *Config) {
 				config.ClientConfig.Endpoint = sampleEndpoint
@@ -388,7 +407,7 @@ func TestISMAndCustomMappingValidation(t *testing.T) {
 				c.MappingsSettings.ISM.Enabled = true
 				c.LogsIndex = "otel-logs-%{service.name}"
 			},
-			expectError: errISMDynamicIndex.Error(),
+			expectError: errISMDynamicLogsIndex.Error(),
 		},
 		{
 			name: "ism enabled with dynamic traces_index is invalid",
@@ -397,7 +416,7 @@ func TestISMAndCustomMappingValidation(t *testing.T) {
 				c.MappingsSettings.ISM.Enabled = true
 				c.TracesIndex = "otel-traces-%{service.name}"
 			},
-			expectError: errISMDynamicIndex.Error(),
+			expectError: errISMDynamicTracesIndex.Error(),
 		},
 		{
 			name: "index_template_file with otel-v1 and manage_index_template is valid",

--- a/exporter/opensearchexporter/index_template_manager.go
+++ b/exporter/opensearchexporter/index_template_manager.go
@@ -5,6 +5,9 @@ package opensearchexporter // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
@@ -16,15 +19,38 @@ import (
 const (
 	otelV1SpanTemplateName = "otel-v1-apm-span-index-template"
 	otelV1LogsTemplateName = "otel-v1-logs-index-template"
+
+	// Base index/alias names for otel-v1 mode. These match the index_patterns in the
+	// embedded templates (otel-v1-apm-span*, otel-v1-logs*) and are used as the write alias
+	// for ISM rollover.
+	otelV1SpanIndexAlias = "otel-v1-apm-span"
+	otelV1LogsIndexAlias = "otel-v1-logs"
 )
 
 type templateManager struct {
 	client *opensearchapi.Client
 	logger *zap.Logger
+
+	// customOverlay is an optional JSON document deep-merged over each built-in template
+	// body before creation. Empty when no custom index template file is configured.
+	customOverlay string
 }
 
-func newTemplateManager(client *opensearchapi.Client, logger *zap.Logger) *templateManager {
-	return &templateManager{client: client, logger: logger}
+func newTemplateManager(client *opensearchapi.Client, logger *zap.Logger, customTemplateFile string) *templateManager {
+	tm := &templateManager{client: client, logger: logger}
+	if customTemplateFile != "" {
+		data, err := os.ReadFile(customTemplateFile)
+		if err != nil {
+			// Best-effort: fall back to the built-in templates so a bad path does not
+			// block startup. Validation only checks that the option is used in a valid
+			// mode, not that the file exists, matching the exporter's other file options.
+			logger.Warn("Failed to read custom index template file; using built-in templates",
+				zap.String("file", customTemplateFile), zap.Error(err))
+		} else {
+			tm.customOverlay = string(data)
+		}
+	}
+	return tm
 }
 
 // ensureTemplates is best-effort: it logs and returns on transient cluster
@@ -40,6 +66,19 @@ func (tm *templateManager) ensureTemplates(ctx context.Context) {
 }
 
 func (tm *templateManager) ensureTemplate(ctx context.Context, name, body string) {
+	// Apply the optional custom overlay (e.g. to uplift attributes to typed fields or keep
+	// them un-indexed) on top of the built-in template. On merge failure, fall back to the
+	// built-in body rather than dropping the template entirely.
+	if tm.customOverlay != "" {
+		merged, err := mergeTemplateBody(body, tm.customOverlay)
+		if err != nil {
+			tm.logger.Warn("Failed to merge custom index template file; using built-in template",
+				zap.String("template", name), zap.Error(err))
+		} else {
+			body = merged
+		}
+	}
+
 	// Check if template exists
 	existsReq := opensearchapi.IndexTemplateExistsReq{IndexTemplate: name}
 	_, err := tm.client.IndexTemplate.Exists(ctx, existsReq)
@@ -62,4 +101,41 @@ func (tm *templateManager) ensureTemplate(ctx context.Context, name, body string
 		return
 	}
 	tm.logger.Info("Created index template", zap.String("template", name))
+}
+
+// mergeTemplateBody deep-merges overlay JSON over base JSON. Object values are merged
+// recursively; array and scalar values in the overlay replace those in the base. This lets a
+// user add or override mappings (e.g. typed properties or dynamic_templates) without restating
+// the whole otel-v1 template.
+func mergeTemplateBody(base, overlay string) (string, error) {
+	var baseMap map[string]any
+	if err := json.Unmarshal([]byte(base), &baseMap); err != nil {
+		return "", fmt.Errorf("parsing built-in template: %w", err)
+	}
+	var overlayMap map[string]any
+	if err := json.Unmarshal([]byte(overlay), &overlayMap); err != nil {
+		return "", fmt.Errorf("parsing custom index template file: %w", err)
+	}
+	merged, err := json.Marshal(deepMerge(baseMap, overlayMap))
+	if err != nil {
+		return "", err
+	}
+	return string(merged), nil
+}
+
+// deepMerge recursively merges overlay into base and returns base. When a key holds an object
+// in both, the objects are merged; otherwise the overlay value wins.
+func deepMerge(base, overlay map[string]any) map[string]any {
+	for k, ov := range overlay {
+		if bv, ok := base[k]; ok {
+			bMap, bIsMap := bv.(map[string]any)
+			oMap, oIsMap := ov.(map[string]any)
+			if bIsMap && oIsMap {
+				base[k] = deepMerge(bMap, oMap)
+				continue
+			}
+		}
+		base[k] = ov
+	}
+	return base
 }

--- a/exporter/opensearchexporter/index_template_manager.go
+++ b/exporter/opensearchexporter/index_template_manager.go
@@ -36,21 +36,22 @@ type templateManager struct {
 	customOverlay string
 }
 
-func newTemplateManager(client *opensearchapi.Client, logger *zap.Logger, customTemplateFile string) *templateManager {
+// newTemplateManager loads the optional custom overlay eagerly. A configured-but-unreadable
+// or non-JSON file is a configuration error and fails startup, rather than silently falling
+// back to the built-in template and indexing with unexpected mappings.
+func newTemplateManager(client *opensearchapi.Client, logger *zap.Logger, customTemplateFile string) (*templateManager, error) {
 	tm := &templateManager{client: client, logger: logger}
 	if customTemplateFile != "" {
 		data, err := os.ReadFile(customTemplateFile)
 		if err != nil {
-			// Best-effort: fall back to the built-in templates so a bad path does not
-			// block startup. Validation only checks that the option is used in a valid
-			// mode, not that the file exists, matching the exporter's other file options.
-			logger.Warn("Failed to read custom index template file; using built-in templates",
-				zap.String("file", customTemplateFile), zap.Error(err))
-		} else {
-			tm.customOverlay = string(data)
+			return nil, fmt.Errorf("reading custom index template file %q: %w", customTemplateFile, err)
 		}
+		if !json.Valid(data) {
+			return nil, fmt.Errorf("custom index template file %q is not valid JSON", customTemplateFile)
+		}
+		tm.customOverlay = string(data)
 	}
-	return tm
+	return tm, nil
 }
 
 // ensureTemplates is best-effort: it logs and returns on transient cluster

--- a/exporter/opensearchexporter/index_template_manager_test.go
+++ b/exporter/opensearchexporter/index_template_manager_test.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package opensearchexporter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeepMerge(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    map[string]any
+		overlay map[string]any
+		want    map[string]any
+	}{
+		{
+			name:    "adds new key",
+			base:    map[string]any{"a": float64(1)},
+			overlay: map[string]any{"b": float64(2)},
+			want:    map[string]any{"a": float64(1), "b": float64(2)},
+		},
+		{
+			name:    "scalar overlay replaces scalar",
+			base:    map[string]any{"a": float64(1)},
+			overlay: map[string]any{"a": float64(9)},
+			want:    map[string]any{"a": float64(9)},
+		},
+		{
+			name:    "nested objects merge recursively",
+			base:    map[string]any{"m": map[string]any{"x": float64(1), "y": float64(2)}},
+			overlay: map[string]any{"m": map[string]any{"y": float64(3), "z": float64(4)}},
+			want:    map[string]any{"m": map[string]any{"x": float64(1), "y": float64(3), "z": float64(4)}},
+		},
+		{
+			name:    "array overlay replaces array wholesale",
+			base:    map[string]any{"a": []any{float64(1), float64(2)}},
+			overlay: map[string]any{"a": []any{float64(9)}},
+			want:    map[string]any{"a": []any{float64(9)}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deepMerge(tt.base, tt.overlay)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMergeTemplateBody(t *testing.T) {
+	base := `{
+		"index_patterns": ["otel-v1-apm-span*"],
+		"template": {
+			"mappings": {
+				"date_detection": false,
+				"properties": {
+					"traceId": {"type": "keyword"}
+				}
+			}
+		}
+	}`
+
+	t.Run("overlay uplifts an attribute to a typed property", func(t *testing.T) {
+		overlay := `{"template":{"mappings":{"properties":{"attributes":{"properties":{"http.status_code":{"type":"integer"}}}}}}}`
+		merged, err := mergeTemplateBody(base, overlay)
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal([]byte(merged), &got))
+		props := got["template"].(map[string]any)["mappings"].(map[string]any)["properties"].(map[string]any)
+		// Base property is preserved.
+		assert.Contains(t, props, "traceId")
+		// Overlay property is added.
+		attrs := props["attributes"].(map[string]any)["properties"].(map[string]any)
+		assert.Equal(t, "integer", attrs["http.status_code"].(map[string]any)["type"])
+		// Base scalar under mappings is preserved.
+		assert.Equal(t, false, got["template"].(map[string]any)["mappings"].(map[string]any)["date_detection"])
+	})
+
+	t.Run("overlay can un-index attributes by disabling the object", func(t *testing.T) {
+		overlay := `{"template":{"mappings":{"properties":{"attributes":{"type":"object","enabled":false}}}}}`
+		merged, err := mergeTemplateBody(base, overlay)
+		require.NoError(t, err)
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal([]byte(merged), &got))
+		attrs := got["template"].(map[string]any)["mappings"].(map[string]any)["properties"].(map[string]any)["attributes"].(map[string]any)
+		assert.Equal(t, false, attrs["enabled"])
+	})
+
+	t.Run("invalid overlay JSON returns error", func(t *testing.T) {
+		_, err := mergeTemplateBody(base, `{not json}`)
+		assert.ErrorContains(t, err, "custom index template file")
+	})
+
+	t.Run("invalid base JSON returns error", func(t *testing.T) {
+		_, err := mergeTemplateBody(`{not json}`, `{}`)
+		assert.ErrorContains(t, err, "built-in template")
+	})
+}

--- a/exporter/opensearchexporter/ism_manager.go
+++ b/exporter/opensearchexporter/ism_manager.go
@@ -1,0 +1,170 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package opensearchexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter"
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"github.com/opensearch-project/opensearch-go/v4/plugins/ism"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultRolloverMinSize     = "50gb"
+	defaultRolloverMinIndexAge = "24h"
+)
+
+// ismManager creates the ISM rollover policy and initial write-aliased index for an otel-v1
+// index. It is best-effort: like templateManager, it logs and returns on cluster errors rather
+// than failing the exporter Start(), so a transient control-plane hiccup does not block the
+// data path.
+type ismManager struct {
+	client    *opensearchapi.Client
+	ismClient *ism.Client
+	logger    *zap.Logger
+	cfg       ISMConfig
+}
+
+func newISMManager(endpoint string, transport http.RoundTripper, client *opensearchapi.Client, ismCfg ISMConfig, logger *zap.Logger) *ismManager {
+	ismClient, err := ism.NewClient(ism.Config{
+		Client: opensearch.Config{
+			Addresses:    []string{endpoint},
+			Transport:    transport,
+			DisableRetry: true,
+		},
+	})
+	if err != nil {
+		// Best-effort: leave ismClient nil and skip ISM setup rather than failing Start().
+		logger.Warn("Failed to create ISM client; skipping ISM setup", zap.Error(err))
+	}
+
+	return &ismManager{
+		client:    client,
+		ismClient: ismClient,
+		logger:    logger,
+		cfg:       ismCfg,
+	}
+}
+
+// setupISM creates the ISM policy and initial index with write alias for the given index alias.
+func (m *ismManager) setupISM(ctx context.Context, indexAlias string) {
+	if m.ismClient == nil {
+		return
+	}
+	policyName := indexAlias + "-policy"
+	m.ensurePolicy(ctx, policyName, indexAlias)
+	m.ensureInitialIndex(ctx, indexAlias)
+}
+
+func (m *ismManager) ensurePolicy(ctx context.Context, policyName, indexAlias string) {
+	policyBody, err := m.buildPolicyBody(indexAlias)
+	if err != nil {
+		m.logger.Warn("Failed to build ISM policy", zap.String("policy", policyName), zap.Error(err))
+		return
+	}
+
+	req := ism.PoliciesPutReq{
+		Policy: policyName,
+		Body:   policyBody,
+	}
+	_, err = m.ismClient.Policies.Put(ctx, req)
+	if err != nil {
+		if strings.Contains(err.Error(), "version_conflict_engine_exception") ||
+			strings.Contains(err.Error(), "resource_already_exists_exception") {
+			m.logger.Debug("ISM policy already exists", zap.String("policy", policyName))
+			return
+		}
+		m.logger.Warn("Failed to create ISM policy", zap.String("policy", policyName), zap.Error(err))
+		return
+	}
+	m.logger.Info("Created ISM policy", zap.String("policy", policyName))
+}
+
+func (m *ismManager) buildPolicyBody(indexAlias string) (ism.PoliciesPutBody, error) {
+	if m.cfg.PolicyFile != "" {
+		return m.loadPolicyFile(m.cfg.PolicyFile)
+	}
+
+	minSize := m.cfg.RolloverMinSize
+	if minSize == "" {
+		minSize = defaultRolloverMinSize
+	}
+	minAge := m.cfg.RolloverMinIndexAge
+	if minAge == "" {
+		minAge = defaultRolloverMinIndexAge
+	}
+
+	return ism.PoliciesPutBody{
+		Policy: ism.PolicyBody{
+			Description:  fmt.Sprintf("Rollover policy for %s", indexAlias),
+			DefaultState: "current_write_index",
+			States: []ism.PolicyState{
+				{
+					Name: "current_write_index",
+					Actions: []ism.PolicyStateAction{
+						{
+							Rollover: &ism.PolicyStateRollover{
+								MinSize:     minSize,
+								MinIndexAge: minAge,
+							},
+						},
+					},
+				},
+			},
+			Template: []ism.Template{
+				{
+					IndexPatterns: []string{indexAlias + "-*"},
+					Priority:      100,
+				},
+			},
+		},
+	}, nil
+}
+
+func (m *ismManager) loadPolicyFile(path string) (ism.PoliciesPutBody, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ism.PoliciesPutBody{}, fmt.Errorf("reading ISM policy file: %w", err)
+	}
+	var body ism.PoliciesPutBody
+	if err := json.Unmarshal(data, &body); err != nil {
+		return ism.PoliciesPutBody{}, fmt.Errorf("parsing ISM policy file: %w", err)
+	}
+	return body, nil
+}
+
+func (m *ismManager) ensureInitialIndex(ctx context.Context, indexAlias string) {
+	existsReq := opensearchapi.IndicesExistsReq{Indices: []string{indexAlias}}
+	_, err := m.client.Indices.Exists(ctx, existsReq)
+	if err == nil {
+		m.logger.Debug("Index/alias already exists", zap.String("alias", indexAlias))
+		return
+	}
+
+	initialIndex := indexAlias + "-000001"
+	body := fmt.Sprintf(`{"aliases":{"%s":{"is_write_index":true}}}`, indexAlias)
+	createReq := opensearchapi.IndicesCreateReq{
+		Index: initialIndex,
+		Body:  strings.NewReader(body),
+	}
+	_, createErr := m.client.Indices.Create(ctx, createReq)
+	if createErr != nil {
+		if strings.Contains(createErr.Error(), "resource_already_exists_exception") {
+			m.logger.Debug("Initial index already exists", zap.String("index", initialIndex))
+			return
+		}
+		m.logger.Warn("Failed to create initial index", zap.String("index", initialIndex), zap.Error(createErr))
+		return
+	}
+	m.logger.Info("Created initial index with write alias",
+		zap.String("index", initialIndex),
+		zap.String("alias", indexAlias))
+}

--- a/exporter/opensearchexporter/ism_manager.go
+++ b/exporter/opensearchexporter/ism_manager.go
@@ -32,9 +32,29 @@ type ismManager struct {
 	ismClient *ism.Client
 	logger    *zap.Logger
 	cfg       ISMConfig
+
+	// customPolicy is the pre-loaded policy body when PolicyFile is set; nil otherwise.
+	customPolicy *ism.PoliciesPutBody
 }
 
-func newISMManager(endpoint string, transport http.RoundTripper, client *opensearchapi.Client, ismCfg ISMConfig, logger *zap.Logger) *ismManager {
+// newISMManager pre-loads the optional custom policy file eagerly. A configured-but-unreadable
+// or invalid policy file is a configuration error and fails startup. Client construction and the
+// cluster-side policy/index calls remain best-effort (logged, non-fatal).
+func newISMManager(endpoint string, transport http.RoundTripper, client *opensearchapi.Client, ismCfg ISMConfig, logger *zap.Logger) (*ismManager, error) {
+	m := &ismManager{
+		client: client,
+		logger: logger,
+		cfg:    ismCfg,
+	}
+
+	if ismCfg.PolicyFile != "" {
+		body, err := loadPolicyFile(ismCfg.PolicyFile)
+		if err != nil {
+			return nil, err
+		}
+		m.customPolicy = &body
+	}
+
 	ismClient, err := ism.NewClient(ism.Config{
 		Client: opensearch.Config{
 			Addresses:    []string{endpoint},
@@ -46,13 +66,9 @@ func newISMManager(endpoint string, transport http.RoundTripper, client *opensea
 		// Best-effort: leave ismClient nil and skip ISM setup rather than failing Start().
 		logger.Warn("Failed to create ISM client; skipping ISM setup", zap.Error(err))
 	}
+	m.ismClient = ismClient
 
-	return &ismManager{
-		client:    client,
-		ismClient: ismClient,
-		logger:    logger,
-		cfg:       ismCfg,
-	}
+	return m, nil
 }
 
 // setupISM creates the ISM policy and initial index with write alias for the given index alias.
@@ -66,17 +82,11 @@ func (m *ismManager) setupISM(ctx context.Context, indexAlias string) {
 }
 
 func (m *ismManager) ensurePolicy(ctx context.Context, policyName, indexAlias string) {
-	policyBody, err := m.buildPolicyBody(indexAlias)
-	if err != nil {
-		m.logger.Warn("Failed to build ISM policy", zap.String("policy", policyName), zap.Error(err))
-		return
-	}
-
 	req := ism.PoliciesPutReq{
 		Policy: policyName,
-		Body:   policyBody,
+		Body:   m.buildPolicyBody(indexAlias),
 	}
-	_, err = m.ismClient.Policies.Put(ctx, req)
+	_, err := m.ismClient.Policies.Put(ctx, req)
 	if err != nil {
 		if strings.Contains(err.Error(), "version_conflict_engine_exception") ||
 			strings.Contains(err.Error(), "resource_already_exists_exception") {
@@ -89,9 +99,9 @@ func (m *ismManager) ensurePolicy(ctx context.Context, policyName, indexAlias st
 	m.logger.Info("Created ISM policy", zap.String("policy", policyName))
 }
 
-func (m *ismManager) buildPolicyBody(indexAlias string) (ism.PoliciesPutBody, error) {
-	if m.cfg.PolicyFile != "" {
-		return loadPolicyFile(m.cfg.PolicyFile)
+func (m *ismManager) buildPolicyBody(indexAlias string) ism.PoliciesPutBody {
+	if m.customPolicy != nil {
+		return *m.customPolicy
 	}
 
 	minSize := m.cfg.RolloverMinSize
@@ -131,7 +141,7 @@ func (m *ismManager) buildPolicyBody(indexAlias string) (ism.PoliciesPutBody, er
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 func loadPolicyFile(path string) (ism.PoliciesPutBody, error) {

--- a/exporter/opensearchexporter/ism_manager.go
+++ b/exporter/opensearchexporter/ism_manager.go
@@ -20,6 +20,7 @@ import (
 const (
 	defaultRolloverMinSize     = "50gb"
 	defaultRolloverMinIndexAge = "24h"
+	defaultRolloverPriority    = 100
 )
 
 // ismManager creates the ISM rollover policy and initial write-aliased index for an otel-v1
@@ -90,7 +91,7 @@ func (m *ismManager) ensurePolicy(ctx context.Context, policyName, indexAlias st
 
 func (m *ismManager) buildPolicyBody(indexAlias string) (ism.PoliciesPutBody, error) {
 	if m.cfg.PolicyFile != "" {
-		return m.loadPolicyFile(m.cfg.PolicyFile)
+		return loadPolicyFile(m.cfg.PolicyFile)
 	}
 
 	minSize := m.cfg.RolloverMinSize
@@ -100,6 +101,10 @@ func (m *ismManager) buildPolicyBody(indexAlias string) (ism.PoliciesPutBody, er
 	minAge := m.cfg.RolloverMinIndexAge
 	if minAge == "" {
 		minAge = defaultRolloverMinIndexAge
+	}
+	priority := m.cfg.RolloverPriority
+	if priority == 0 {
+		priority = defaultRolloverPriority
 	}
 
 	return ism.PoliciesPutBody{
@@ -122,14 +127,14 @@ func (m *ismManager) buildPolicyBody(indexAlias string) (ism.PoliciesPutBody, er
 			Template: []ism.Template{
 				{
 					IndexPatterns: []string{indexAlias + "-*"},
-					Priority:      100,
+					Priority:      priority,
 				},
 			},
 		},
 	}, nil
 }
 
-func (m *ismManager) loadPolicyFile(path string) (ism.PoliciesPutBody, error) {
+func loadPolicyFile(path string) (ism.PoliciesPutBody, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ism.PoliciesPutBody{}, fmt.Errorf("reading ISM policy file: %w", err)
@@ -150,7 +155,7 @@ func (m *ismManager) ensureInitialIndex(ctx context.Context, indexAlias string) 
 	}
 
 	initialIndex := indexAlias + "-000001"
-	body := fmt.Sprintf(`{"aliases":{"%s":{"is_write_index":true}}}`, indexAlias)
+	body := fmt.Sprintf(`{"aliases":{%q:{"is_write_index":true}}}`, indexAlias)
 	createReq := opensearchapi.IndicesCreateReq{
 		Index: initialIndex,
 		Body:  strings.NewReader(body),

--- a/exporter/opensearchexporter/ism_manager_test.go
+++ b/exporter/opensearchexporter/ism_manager_test.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package opensearchexporter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPolicyBodyDefaults(t *testing.T) {
+	m := &ismManager{cfg: ISMConfig{}}
+	body, err := m.buildPolicyBody(otelV1SpanIndexAlias)
+	require.NoError(t, err)
+
+	require.Len(t, body.Policy.States, 1)
+	require.Len(t, body.Policy.States[0].Actions, 1)
+	rollover := body.Policy.States[0].Actions[0].Rollover
+	require.NotNil(t, rollover)
+	assert.Equal(t, defaultRolloverMinSize, rollover.MinSize)
+	assert.Equal(t, defaultRolloverMinIndexAge, rollover.MinIndexAge)
+
+	require.Len(t, body.Policy.Template, 1)
+	assert.Equal(t, []string{otelV1SpanIndexAlias + "-*"}, body.Policy.Template[0].IndexPatterns)
+}
+
+func TestBuildPolicyBodyCustomRollover(t *testing.T) {
+	m := &ismManager{cfg: ISMConfig{RolloverMinSize: "10gb", RolloverMinIndexAge: "1h"}}
+	body, err := m.buildPolicyBody(otelV1LogsIndexAlias)
+	require.NoError(t, err)
+
+	rollover := body.Policy.States[0].Actions[0].Rollover
+	require.NotNil(t, rollover)
+	assert.Equal(t, "10gb", rollover.MinSize)
+	assert.Equal(t, "1h", rollover.MinIndexAge)
+}
+
+func TestBuildPolicyBodyFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	content := `{"policy":{"description":"custom","default_state":"hot","states":[{"name":"hot","actions":[{"rollover":{"min_size":"5gb"}}]}]}}`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	m := &ismManager{cfg: ISMConfig{PolicyFile: path}}
+	body, err := m.buildPolicyBody(otelV1SpanIndexAlias)
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom", body.Policy.Description)
+	assert.Equal(t, "hot", body.Policy.DefaultState)
+	require.Len(t, body.Policy.States, 1)
+	assert.Equal(t, "5gb", body.Policy.States[0].Actions[0].Rollover.MinSize)
+}
+
+func TestBuildPolicyBodyFromMissingFile(t *testing.T) {
+	m := &ismManager{cfg: ISMConfig{PolicyFile: "/does/not/exist.json"}}
+	_, err := m.buildPolicyBody(otelV1SpanIndexAlias)
+	assert.ErrorContains(t, err, "reading ISM policy file")
+}

--- a/exporter/opensearchexporter/ism_manager_test.go
+++ b/exporter/opensearchexporter/ism_manager_test.go
@@ -26,6 +26,15 @@ func TestBuildPolicyBodyDefaults(t *testing.T) {
 
 	require.Len(t, body.Policy.Template, 1)
 	assert.Equal(t, []string{otelV1SpanIndexAlias + "-*"}, body.Policy.Template[0].IndexPatterns)
+	assert.Equal(t, defaultRolloverPriority, body.Policy.Template[0].Priority)
+}
+
+func TestBuildPolicyBodyCustomPriority(t *testing.T) {
+	m := &ismManager{cfg: ISMConfig{RolloverPriority: 200}}
+	body, err := m.buildPolicyBody(otelV1SpanIndexAlias)
+	require.NoError(t, err)
+	require.Len(t, body.Policy.Template, 1)
+	assert.Equal(t, 200, body.Policy.Template[0].Priority)
 }
 
 func TestBuildPolicyBodyCustomRollover(t *testing.T) {

--- a/exporter/opensearchexporter/ism_manager_test.go
+++ b/exporter/opensearchexporter/ism_manager_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestBuildPolicyBodyDefaults(t *testing.T) {
 	m := &ismManager{cfg: ISMConfig{}}
-	body, err := m.buildPolicyBody(otelV1SpanIndexAlias)
-	require.NoError(t, err)
+	body := m.buildPolicyBody(otelV1SpanIndexAlias)
 
 	require.Len(t, body.Policy.States, 1)
 	require.Len(t, body.Policy.States[0].Actions, 1)
@@ -29,18 +29,9 @@ func TestBuildPolicyBodyDefaults(t *testing.T) {
 	assert.Equal(t, defaultRolloverPriority, body.Policy.Template[0].Priority)
 }
 
-func TestBuildPolicyBodyCustomPriority(t *testing.T) {
-	m := &ismManager{cfg: ISMConfig{RolloverPriority: 200}}
-	body, err := m.buildPolicyBody(otelV1SpanIndexAlias)
-	require.NoError(t, err)
-	require.Len(t, body.Policy.Template, 1)
-	assert.Equal(t, 200, body.Policy.Template[0].Priority)
-}
-
 func TestBuildPolicyBodyCustomRollover(t *testing.T) {
 	m := &ismManager{cfg: ISMConfig{RolloverMinSize: "10gb", RolloverMinIndexAge: "1h"}}
-	body, err := m.buildPolicyBody(otelV1LogsIndexAlias)
-	require.NoError(t, err)
+	body := m.buildPolicyBody(otelV1LogsIndexAlias)
 
 	rollover := body.Policy.States[0].Actions[0].Rollover
 	require.NotNil(t, rollover)
@@ -48,24 +39,51 @@ func TestBuildPolicyBodyCustomRollover(t *testing.T) {
 	assert.Equal(t, "1h", rollover.MinIndexAge)
 }
 
-func TestBuildPolicyBodyFromFile(t *testing.T) {
+func TestBuildPolicyBodyCustomPriority(t *testing.T) {
+	m := &ismManager{cfg: ISMConfig{RolloverPriority: 200}}
+	body := m.buildPolicyBody(otelV1SpanIndexAlias)
+	require.Len(t, body.Policy.Template, 1)
+	assert.Equal(t, 200, body.Policy.Template[0].Priority)
+}
+
+func TestLoadPolicyFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "policy.json")
 	content := `{"policy":{"description":"custom","default_state":"hot","states":[{"name":"hot","actions":[{"rollover":{"min_size":"5gb"}}]}]}}`
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 
-	m := &ismManager{cfg: ISMConfig{PolicyFile: path}}
-	body, err := m.buildPolicyBody(otelV1SpanIndexAlias)
+	body, err := loadPolicyFile(path)
 	require.NoError(t, err)
-
 	assert.Equal(t, "custom", body.Policy.Description)
 	assert.Equal(t, "hot", body.Policy.DefaultState)
 	require.Len(t, body.Policy.States, 1)
 	assert.Equal(t, "5gb", body.Policy.States[0].Actions[0].Rollover.MinSize)
 }
 
-func TestBuildPolicyBodyFromMissingFile(t *testing.T) {
-	m := &ismManager{cfg: ISMConfig{PolicyFile: "/does/not/exist.json"}}
-	_, err := m.buildPolicyBody(otelV1SpanIndexAlias)
+func TestLoadPolicyFileInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not json}"), 0o600))
+
+	_, err := loadPolicyFile(path)
+	assert.ErrorContains(t, err, "parsing ISM policy file")
+}
+
+// newISMManager pre-loads the custom policy file eagerly and fails fast on a bad path.
+func TestNewISMManagerBadPolicyFile(t *testing.T) {
+	_, err := newISMManager("http://localhost:9200", nil, nil, ISMConfig{PolicyFile: "/does/not/exist.json"}, zap.NewNop())
 	assert.ErrorContains(t, err, "reading ISM policy file")
+}
+
+// A valid custom policy file is used verbatim by buildPolicyBody, overriding the built-in policy.
+func TestNewISMManagerCustomPolicyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	content := `{"policy":{"description":"custom","default_state":"hot","states":[{"name":"hot","actions":[{"rollover":{"min_size":"5gb"}}]}]}}`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	m, err := newISMManager("http://localhost:9200", nil, nil, ISMConfig{PolicyFile: path}, zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, m.customPolicy)
+	assert.Equal(t, "custom", m.buildPolicyBody(otelV1SpanIndexAlias).Policy.Description)
 }

--- a/exporter/opensearchexporter/opensearch_integration_test.go
+++ b/exporter/opensearchexporter/opensearch_integration_test.go
@@ -12,6 +12,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -73,6 +75,109 @@ func setupOpenSearch(t *testing.T) string {
 	require.NoError(t, err)
 
 	return fmt.Sprintf("http://%s:%s", host, port.Port())
+}
+
+// httpGetJSON is a small helper for querying OpenSearch control-plane endpoints
+// (ISM policies, index templates, aliases) that the typed client does not expose.
+func httpGetJSON(t *testing.T, url string) (int, map[string]any) {
+	t.Helper()
+	resp, err := http.Get(url) //nolint:noctx,gosec // test-only, endpoint is a local container
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body := map[string]any{}
+	if resp.StatusCode == http.StatusOK {
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	}
+	return resp.StatusCode, body
+}
+
+func TestIntegration_ISM_CreatesPolicyAndWriteAlias(t *testing.T) {
+	endpoint := setupOpenSearch(t)
+
+	cfg := NewFactory().CreateDefaultConfig().(*Config)
+	cfg.ClientConfig.Endpoint = endpoint
+	cfg.MappingsSettings.Mode = "otel-v1"
+	cfg.MappingsSettings.ManageIndexTemplate = true
+	cfg.MappingsSettings.ISM.Enabled = true
+	cfg.MappingsSettings.ISM.RolloverMinSize = "10gb"
+	cfg.MappingsSettings.ISM.RolloverMinIndexAge = "1h"
+	cfg.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+
+	require.NoError(t, cfg.Validate())
+
+	exporter, err := NewFactory().CreateTraces(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exporter.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, exporter.Shutdown(context.Background())) //nolint:usetesting
+	})
+
+	// The ISM rollover policy is created for the span alias.
+	status, policy := httpGetJSON(t, endpoint+"/_plugins/_ism/policies/otel-v1-apm-span-policy")
+	require.Equal(t, http.StatusOK, status, "ISM policy should exist")
+	assert.Contains(t, policy, "policy")
+
+	// The initial index exists with the write alias attached.
+	status, alias := httpGetJSON(t, endpoint+"/otel-v1-apm-span-000001/_alias/otel-v1-apm-span")
+	require.Equal(t, http.StatusOK, status, "initial index with write alias should exist")
+	idx, ok := alias["otel-v1-apm-span-000001"].(map[string]any)
+	require.True(t, ok, "initial index should be present in alias response: %v", alias)
+	aliases, ok := idx["aliases"].(map[string]any)
+	require.True(t, ok)
+	writeAlias, ok := aliases["otel-v1-apm-span"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, writeAlias["is_write_index"])
+
+	// Idempotency: a second Start() must not error even though the policy/alias exist.
+	require.NoError(t, exporter.Start(t.Context(), componenttest.NewNopHost()))
+}
+
+func TestIntegration_CustomIndexTemplate_Overlay(t *testing.T) {
+	endpoint := setupOpenSearch(t)
+
+	// Overlay uplifts a custom attribute to a typed field and keeps free-form span
+	// attributes un-indexed to bound the field count.
+	overlay := `{"template":{"mappings":{"properties":{"custom_uplifted_field":{"type":"integer"},"attributes":{"type":"object","enabled":false}}}}}`
+	overlayPath := filepath.Join(t.TempDir(), "overlay.json")
+	require.NoError(t, os.WriteFile(overlayPath, []byte(overlay), 0o600))
+
+	cfg := NewFactory().CreateDefaultConfig().(*Config)
+	cfg.ClientConfig.Endpoint = endpoint
+	cfg.MappingsSettings.Mode = "otel-v1"
+	cfg.MappingsSettings.ManageIndexTemplate = true
+	cfg.MappingsSettings.IndexTemplateFile = overlayPath
+	cfg.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+
+	require.NoError(t, cfg.Validate())
+
+	exporter, err := NewFactory().CreateTraces(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exporter.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, exporter.Shutdown(context.Background())) //nolint:usetesting
+	})
+
+	status, tmpl := httpGetJSON(t, endpoint+"/_index_template/otel-v1-apm-span-index-template")
+	require.Equal(t, http.StatusOK, status, "index template should exist")
+
+	templates, ok := tmpl["index_templates"].([]any)
+	require.True(t, ok, "index_templates array expected: %v", tmpl)
+	require.NotEmpty(t, templates)
+	first := templates[0].(map[string]any)["index_template"].(map[string]any)
+	props := first["template"].(map[string]any)["mappings"].(map[string]any)["properties"].(map[string]any)
+
+	// Overlay-added property is present and typed.
+	uplifted, ok := props["custom_uplifted_field"].(map[string]any)
+	require.True(t, ok, "custom overlay field should be merged into the template: %v", props)
+	assert.Equal(t, "integer", uplifted["type"])
+
+	// Overlay override applied: attributes object is disabled (un-indexed).
+	attrs, ok := props["attributes"].(map[string]any)
+	require.True(t, ok, "attributes property should exist")
+	assert.Equal(t, false, attrs["enabled"])
+
+	// Built-in base mapping is preserved (not clobbered by the overlay).
+	assert.Contains(t, props, "traceId")
 }
 
 func TestIntegration_OtelV1Mapping_Traces(t *testing.T) {

--- a/exporter/opensearchexporter/sso_log_exporter.go
+++ b/exporter/opensearchexporter/sso_log_exporter.go
@@ -51,7 +51,7 @@ func newLogExporter(cfg *Config, set exporter.Settings) *logExporter {
 	dataset := cfg.Dataset
 	namespace := cfg.Namespace
 	if cfg.MappingsSettings.Mode == MappingOTelV1.String() {
-		defaultPrefix = "otel-v1-logs"
+		defaultPrefix = otelV1LogsIndexAlias
 		dataset = ""
 		namespace = ""
 	}
@@ -80,8 +80,13 @@ func (l *logExporter) Start(ctx context.Context, host component.Host) error {
 	l.client = client
 
 	if l.config.MappingsSettings.ManageIndexTemplate {
-		tm := newTemplateManager(client, l.telemetry.Logger)
+		tm := newTemplateManager(client, l.telemetry.Logger, l.config.MappingsSettings.IndexTemplateFile)
 		tm.ensureTemplates(ctx)
+	}
+
+	if l.config.MappingsSettings.ISM.Enabled {
+		im := newISMManager(l.httpSettings.Endpoint, httpClient.Transport, client, l.config.MappingsSettings.ISM, l.telemetry.Logger)
+		im.setupISM(ctx, otelV1LogsIndexAlias)
 	}
 
 	return nil

--- a/exporter/opensearchexporter/sso_log_exporter.go
+++ b/exporter/opensearchexporter/sso_log_exporter.go
@@ -80,12 +80,18 @@ func (l *logExporter) Start(ctx context.Context, host component.Host) error {
 	l.client = client
 
 	if l.config.MappingsSettings.ManageIndexTemplate {
-		tm := newTemplateManager(client, l.telemetry.Logger, l.config.MappingsSettings.IndexTemplateFile)
+		tm, tmErr := newTemplateManager(client, l.telemetry.Logger, l.config.MappingsSettings.IndexTemplateFile)
+		if tmErr != nil {
+			return tmErr
+		}
 		tm.ensureTemplates(ctx)
 	}
 
 	if l.config.MappingsSettings.ISM.Enabled {
-		im := newISMManager(l.httpSettings.Endpoint, httpClient.Transport, client, l.config.MappingsSettings.ISM, l.telemetry.Logger)
+		im, imErr := newISMManager(l.httpSettings.Endpoint, httpClient.Transport, client, l.config.MappingsSettings.ISM, l.telemetry.Logger)
+		if imErr != nil {
+			return imErr
+		}
 		im.setupISM(ctx, otelV1LogsIndexAlias)
 	}
 

--- a/exporter/opensearchexporter/sso_trace_exporter.go
+++ b/exporter/opensearchexporter/sso_trace_exporter.go
@@ -40,7 +40,7 @@ func newSSOTracesExporter(cfg *Config, set exporter.Settings) *ssoTracesExporter
 	dataset := cfg.Dataset
 	namespace := cfg.Namespace
 	if cfg.MappingsSettings.Mode == MappingOTelV1.String() {
-		defaultPrefix = "otel-v1-apm-span"
+		defaultPrefix = otelV1SpanIndexAlias
 		dataset = ""
 		namespace = ""
 	}
@@ -71,8 +71,13 @@ func (s *ssoTracesExporter) Start(ctx context.Context, host component.Host) erro
 	s.client = client
 
 	if s.config.MappingsSettings.ManageIndexTemplate {
-		tm := newTemplateManager(client, s.telemetry.Logger)
+		tm := newTemplateManager(client, s.telemetry.Logger, s.config.MappingsSettings.IndexTemplateFile)
 		tm.ensureTemplates(ctx)
+	}
+
+	if s.config.MappingsSettings.ISM.Enabled {
+		im := newISMManager(s.httpSettings.Endpoint, httpClient.Transport, client, s.config.MappingsSettings.ISM, s.telemetry.Logger)
+		im.setupISM(ctx, otelV1SpanIndexAlias)
 	}
 
 	return nil

--- a/exporter/opensearchexporter/sso_trace_exporter.go
+++ b/exporter/opensearchexporter/sso_trace_exporter.go
@@ -71,12 +71,18 @@ func (s *ssoTracesExporter) Start(ctx context.Context, host component.Host) erro
 	s.client = client
 
 	if s.config.MappingsSettings.ManageIndexTemplate {
-		tm := newTemplateManager(client, s.telemetry.Logger, s.config.MappingsSettings.IndexTemplateFile)
+		tm, tmErr := newTemplateManager(client, s.telemetry.Logger, s.config.MappingsSettings.IndexTemplateFile)
+		if tmErr != nil {
+			return tmErr
+		}
 		tm.ensureTemplates(ctx)
 	}
 
 	if s.config.MappingsSettings.ISM.Enabled {
-		im := newISMManager(s.httpSettings.Endpoint, httpClient.Transport, client, s.config.MappingsSettings.ISM, s.telemetry.Logger)
+		im, imErr := newISMManager(s.httpSettings.Endpoint, httpClient.Transport, client, s.config.MappingsSettings.ISM, s.telemetry.Logger)
+		if imErr != nil {
+			return imErr
+		}
 		im.setupISM(ctx, otelV1SpanIndexAlias)
 	}
 

--- a/exporter/opensearchexporter/testdata/config.yaml
+++ b/exporter/opensearchexporter/testdata/config.yaml
@@ -26,6 +26,19 @@ opensearch/invalid_bulk_action:
   http:
     endpoint: https://opensearch.example.com:9200
 
+opensearch/otel_v1_ism:
+  http:
+    endpoint: https://opensearch.example.com:9200
+  mapping:
+    mode: otel-v1
+    manage_index_template: true
+    index_template_file: /etc/otelcol/otel-v1-overlay.json
+    ism:
+      enabled: true
+      rollover_min_size: 25gb
+      rollover_min_index_age: 12h
+      rollover_priority: 200
+
 opensearch/trace:
   dataset: ngnix
   namespace: eu


### PR DESCRIPTION
#### Description

Adds two opt-in capabilities to the OpenSearch exporter's otel-v1 mapping mode:

- **ISM rollover** (`mapping.ism.*`): on startup the exporter creates an Index State Management rollover policy plus an initial write-aliased index, so otel-v1 indices roll over by size/age instead of growing unbounded. Configurable `rollover_min_size`, `rollover_min_index_age`, `rollover_priority`, or a full custom `policy_file`.
- **Custom index mappings** (`mapping.index_template_file`): a user-supplied JSON overlay is deep-merged over the built-in otel-v1 index template, letting operators uplift attributes to typed fields or keep high-cardinality attributes un-indexed to avoid mapping explosion.

Both are gated on `mapping.mode: otel-v1`, default off, and are best-effort (they log and continue rather than failing `Start()`).

#### Link to tracking issue

Fixes #48585

#### Testing

Unit tests for config validation, template deep-merge, and the ISM policy builder/file loader. Integration tests (testcontainers, real OpenSearch) assert ISM policy + write alias + initial index and that a custom overlay is merged into the created template. Also manually sanity-tested against a running OpenSearch cluster.

#### Documentation

README updated with ISM and custom index-mapping sections (config keys, merge semantics, examples); `config.schema.yaml` regenerated.

#### Authorship

- [x] I, a human, wrote this pull request description myself. *(you must check this)*
