### PR TITLE
[processor/adaptive_tail_sampling] add initial sampling percentage for adaptive_throughput, fix windowed keep-all fallback

### DIFF
--- a/.chloggen/adaptivetailsampling-coldstart-windowed.yaml
+++ b/.chloggen/adaptivetailsampling-coldstart-windowed.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/adaptive_tail_sampling
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`adaptive_throughput` with `algorithm: windowed` kept 100% of traffic during cold start and for fingerprints it was not tracking (including `max_keys` overflow); it now samples them at `initial_sampling_percentage`."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50538]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The windowed sampler reports no rate for keys outside its computed window, and the
+  processor previously treated that as keep-everything. The `ema` algorithms are
+  unaffected; their `max_keys` overflow behavior still keeps overflow traffic and
+  needs upstream library support to change, tracked in the same issue.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/adaptivetailsampling-initial-sampling-percentage.yaml
+++ b/.chloggen/adaptivetailsampling-initial-sampling-percentage.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/adaptive_tail_sampling
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `initial_sampling_percentage` (default 10) to `adaptive_throughput`, making the cold-start sampling rate visible and configurable instead of a hidden library default.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50538]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  A throughput goal cannot be converted to a sample rate before any volume has been
+  observed, so the pre-warmup rate is an explicit bootstrap. The default matches the
+  previous behavior of the `ema` algorithm (keep 10%). `adaptive_percentage` is
+  unchanged: it already samples at the goal rate during cold start.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -283,15 +283,15 @@ observed. After warmup, a fingerprint the sampler has not yet learned is kept
 adjustment learns it.
 
 In practice this means a short smoke test right after startup keeps roughly the
-goal rate (`adaptive_percentage`) or the bootstrap percentage
-(`adaptive_throughput`), not everything; give the sampler at least one
+goal percentage (`adaptive_percentage`) or the bootstrap percentage
+(`adaptive_throughput`), not everything. Give the sampler at least one
 `adjustment_interval` (or one `lookback_frequency` window) of traffic before
 judging its rates.
 
 #### `max_keys` overflow
 
 When an `ema` sampler's key map is full, traffic for fingerprints beyond
-`max_keys` is kept at 100% rather than sampled toward the goal; the `windowed`
+`max_keys` is kept at 100% rather than sampled toward the goal. The `windowed`
 algorithm samples overflow traffic at `initial_sampling_percentage` instead. A
 fingerprint-cardinality explosion under the `ema` algorithms therefore
 increases output volume instead of degrading it, so size `max_keys` above your

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -274,29 +274,31 @@ faster to traffic shifts at the cost of more spike sensitivity, tuned with
 #### Cold start and unseen fingerprints
 
 The adaptive samplers need one adjustment cycle before they have per-fingerprint
-rates, and each behaves differently until then:
+rates. Until then, `adaptive_percentage` samples every trace at the goal rate,
+and `adaptive_throughput` (either algorithm) samples every trace at
+`initial_sampling_percentage` (default 10%), an explicit bootstrap because a
+throughput goal cannot be converted to a sample rate before any volume has been
+observed. After warmup, a fingerprint the sampler has not yet learned is kept
+(`ema` algorithms) or sampled at the bootstrap (`windowed`) until the next
+adjustment learns it.
 
-| Sampler | Before the first interval | Unseen fingerprint after warmup |
-| --- | --- | --- |
-| `adaptive_percentage` (`ema`) | samples every trace at the goal rate | kept (rate 1) until the next interval learns it |
-| `adaptive_throughput` (`ema`) | samples every trace at 1-in-10 (a library default, not derived from `goal_throughput`) | kept until learned |
-| `adaptive_throughput` (`windowed`) | keeps every trace | kept until the first lookback window completes |
-
-In practice this means a short smoke test right after startup may keep far less
-(or far more) than the configured goal; give the sampler at least one
+In practice this means a short smoke test right after startup keeps roughly the
+goal rate (`adaptive_percentage`) or the bootstrap percentage
+(`adaptive_throughput`), not everything; give the sampler at least one
 `adjustment_interval` (or one `lookback_frequency` window) of traffic before
-judging its rates. Aligning these behaviours is tracked in
-[#50538](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50538).
+judging its rates.
 
 #### `max_keys` overflow
 
-When a sampler's key map is full, traffic for fingerprints beyond `max_keys` is
-kept at 100% rather than sampled toward the goal, for every sampler and
-algorithm. A fingerprint-cardinality explosion therefore increases output
-volume instead of degrading it, so size `max_keys` above your expected
-fingerprint cardinality and alert on the `trace_span_count` and
-`decision_sample_rate` metrics if output volume grows unexpectedly. Changing
-the overflow behaviour to fall back to the goal rate is also tracked in
+When an `ema` sampler's key map is full, traffic for fingerprints beyond
+`max_keys` is kept at 100% rather than sampled toward the goal; the `windowed`
+algorithm samples overflow traffic at `initial_sampling_percentage` instead. A
+fingerprint-cardinality explosion under the `ema` algorithms therefore
+increases output volume instead of degrading it, so size `max_keys` above your
+expected fingerprint cardinality and alert on the `trace_span_count` and
+`decision_sample_rate` metrics if output volume grows unexpectedly. Falling
+back to the goal rate on `ema` overflow needs upstream library support and is
+tracked in
 [#50538](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50538).
 
 Migrating from Refinery: `DeterministicSampler` -> `probabilistic` (the same
@@ -341,6 +343,7 @@ Adjusts rates per key to hit a sustained volume budget in spans per second.
 sampler:
   type: adaptive_throughput
   goal_throughput: 100                    # target spans/sec per instance, across all keys
+  initial_sampling_percentage: 10         # % kept before rates are learned (default 10)
   fingerprint_attributes:
     - resource.attributes["service.name"]
     - span.attributes["http.status_code"]

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -271,6 +271,34 @@ default) smooths traffic with an exponential moving average, tuned with
 faster to traffic shifts at the cost of more spike sensitivity, tuned with
 `update_frequency` and `lookback_frequency`.
 
+#### Cold start and unseen fingerprints
+
+The adaptive samplers need one adjustment cycle before they have per-fingerprint
+rates, and each behaves differently until then:
+
+| Sampler | Before the first interval | Unseen fingerprint after warmup |
+| --- | --- | --- |
+| `adaptive_percentage` (`ema`) | samples every trace at the goal rate | kept (rate 1) until the next interval learns it |
+| `adaptive_throughput` (`ema`) | samples every trace at 1-in-10 (a library default, not derived from `goal_throughput`) | kept until learned |
+| `adaptive_throughput` (`windowed`) | keeps every trace | kept until the first lookback window completes |
+
+In practice this means a short smoke test right after startup may keep far less
+(or far more) than the configured goal; give the sampler at least one
+`adjustment_interval` (or one `lookback_frequency` window) of traffic before
+judging its rates. Aligning these behaviours is tracked in
+[#50538](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50538).
+
+#### `max_keys` overflow
+
+When a sampler's key map is full, traffic for fingerprints beyond `max_keys` is
+kept at 100% rather than sampled toward the goal, for every sampler and
+algorithm. A fingerprint-cardinality explosion therefore increases output
+volume instead of degrading it, so size `max_keys` above your expected
+fingerprint cardinality and alert on the `trace_span_count` and
+`decision_sample_rate` metrics if output volume grows unexpectedly. Changing
+the overflow behaviour to fall back to the goal rate is also tracked in
+[#50538](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50538).
+
 Migrating from Refinery: `DeterministicSampler` -> `probabilistic` (the same
 hash-consistent fixed fraction), `EMADynamicSampler` -> `adaptive_percentage`
 (note Refinery's `GoalSampleRate: N` means keep 1-in-N, so `GoalSampleRate: 5`

--- a/processor/adaptivetailsamplingprocessor/config.go
+++ b/processor/adaptivetailsamplingprocessor/config.go
@@ -237,6 +237,15 @@ type SamplerConfig struct {
 	// Used by: adaptive_throughput.
 	GoalThroughput int `mapstructure:"goal_throughput"`
 
+	// InitialSamplingPercentage is the percentage of traces kept before the
+	// sampler has learned per-fingerprint rates: during the first adjustment
+	// cycle after start, and (windowed algorithm) for fingerprints the
+	// sampler has no computed rate for, including max_keys overflow. A
+	// throughput goal cannot be converted to a sample rate without observed
+	// volume, so the bootstrap is explicit. Defaults to 10 (keep 10%).
+	// Used by: adaptive_throughput.
+	InitialSamplingPercentage float64 `mapstructure:"initial_sampling_percentage"`
+
 	// FingerprintAttributes is the list of scoped attribute selectors that
 	// identify what kind of trace this is for sampling purposes. Each entry
 	// has the form `<scope>.attributes["<name>"]` where scope is one of
@@ -455,18 +464,22 @@ func (s *SamplerConfig) validate(ruleName string) error {
 		if s.MaxKeys < 0 {
 			return fmt.Errorf("rule %q: max_keys must be non-negative", ruleName)
 		}
+		if s.InitialSamplingPercentage < 0 || s.InitialSamplingPercentage > 100 {
+			return fmt.Errorf("rule %q: initial_sampling_percentage must be in (0, 100], or 0 for the default", ruleName)
+		}
 		switch s.effectiveAlgorithm() {
 		case AlgorithmEMA:
 			if s.Weight < 0 || s.Weight >= 1 {
 				return fmt.Errorf("rule %q: weight must be in [0, 1)", ruleName)
 			}
 			return s.rejectUnusedFields(ruleName, "adaptive_throughput (ema)", map[string]bool{
-				"algorithm":              true,
-				"goal_throughput":        true,
-				"fingerprint_attributes": true,
-				"max_keys":               true,
-				"adjustment_interval":    true,
-				"weight":                 true,
+				"algorithm":                   true,
+				"goal_throughput":             true,
+				"initial_sampling_percentage": true,
+				"fingerprint_attributes":      true,
+				"max_keys":                    true,
+				"adjustment_interval":         true,
+				"weight":                      true,
 			})
 		case AlgorithmWindowed:
 			if s.UpdateFrequency < 0 {
@@ -476,12 +489,13 @@ func (s *SamplerConfig) validate(ruleName string) error {
 				return fmt.Errorf("rule %q: lookback_frequency must be non-negative", ruleName)
 			}
 			return s.rejectUnusedFields(ruleName, "adaptive_throughput (windowed)", map[string]bool{
-				"algorithm":              true,
-				"goal_throughput":        true,
-				"fingerprint_attributes": true,
-				"max_keys":               true,
-				"update_frequency":       true,
-				"lookback_frequency":     true,
+				"algorithm":                   true,
+				"goal_throughput":             true,
+				"initial_sampling_percentage": true,
+				"fingerprint_attributes":      true,
+				"max_keys":                    true,
+				"update_frequency":            true,
+				"lookback_frequency":          true,
 			})
 		default:
 			return fmt.Errorf("rule %q: unknown algorithm %q (must be %q or %q)", ruleName, s.Algorithm, AlgorithmEMA, AlgorithmWindowed)
@@ -521,6 +535,9 @@ func (s *SamplerConfig) rejectUnusedFields(ruleName, typeName string, allowed ma
 		return err
 	}
 	if err := set("goal_throughput", s.GoalThroughput != 0); err != nil {
+		return err
+	}
+	if err := set("initial_sampling_percentage", s.InitialSamplingPercentage != 0); err != nil {
 		return err
 	}
 	if err := set("fingerprint_attributes", len(s.FingerprintAttributes) > 0); err != nil {

--- a/processor/adaptivetailsamplingprocessor/config.go
+++ b/processor/adaptivetailsamplingprocessor/config.go
@@ -242,9 +242,10 @@ type SamplerConfig struct {
 	// cycle after start, and (windowed algorithm) for fingerprints the
 	// sampler has no computed rate for, including max_keys overflow. A
 	// throughput goal cannot be converted to a sample rate without observed
-	// volume, so the bootstrap is explicit. Defaults to 10 (keep 10%).
-	// Used by: adaptive_throughput.
-	InitialSamplingPercentage float64 `mapstructure:"initial_sampling_percentage"`
+	// volume, so the bootstrap is explicit. Omit for the default of 10
+	// (keep 10%); supplied values must be in (0, 100] like every other
+	// percentage. Used by: adaptive_throughput.
+	InitialSamplingPercentage *float64 `mapstructure:"initial_sampling_percentage"`
 
 	// FingerprintAttributes is the list of scoped attribute selectors that
 	// identify what kind of trace this is for sampling purposes. Each entry
@@ -464,8 +465,8 @@ func (s *SamplerConfig) validate(ruleName string) error {
 		if s.MaxKeys < 0 {
 			return fmt.Errorf("rule %q: max_keys must be non-negative", ruleName)
 		}
-		if s.InitialSamplingPercentage < 0 || s.InitialSamplingPercentage > 100 {
-			return fmt.Errorf("rule %q: initial_sampling_percentage must be in (0, 100], or 0 for the default", ruleName)
+		if s.InitialSamplingPercentage != nil && (*s.InitialSamplingPercentage <= 0 || *s.InitialSamplingPercentage > 100) {
+			return fmt.Errorf("rule %q: initial_sampling_percentage must be in (0, 100]", ruleName)
 		}
 		switch s.effectiveAlgorithm() {
 		case AlgorithmEMA:
@@ -537,7 +538,7 @@ func (s *SamplerConfig) rejectUnusedFields(ruleName, typeName string, allowed ma
 	if err := set("goal_throughput", s.GoalThroughput != 0); err != nil {
 		return err
 	}
-	if err := set("initial_sampling_percentage", s.InitialSamplingPercentage != 0); err != nil {
+	if err := set("initial_sampling_percentage", s.InitialSamplingPercentage != nil); err != nil {
 		return err
 	}
 	if err := set("fingerprint_attributes", len(s.FingerprintAttributes) > 0); err != nil {

--- a/processor/adaptivetailsamplingprocessor/config_test.go
+++ b/processor/adaptivetailsamplingprocessor/config_test.go
@@ -211,11 +211,24 @@ func TestConfig_Validate(t *testing.T) {
 				Sampler: SamplerConfig{
 					Type:                      AdaptiveThroughput,
 					GoalThroughput:            100,
-					InitialSamplingPercentage: 25,
+					InitialSamplingPercentage: new(25.0),
 					FingerprintAttributes:     []string{`resource.attributes["service.name"]`},
 					Weight:                    0.5,
 				},
 			}),
+		},
+		{
+			name: "adaptive_throughput_initial_sampling_percentage_zero_rejected",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                      AdaptiveThroughput,
+					GoalThroughput:            100,
+					InitialSamplingPercentage: new(0.0),
+					FingerprintAttributes:     []string{`resource.attributes["service.name"]`},
+				},
+			}),
+			wantErr: "initial_sampling_percentage must be in (0, 100]",
 		},
 		{
 			name: "adaptive_throughput_initial_sampling_percentage_too_high",
@@ -224,7 +237,7 @@ func TestConfig_Validate(t *testing.T) {
 				Sampler: SamplerConfig{
 					Type:                      AdaptiveThroughput,
 					GoalThroughput:            100,
-					InitialSamplingPercentage: 101,
+					InitialSamplingPercentage: new(101.0),
 					FingerprintAttributes:     []string{`resource.attributes["service.name"]`},
 				},
 			}),
@@ -237,7 +250,7 @@ func TestConfig_Validate(t *testing.T) {
 				Sampler: SamplerConfig{
 					Type:                      AdaptivePercentage,
 					GoalPercentage:            10,
-					InitialSamplingPercentage: 25,
+					InitialSamplingPercentage: new(25.0),
 					FingerprintAttributes:     []string{`resource.attributes["service.name"]`},
 				},
 			}),

--- a/processor/adaptivetailsamplingprocessor/config_test.go
+++ b/processor/adaptivetailsamplingprocessor/config_test.go
@@ -205,6 +205,45 @@ func TestConfig_Validate(t *testing.T) {
 			}),
 		},
 		{
+			name: "valid_adaptive_throughput_with_initial_sampling_percentage",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                      AdaptiveThroughput,
+					GoalThroughput:            100,
+					InitialSamplingPercentage: 25,
+					FingerprintAttributes:     []string{`resource.attributes["service.name"]`},
+					Weight:                    0.5,
+				},
+			}),
+		},
+		{
+			name: "adaptive_throughput_initial_sampling_percentage_too_high",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                      AdaptiveThroughput,
+					GoalThroughput:            100,
+					InitialSamplingPercentage: 101,
+					FingerprintAttributes:     []string{`resource.attributes["service.name"]`},
+				},
+			}),
+			wantErr: "initial_sampling_percentage must be in (0, 100]",
+		},
+		{
+			name: "initial_sampling_percentage_rejected_on_adaptive_percentage",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                      AdaptivePercentage,
+					GoalPercentage:            10,
+					InitialSamplingPercentage: 25,
+					FingerprintAttributes:     []string{`resource.attributes["service.name"]`},
+				},
+			}),
+			wantErr: "adaptive_percentage does not use initial_sampling_percentage",
+		},
+		{
 			name: "adaptive_throughput_invalid_weight",
 			cfg: baseCfg(RuleConfig{
 				Name: "r",

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/sampler.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/sampler.go
@@ -78,11 +78,18 @@ type dynsamplerImpl interface {
 // interface. Start/Stop are guarded by sync.Once so they are safe to call
 // multiple times.
 type dynsamplerWrapper struct {
-	inner     dynsamplerImpl
-	startOnce sync.Once
-	startErr  error
-	stopOnce  sync.Once
-	stopErr   error
+	inner dynsamplerImpl
+	// fallbackRate is applied when the inner sampler has no rate for a key
+	// and signals it by returning a non-positive rate. The windowed
+	// throughput sampler does this during cold start and for keys it is not
+	// tracking (including max_keys overflow); without the fallback those
+	// traces would all be kept. The EMA samplers return their own bootstrap
+	// rates instead, so the fallback never fires for them.
+	fallbackRate int
+	startOnce    sync.Once
+	startErr     error
+	stopOnce     sync.Once
+	stopErr      error
 }
 
 // GetSampleRate implements Sampler.
@@ -90,7 +97,11 @@ func (w *dynsamplerWrapper) GetSampleRate(key string, spanCount int) int {
 	if spanCount <= 0 {
 		spanCount = 1
 	}
-	return max(w.inner.GetSampleRateMulti(key, spanCount), 1)
+	rate := w.inner.GetSampleRateMulti(key, spanCount)
+	if rate <= 0 {
+		return max(w.fallbackRate, 1)
+	}
+	return rate
 }
 
 // Start implements Sampler.
@@ -126,6 +137,7 @@ func NewEMAPercentage(cfg EMAPercentageConfig) (Sampler, error) {
 			Weight:                     cfg.Weight,
 			MaxKeys:                    cfg.MaxKeys,
 		},
+		fallbackRate: goalRate,
 	}, nil
 }
 
@@ -152,6 +164,7 @@ func NewEMAThroughput(cfg EMAThroughputConfig) (Sampler, error) {
 			Weight:               cfg.Weight,
 			MaxKeys:              cfg.MaxKeys,
 		},
+		fallbackRate: cfg.InitialSamplingRate,
 	}, nil
 }
 
@@ -160,6 +173,7 @@ func NewEMAThroughput(cfg EMAThroughputConfig) (Sampler, error) {
 // lookback window.
 type WindowedThroughputConfig struct {
 	GoalThroughputPerSec float64
+	InitialSamplingRate  int
 	UpdateFrequency      time.Duration
 	LookbackFrequency    time.Duration
 	MaxKeys              int
@@ -170,6 +184,9 @@ func NewWindowedThroughput(cfg WindowedThroughputConfig) (Sampler, error) {
 	if cfg.GoalThroughputPerSec <= 0 {
 		return nil, errors.New("adaptive_throughput (windowed) sampler: goal_throughput must be greater than zero")
 	}
+	// The windowed sampler has no bootstrap rate of its own: it returns 0 for
+	// any key it has no computed rate for, which the wrapper's fallback maps
+	// to InitialSamplingRate.
 	return &dynsamplerWrapper{
 		inner: &dynsampler.WindowedThroughput{
 			GoalThroughputPerSec:      cfg.GoalThroughputPerSec,
@@ -177,5 +194,6 @@ func NewWindowedThroughput(cfg WindowedThroughputConfig) (Sampler, error) {
 			LookbackFrequencyDuration: cfg.LookbackFrequency,
 			MaxKeys:                   cfg.MaxKeys,
 		},
+		fallbackRate: cfg.InitialSamplingRate,
 	}, nil
 }

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/sampler_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/sampler_test.go
@@ -111,6 +111,41 @@ func TestWindowedThroughput_InvalidGoal(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// zeroRateSampler stands in for the windowed throughput sampler's behavior of
+// returning 0 for keys it has no computed rate for (cold start, untracked
+// keys, max_keys overflow).
+type zeroRateSampler struct{}
+
+func (zeroRateSampler) Start() error                       { return nil }
+func (zeroRateSampler) Stop() error                        { return nil }
+func (zeroRateSampler) GetSampleRateMulti(string, int) int { return 0 }
+
+func TestDynsamplerWrapper_FallbackRateOnZero(t *testing.T) {
+	w := &dynsamplerWrapper{inner: zeroRateSampler{}, fallbackRate: 10}
+	assert.Equal(t, 10, w.GetSampleRate("any-key", 1),
+		"a non-positive inner rate must map to the bootstrap rate, not keep-everything")
+
+	// An unset fallback still never returns a non-positive rate.
+	w = &dynsamplerWrapper{inner: zeroRateSampler{}}
+	assert.Equal(t, 1, w.GetSampleRate("any-key", 1))
+}
+
+func TestWindowedThroughput_ColdStartUsesInitialRate(t *testing.T) {
+	s, err := NewWindowedThroughput(WindowedThroughputConfig{
+		GoalThroughputPerSec: 100,
+		InitialSamplingRate:  10,
+		UpdateFrequency:      time.Second,
+		LookbackFrequency:    30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.Start())
+	t.Cleanup(func() { _ = s.Stop() })
+
+	// Before the first lookback window completes, the library has no rate for
+	// any key; the wrapper must apply the bootstrap instead of keeping all.
+	assert.Equal(t, 10, s.GetSampleRate("svc-a", 1))
+}
+
 func TestDynsamplerWrapper_StopIsIdempotent(t *testing.T) {
 	samplers := []func() (Sampler, error){
 		func() (Sampler, error) {

--- a/processor/adaptivetailsamplingprocessor/processor.go
+++ b/processor/adaptivetailsamplingprocessor/processor.go
@@ -266,9 +266,9 @@ func newSamplerForRule(rc *RuleConfig) (sampler.Sampler, []sampler.Selector, err
 		// A throughput goal cannot be converted to a sample rate without
 		// observed volume, so the pre-warmup rate comes from the explicit
 		// initial_sampling_percentage bootstrap (default 10%, i.e. 1-in-10).
-		initialPct := sc.InitialSamplingPercentage
-		if initialPct == 0 {
-			initialPct = 10
+		initialPct := 10.0
+		if sc.InitialSamplingPercentage != nil {
+			initialPct = *sc.InitialSamplingPercentage
 		}
 		initialRate := max(int(100.0/initialPct), 1)
 		var s sampler.Sampler

--- a/processor/adaptivetailsamplingprocessor/processor.go
+++ b/processor/adaptivetailsamplingprocessor/processor.go
@@ -263,11 +263,20 @@ func newSamplerForRule(rc *RuleConfig) (sampler.Sampler, []sampler.Selector, err
 		selectors, err := sampler.ParseSelectors(sc.FingerprintAttributes)
 		return s, selectors, err
 	case AdaptiveThroughput:
+		// A throughput goal cannot be converted to a sample rate without
+		// observed volume, so the pre-warmup rate comes from the explicit
+		// initial_sampling_percentage bootstrap (default 10%, i.e. 1-in-10).
+		initialPct := sc.InitialSamplingPercentage
+		if initialPct == 0 {
+			initialPct = 10
+		}
+		initialRate := max(int(100.0/initialPct), 1)
 		var s sampler.Sampler
 		var err error
 		if sc.effectiveAlgorithm() == AlgorithmWindowed {
 			s, err = sampler.NewWindowedThroughput(sampler.WindowedThroughputConfig{
 				GoalThroughputPerSec: float64(sc.GoalThroughput),
+				InitialSamplingRate:  initialRate,
 				UpdateFrequency:      sc.UpdateFrequency,
 				LookbackFrequency:    sc.LookbackFrequency,
 				MaxKeys:              sc.MaxKeys,
@@ -275,6 +284,7 @@ func newSamplerForRule(rc *RuleConfig) (sampler.Sampler, []sampler.Selector, err
 		} else {
 			s, err = sampler.NewEMAThroughput(sampler.EMAThroughputConfig{
 				GoalThroughputPerSec: sc.GoalThroughput,
+				InitialSamplingRate:  initialRate,
 				AdjustmentInterval:   sc.AdjustmentInterval,
 				Weight:               sc.Weight,
 				MaxKeys:              sc.MaxKeys,


### PR DESCRIPTION
#### Description

Implements the processor-side half of #50538. `adaptive_throughput` gets an explicit `initial_sampling_percentage` (default 10, the same value the hidden dynsampler default applied), used before per-fingerprint rates are learned. The windowed algorithm reports no rate for keys outside its computed window, and the processor treated that as keep everything. The wrapper now maps a non-positive rate to the bootstrap, so windowed cold start, unseen fingerprints, and `max_keys` overflow sample at the configured percentage instead of keeping 100%. `adaptive_percentage` is unchanged, it already samples at the goal rate during cold start.

`max_keys` overflow on the `ema` algorithms still keeps overflow traffic. Those samplers return rate 1 for untracked keys, which the wrapper can't tell apart from a learned rate of 1, so that half needs a dynsampler-go API and stays tracked in #50538.

#### Link to tracking issue

Refs #50538

#### Testing

- Wrapper fallback unit tests (a non-positive inner rate maps to the bootstrap), and windowed cold start returns the configured rate
- Config validation for the new field, range checks and rejection on non-throughput samplers
- README example tests cover the updated config block, and the full module suite and lint pass

#### Documentation

- README `adaptive_throughput` config block updated, and the cold-start and `max_keys` sections added, written for the new behaviour
- Two changelog entries, a bug_fix for the windowed fallback and an enhancement for the new config field

#### Authorship

- [x] I, a human, wrote this pull request description myself.

