### PR TITLE
[chore][exporter/faro] Use confighttp defaults in tests

### DIFF
--- a/exporter/faroexporter/config_test.go
+++ b/exporter/faroexporter/config_test.go
@@ -35,10 +35,6 @@ func TestLoadConfig(t *testing.T) {
 
 func TestValidateConfig(t *testing.T) {
 	emptyEndpointClientConfig := confighttp.NewDefaultClientConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	emptyEndpointClientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-	emptyEndpointClientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
-	emptyEndpointClientConfig.ForceAttemptHTTP2 = false
 	emptyEndpointClientConfig.Endpoint = ""
 	cfg := &Config{
 		ClientConfig: emptyEndpointClientConfig,
@@ -46,10 +42,6 @@ func TestValidateConfig(t *testing.T) {
 	assert.Error(t, cfg.Validate())
 
 	validEndpointClientConfig := confighttp.NewDefaultClientConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	validEndpointClientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-	validEndpointClientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
-	validEndpointClientConfig.ForceAttemptHTTP2 = false
 	validEndpointClientConfig.Endpoint = "https://faro.example.com/collect"
 	cfg = &Config{
 		ClientConfig: validEndpointClientConfig,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adopted the confighttp client defaults instead of relying on zero values in tests

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Ran existing unit tests

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
