### PR TITLE
[exporter/elasticsearch] reduce ECS encode CPU and allocations

### DIFF
--- a/exporter/elasticsearchexporter/benchmark_test.go
+++ b/exporter/elasticsearchexporter/benchmark_test.go
@@ -19,9 +19,9 @@ const benchECSBatch = 32
 
 func BenchmarkEncodeECS(b *testing.B) {
 	// Measures ECS encode time and allocs for logs and spans. Cases cover a
-	// small resource (2 attributes) and a large resource. Resource and scope
-	// are mapped once per batch. The cache is reset every benchECSBatch
-	// records.
+	// small resource (2 attributes) and a large resource. A new encoding
+	// context is created every benchECSBatch records, matching one
+	// Resource+Scope batch in the exporter.
 	encoder, err := newEncoder(MappingECS)
 	require.NoError(b, err)
 	scope := pcommon.NewInstrumentationScope()
@@ -66,13 +66,13 @@ func BenchmarkEncodeECS(b *testing.B) {
 	for _, tc := range encodes {
 		for _, rc := range resources {
 			b.Run(tc.name+"/"+rc.name, func(b *testing.B) {
-				ec := encodingContext{resource: rc.resource, scope: scope}
+				ec := benchECSEncodingContext(rc.resource, scope)
 				var buf bytes.Buffer
 				b.ReportAllocs()
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					if i%benchECSBatch == 0 {
-						ec.ecsBase = &ecsAttributeBase{}
+						ec = benchECSEncodingContext(rc.resource, scope)
 					}
 					buf.Reset()
 					if err := tc.encode(ec, i%benchECSBatch, &buf); err != nil {
@@ -81,6 +81,14 @@ func BenchmarkEncodeECS(b *testing.B) {
 				}
 			})
 		}
+	}
+}
+
+func benchECSEncodingContext(resource pcommon.Resource, scope pcommon.InstrumentationScope) encodingContext {
+	return encodingContext{
+		resource: resource,
+		scope:    scope,
+		ecsDoc:   newECSDocument(MappingECS),
 	}
 }
 

--- a/exporter/elasticsearchexporter/benchmark_test.go
+++ b/exporter/elasticsearchexporter/benchmark_test.go
@@ -1,0 +1,133 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package elasticsearchexporter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/elasticsearch"
+)
+
+const benchECSBatch = 32
+
+func BenchmarkEncodeECS(b *testing.B) {
+	// Measures ECS encode time and allocs for logs and spans. Cases cover a
+	// small resource (2 attributes) and a large resource. Resource and scope
+	// are mapped once per batch. The cache is reset every benchECSBatch
+	// records.
+	encoder, err := newEncoder(MappingECS)
+	require.NoError(b, err)
+	scope := pcommon.NewInstrumentationScope()
+	scope.Attributes().PutStr("otel.scope.name", "go.opentelemetry.io/contrib/instrumentation/net/http")
+	scope.Attributes().PutStr("otel.scope.version", "0.49.0")
+	logs := benchECSLogRecords(benchECSBatch)
+	spans := benchECSSpans(benchECSBatch)
+	logIdx := elasticsearch.NewDataStreamIndex("logs", "app", "default")
+	traceIdx := elasticsearch.NewDataStreamIndex("traces", "app", "default")
+
+	resources := []struct {
+		name     string
+		resource pcommon.Resource
+	}{
+		{
+			name:     "small",
+			resource: benchECSSmallResource(),
+		},
+		{
+			name:     "large",
+			resource: ecsModeResource(b),
+		},
+	}
+	encodes := []struct {
+		name   string
+		encode func(ec encodingContext, i int, buf *bytes.Buffer) error
+	}{
+		{
+			name: "log",
+			encode: func(ec encodingContext, i int, buf *bytes.Buffer) error {
+				return encoder.encodeLog(ec, logs[i], logIdx, buf)
+			},
+		},
+		{
+			name: "span",
+			encode: func(ec encodingContext, i int, buf *bytes.Buffer) error {
+				return encoder.encodeSpan(ec, spans[i], traceIdx, buf)
+			},
+		},
+	}
+
+	for _, tc := range encodes {
+		for _, rc := range resources {
+			b.Run(tc.name+"/"+rc.name, func(b *testing.B) {
+				ec := encodingContext{resource: rc.resource, scope: scope}
+				var buf bytes.Buffer
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if i%benchECSBatch == 0 {
+						ec.ecsBase = &ecsAttributeBase{}
+					}
+					buf.Reset()
+					if err := tc.encode(ec, i%benchECSBatch, &buf); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func benchECSSmallResource() pcommon.Resource {
+	r := pcommon.NewResource()
+	r.Attributes().PutStr("service.name", "api")
+	r.Attributes().PutStr("deployment.environment", "prod")
+	return r
+}
+
+func benchECSLogRecords(n int) []plog.LogRecord {
+	records := make([]plog.LogRecord, n)
+	for i := range records {
+		rec := plog.NewLogRecord()
+		rec.SetTimestamp(1710273639345678901)
+		rec.SetObservedTimestamp(1710273641123456789)
+		rec.SetSeverityText("INFO")
+		rec.SetSeverityNumber(plog.SeverityNumberInfo)
+		rec.Body().SetStr("request completed")
+		rec.Attributes().PutStr("event.name", "http.request")
+		rec.Attributes().PutStr("http.request.method", "GET")
+		rec.Attributes().PutInt("http.response.status_code", 200)
+		rec.Attributes().PutStr("url.path", "/v1/users")
+		rec.Attributes().PutInt("http.response.body.size", int64(512+i))
+		records[i] = rec
+	}
+	return records
+}
+
+func benchECSSpans(n int) []ptrace.Span {
+	spans := make([]ptrace.Span, n)
+	var tid pcommon.TraceID
+	tid[0] = 1
+	for i := range spans {
+		sp := ptrace.NewSpan()
+		sp.SetTraceID(tid)
+		var sid pcommon.SpanID
+		sid[0] = byte(i + 1)
+		sp.SetSpanID(sid)
+		sp.SetName("GET /v1/users")
+		sp.SetKind(ptrace.SpanKindServer)
+		sp.SetStartTimestamp(1710273639345678901)
+		sp.SetEndTimestamp(1710273641123456789)
+		sp.Status().SetCode(ptrace.StatusCodeOk)
+		sp.Attributes().PutStr("http.request.method", "GET")
+		sp.Attributes().PutInt("http.response.status_code", 200)
+		spans[i] = sp
+	}
+	return spans
+}

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -127,6 +127,7 @@ func (e *elasticsearchExporter) pushLogsData(ctx context.Context, ld plog.Logs) 
 				resourceSchemaURL: rl.SchemaUrl(),
 				scope:             scope,
 				scopeSchemaURL:    ill.SchemaUrl(),
+				ecsBase:           newECSAttributeBase(mappingMode),
 			}
 
 			for _, lr := range ill.LogRecords().All() {
@@ -393,6 +394,7 @@ func (e *elasticsearchExporter) pushTraceData(
 				resourceSchemaURL: il.SchemaUrl(),
 				scope:             scope,
 				scopeSchemaURL:    scopeSpan.SchemaUrl(),
+				ecsBase:           newECSAttributeBase(mappingMode),
 			}
 
 			for _, span := range scopeSpan.Spans().All() {

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -127,7 +127,7 @@ func (e *elasticsearchExporter) pushLogsData(ctx context.Context, ld plog.Logs) 
 				resourceSchemaURL: rl.SchemaUrl(),
 				scope:             scope,
 				scopeSchemaURL:    ill.SchemaUrl(),
-				ecsBase:           newECSAttributeBase(mappingMode),
+				ecsDoc:            newECSDocument(mappingMode),
 			}
 
 			for _, lr := range ill.LogRecords().All() {
@@ -394,7 +394,7 @@ func (e *elasticsearchExporter) pushTraceData(
 				resourceSchemaURL: il.SchemaUrl(),
 				scope:             scope,
 				scopeSchemaURL:    scopeSpan.SchemaUrl(),
-				ecsBase:           newECSAttributeBase(mappingMode),
+				ecsDoc:            newECSDocument(mappingMode),
 			}
 
 			for _, span := range scopeSpan.Spans().All() {

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -115,26 +115,10 @@ func DocumentFromAttributesWithPath(path string, am pcommon.Map) Document {
 	return Document{fields: fields}
 }
 
-func cloneDocument(src Document) Document {
-	fields := make([]field, len(src.fields))
-	for i := range src.fields {
-		fields[i] = field{key: src.fields[i].key, value: cloneValue(src.fields[i].value)}
-	}
-	return Document{fields: fields, dynamicTemplates: maps.Clone(src.dynamicTemplates)}
-}
-
-func cloneValue(v Value) Value {
-	switch v.kind {
-	case KindArr:
-		arr := make([]Value, len(v.arr))
-		for i := range v.arr {
-			arr[i] = cloneValue(v.arr[i])
-		}
-		v.arr = arr
-	case KindObject, KindUnflattenableObject:
-		v.doc = cloneDocument(v.doc)
-	}
-	return v
+func (doc *Document) Clone() *Document {
+	fields := make([]field, len(doc.fields))
+	copy(fields, doc.fields)
+	return &Document{fields: fields, dynamicTemplates: maps.Clone(doc.dynamicTemplates)}
 }
 
 func (doc *Document) AddDynamicTemplate(path, template string) {
@@ -146,6 +130,18 @@ func (doc *Document) AddDynamicTemplate(path, template string) {
 
 func (doc *Document) DynamicTemplates() map[string]string {
 	return doc.dynamicTemplates
+}
+
+// Grow increases the field-slice capacity so at least n more fields can be
+// appended without another allocation. It matches slices.Grow.
+func (doc *Document) Grow(n int) {
+	doc.fields = slices.Grow(doc.fields, n)
+}
+
+// Reset truncates fields and drops dynamic templates. Capacity is kept.
+func (doc *Document) Reset() {
+	doc.fields = doc.fields[:0]
+	doc.dynamicTemplates = nil
 }
 
 // AddTimestamp adds a raw timestamp value to the Document.
@@ -235,8 +231,7 @@ func (doc *Document) AddLinks(key string, links ptrace.SpanLinkSlice) {
 	doc.Add(key, ArrValue(linkValues...))
 }
 
-// Sort stably sorts document keys, including nested objects.
-func (doc *Document) Sort() {
+func (doc *Document) sort() {
 	slices.SortStableFunc(doc.fields, func(a, b field) int {
 		return strings.Compare(a.key, b.key)
 	})
@@ -250,67 +245,29 @@ func (doc *Document) Sort() {
 // Dedup removes fields from the document, that have duplicate keys.
 // The filtering only keeps the last value for a key.
 // protectedSet is an optional map of field paths that should never get .value suffix.
-// Dedup ensures that keys are sorted.
+// Dedup ensure that keys are sorted.
 func (doc *Document) Dedup(protectedSet map[string]struct{}) {
-	doc.Sort()
-	doc.dedupSorted(protectedSet)
-}
+	// 1. Always ensure the fields are sorted, Dedup support requires
+	// Fields to be sorted.
+	doc.sort()
 
-// assembleFromSortedBase merges a sorted base with extra, then runs Dedup
-// without sorting the concatenated document. On equal keys the merge emits
-// the base field first so last-wins still keeps extra. extra is sorted in
-// place. Nested object and array values from base are cloned.
-// Dynamic templates are copied from base only. extra.dynamicTemplates are dropped.
-func assembleFromSortedBase(base, extra Document, protectedSet map[string]struct{}) Document {
-	extra.Sort()
-	out := Document{
-		fields:           mergeSortedFields(base.fields, extra.fields),
-		dynamicTemplates: maps.Clone(base.dynamicTemplates),
-	}
-	out.dedupSorted(protectedSet)
-	return out
-}
-
-func mergeSortedFields(base, extra []field) []field {
-	out := make([]field, 0, len(base)+len(extra))
-	i, j := 0, 0
-	for i < len(base) && j < len(extra) {
-		if strings.Compare(base[i].key, extra[j].key) <= 0 {
-			out = append(out, field{key: base[i].key, value: cloneValue(base[i].value)})
-			i++
-			continue
-		}
-		out = append(out, extra[j])
-		j++
-	}
-	for ; i < len(base); i++ {
-		out = append(out, field{key: base[i].key, value: cloneValue(base[i].value)})
-	}
-	return append(out, extra[j:]...)
-}
-
-func (doc *Document) dedupSorted(protectedSet map[string]struct{}) {
-	// 1. Rename fields if a primitive value is overwritten by an object,
+	// 2. rename fields if a primitive value is overwritten by an object,
 	//    EXCEPT for protected fields (well-defined schema fields like ECS).
 	//    For example the pair (path.x=1, path.x.a="test") becomes:
 	//    (path.x.value=1, path.x.a="test").
 	//
-	//    However, if path.x is a protected field, we skip the renaming and
-	//    instead remove the conflicting nested field (path.x.a) to preserve
-	//    the protected field.
+	//    However, if path.x is a protected field, we skip the renaming and instead
+	//    remove the conflicting nested field (path.x.a) to preserve the protected field.
 	//
 	//    NOTE: We do the renaming, in order to preserve the original value
-	//    in case of conflicts after dedotting, which would lead to the
-	//    removal of the field. For example docker/k8s labels tend to use
-	//    `.`, which need to be handled in case the collector does pass us
-	//    these kind of labels as an AttributeMap.
+	//    in case of conflicts after dedotting, which would lead to the removal of the field.
+	//    For example docker/k8s labels tend to use `.`, which need to be handled in case
+	//    The collector does pass us these kind of labels as an AttributeMap.
 	//
-	//    NOTE: If the embedded document already has a field name `value`, we
-	//    will remove the renamed field in favor of the `value` field in the
-	//    document.
+	//    NOTE: If the embedded document already has a field name `value`, we will remove the renamed
+	//    field in favor of the `value` field in the document.
 	//
-	//    This step removes potential conflicts when dedotting and serializing
-	//    fields.
+	//    This step removes potential conflicts when dedotting and serializing fields.
 	var renamed bool
 	for i := 0; i < len(doc.fields)-1; i++ {
 		key, nextKey := doc.fields[i].key, doc.fields[i+1].key
@@ -332,10 +289,10 @@ func (doc *Document) dedupSorted(protectedSet map[string]struct{}) {
 		}
 	}
 	if renamed {
-		doc.Sort()
+		doc.sort()
 	}
 
-	// 2. mark duplicates as 'ignore'
+	// 3. mark duplicates as 'ignore'
 	//
 	//    This step ensures that we do not have duplicate fields names when serializing.
 	//    Elasticsearch JSON parser will fail otherwise.
@@ -345,7 +302,7 @@ func (doc *Document) dedupSorted(protectedSet map[string]struct{}) {
 		}
 	}
 
-	// 3. fix objects that might be stored in arrays
+	// 4. fix objects that might be stored in arrays
 	for i := range doc.fields {
 		doc.fields[i].value.Dedup(protectedSet)
 	}
@@ -364,18 +321,6 @@ func newJSONVisitor(w io.Writer) *json.Visitor {
 // serialization.
 func (doc *Document) Serialize(w io.Writer, dedot bool, protectedSet map[string]struct{}) error {
 	doc.Dedup(protectedSet)
-	return doc.writeJSON(w, dedot)
-}
-
-// SerializeFromSortedBase merges a sorted base with extra, then writes JSON.
-// It does not run Dedup a second time. extra is sorted in place.
-func SerializeFromSortedBase(base, extra Document, protectedSet map[string]struct{}, w io.Writer, dedot bool) error {
-	doc := assembleFromSortedBase(base, extra, protectedSet)
-	return doc.writeJSON(w, dedot)
-}
-
-// writeJSON writes the document without Dedup. Fields must already be prepared.
-func (doc *Document) writeJSON(w io.Writer, dedot bool) error {
 	v := newJSONVisitor(w)
 	return doc.iterJSON(v, dedot)
 }
@@ -565,7 +510,7 @@ func ValueFromAttribute(attr pcommon.Value) Value {
 func (v *Value) sort() {
 	switch v.kind {
 	case KindObject:
-		v.doc.Sort()
+		v.doc.sort()
 	case KindArr:
 		for i := range v.arr {
 			v.arr[i].sort()

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -115,10 +115,26 @@ func DocumentFromAttributesWithPath(path string, am pcommon.Map) Document {
 	return Document{fields: fields}
 }
 
-func (doc *Document) Clone() *Document {
-	fields := make([]field, len(doc.fields))
-	copy(fields, doc.fields)
-	return &Document{fields: fields, dynamicTemplates: maps.Clone(doc.dynamicTemplates)}
+func cloneDocument(src Document) Document {
+	fields := make([]field, len(src.fields))
+	for i := range src.fields {
+		fields[i] = field{key: src.fields[i].key, value: cloneValue(src.fields[i].value)}
+	}
+	return Document{fields: fields, dynamicTemplates: maps.Clone(src.dynamicTemplates)}
+}
+
+func cloneValue(v Value) Value {
+	switch v.kind {
+	case KindArr:
+		arr := make([]Value, len(v.arr))
+		for i := range v.arr {
+			arr[i] = cloneValue(v.arr[i])
+		}
+		v.arr = arr
+	case KindObject, KindUnflattenableObject:
+		v.doc = cloneDocument(v.doc)
+	}
+	return v
 }
 
 func (doc *Document) AddDynamicTemplate(path, template string) {
@@ -219,7 +235,8 @@ func (doc *Document) AddLinks(key string, links ptrace.SpanLinkSlice) {
 	doc.Add(key, ArrValue(linkValues...))
 }
 
-func (doc *Document) sort() {
+// Sort stably sorts document keys, including nested objects.
+func (doc *Document) Sort() {
 	slices.SortStableFunc(doc.fields, func(a, b field) int {
 		return strings.Compare(a.key, b.key)
 	})
@@ -233,29 +250,67 @@ func (doc *Document) sort() {
 // Dedup removes fields from the document, that have duplicate keys.
 // The filtering only keeps the last value for a key.
 // protectedSet is an optional map of field paths that should never get .value suffix.
-// Dedup ensure that keys are sorted.
+// Dedup ensures that keys are sorted.
 func (doc *Document) Dedup(protectedSet map[string]struct{}) {
-	// 1. Always ensure the fields are sorted, Dedup support requires
-	// Fields to be sorted.
-	doc.sort()
+	doc.Sort()
+	doc.dedupSorted(protectedSet)
+}
 
-	// 2. rename fields if a primitive value is overwritten by an object,
+// assembleFromSortedBase merges a sorted base with extra, then runs Dedup
+// without sorting the concatenated document. On equal keys the merge emits
+// the base field first so last-wins still keeps extra. extra is sorted in
+// place. Nested object and array values from base are cloned.
+// Dynamic templates are copied from base only. extra.dynamicTemplates are dropped.
+func assembleFromSortedBase(base, extra Document, protectedSet map[string]struct{}) Document {
+	extra.Sort()
+	out := Document{
+		fields:           mergeSortedFields(base.fields, extra.fields),
+		dynamicTemplates: maps.Clone(base.dynamicTemplates),
+	}
+	out.dedupSorted(protectedSet)
+	return out
+}
+
+func mergeSortedFields(base, extra []field) []field {
+	out := make([]field, 0, len(base)+len(extra))
+	i, j := 0, 0
+	for i < len(base) && j < len(extra) {
+		if strings.Compare(base[i].key, extra[j].key) <= 0 {
+			out = append(out, field{key: base[i].key, value: cloneValue(base[i].value)})
+			i++
+			continue
+		}
+		out = append(out, extra[j])
+		j++
+	}
+	for ; i < len(base); i++ {
+		out = append(out, field{key: base[i].key, value: cloneValue(base[i].value)})
+	}
+	return append(out, extra[j:]...)
+}
+
+func (doc *Document) dedupSorted(protectedSet map[string]struct{}) {
+	// 1. Rename fields if a primitive value is overwritten by an object,
 	//    EXCEPT for protected fields (well-defined schema fields like ECS).
 	//    For example the pair (path.x=1, path.x.a="test") becomes:
 	//    (path.x.value=1, path.x.a="test").
 	//
-	//    However, if path.x is a protected field, we skip the renaming and instead
-	//    remove the conflicting nested field (path.x.a) to preserve the protected field.
+	//    However, if path.x is a protected field, we skip the renaming and
+	//    instead remove the conflicting nested field (path.x.a) to preserve
+	//    the protected field.
 	//
 	//    NOTE: We do the renaming, in order to preserve the original value
-	//    in case of conflicts after dedotting, which would lead to the removal of the field.
-	//    For example docker/k8s labels tend to use `.`, which need to be handled in case
-	//    The collector does pass us these kind of labels as an AttributeMap.
+	//    in case of conflicts after dedotting, which would lead to the
+	//    removal of the field. For example docker/k8s labels tend to use
+	//    `.`, which need to be handled in case the collector does pass us
+	//    these kind of labels as an AttributeMap.
 	//
-	//    NOTE: If the embedded document already has a field name `value`, we will remove the renamed
-	//    field in favor of the `value` field in the document.
+	//    NOTE: If the embedded document already has a field name `value`, we
+	//    will remove the renamed field in favor of the `value` field in the
+	//    document.
 	//
-	//    This step removes potential conflicts when dedotting and serializing fields.
+	//    This step removes potential conflicts when dedotting and serializing
+	//    fields.
 	var renamed bool
 	for i := 0; i < len(doc.fields)-1; i++ {
 		key, nextKey := doc.fields[i].key, doc.fields[i+1].key
@@ -277,10 +332,10 @@ func (doc *Document) Dedup(protectedSet map[string]struct{}) {
 		}
 	}
 	if renamed {
-		doc.sort()
+		doc.Sort()
 	}
 
-	// 3. mark duplicates as 'ignore'
+	// 2. mark duplicates as 'ignore'
 	//
 	//    This step ensures that we do not have duplicate fields names when serializing.
 	//    Elasticsearch JSON parser will fail otherwise.
@@ -290,7 +345,7 @@ func (doc *Document) Dedup(protectedSet map[string]struct{}) {
 		}
 	}
 
-	// 4. fix objects that might be stored in arrays
+	// 3. fix objects that might be stored in arrays
 	for i := range doc.fields {
 		doc.fields[i].value.Dedup(protectedSet)
 	}
@@ -309,6 +364,18 @@ func newJSONVisitor(w io.Writer) *json.Visitor {
 // serialization.
 func (doc *Document) Serialize(w io.Writer, dedot bool, protectedSet map[string]struct{}) error {
 	doc.Dedup(protectedSet)
+	return doc.writeJSON(w, dedot)
+}
+
+// SerializeFromSortedBase merges a sorted base with extra, then writes JSON.
+// It does not run Dedup a second time. extra is sorted in place.
+func SerializeFromSortedBase(base, extra Document, protectedSet map[string]struct{}, w io.Writer, dedot bool) error {
+	doc := assembleFromSortedBase(base, extra, protectedSet)
+	return doc.writeJSON(w, dedot)
+}
+
+// writeJSON writes the document without Dedup. Fields must already be prepared.
+func (doc *Document) writeJSON(w io.Writer, dedot bool) error {
 	v := newJSONVisitor(w)
 	return doc.iterJSON(v, dedot)
 }
@@ -498,7 +565,7 @@ func ValueFromAttribute(attr pcommon.Value) Value {
 func (v *Value) sort() {
 	switch v.kind {
 	case KindObject:
-		v.doc.sort()
+		v.doc.Sort()
 	case KindArr:
 		for i := range v.arr {
 			v.arr[i].sort()

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
@@ -5,6 +5,8 @@ package objmodel
 
 import (
 	"math"
+	"math/rand/v2"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -397,4 +399,231 @@ func TestValue_Serialize(t *testing.T) {
 			assert.Equal(t, test.want, buf.String())
 		})
 	}
+}
+
+func TestCloneDocument_NestedValuesAreIndependent(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func() Document
+		key   string
+	}{
+		{
+			name: "nested object",
+			build: func() Document {
+				var nested Document
+				nested.AddInt("a", 1)
+				nested.AddString("a.b", "nested")
+				var src Document
+				src.Add("obj", Value{kind: KindObject, doc: nested})
+				return src
+			},
+			key: "obj",
+		},
+		{
+			name: "array of objects",
+			build: func() Document {
+				var nested Document
+				nested.AddInt("a", 1)
+				nested.AddString("a.b", "nested")
+				var src Document
+				src.Add("arr", ArrValue(Value{kind: KindObject, doc: nested}))
+				return src
+			},
+			key: "arr",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := tc.build()
+			cloned := cloneDocument(src)
+			cloned.Dedup(nil)
+
+			require.Equal(t, "a", nestedFirstKey(t, src, tc.key))
+		})
+	}
+}
+
+func TestAssembleFromSortedBase_MatchesConcatDedup(t *testing.T) {
+	cases := []struct {
+		name      string
+		base      func() Document
+		extra     func() Document
+		protected map[string]struct{}
+	}{
+		{
+			name: "prefix conflict keeps resource and record value",
+			base: func() Document {
+				var doc Document
+				doc.AddString("x", "resource")
+				doc.AddString("x.a", "scope")
+				return doc
+			},
+			extra: func() Document {
+				var doc Document
+				doc.AddString("x", "record")
+				return doc
+			},
+		},
+		{
+			name: "equal key last-wins keeps extra",
+			base: func() Document {
+				var doc Document
+				doc.AddString("service.name", "from-resource")
+				return doc
+			},
+			extra: func() Document {
+				var doc Document
+				doc.AddString("service.name", "from-record")
+				return doc
+			},
+		},
+		{
+			name: "duplicate keys inside extra",
+			base: func() Document {
+				var doc Document
+				doc.AddInt("a", 1)
+				return doc
+			},
+			extra: func() Document {
+				var doc Document
+				doc.AddInt("b", 2)
+				doc.AddInt("b", 3)
+				return doc
+			},
+		},
+		{
+			name: "protected prefix ignores nested extra",
+			base: func() Document {
+				var doc Document
+				doc.AddString("host", "from-resource")
+				return doc
+			},
+			extra: func() Document {
+				var doc Document
+				doc.AddString("host.name", "from-record")
+				return doc
+			},
+			protected: map[string]struct{}{"host": {}},
+		},
+		{
+			name: "empty extra",
+			base: func() Document {
+				var doc Document
+				doc.AddInt("a", 1)
+				doc.AddInt("c", 3)
+				return doc
+			},
+			extra: func() Document {
+				return Document{}
+			},
+		},
+		{
+			name: "empty base",
+			base: func() Document {
+				return Document{}
+			},
+			extra: func() Document {
+				var doc Document
+				doc.AddInt("a", 1)
+				doc.AddInt("c", 3)
+				return doc
+			},
+		},
+		{
+			name: "dynamic templates copy from base",
+			base: func() Document {
+				var doc Document
+				doc.AddInt("a", 1)
+				doc.AddDynamicTemplate("a", "histogram")
+				return doc
+			},
+			extra: func() Document {
+				var doc Document
+				doc.AddInt("b", 2)
+				return doc
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertAssembleMatchesConcat(t, tc.base(), tc.extra(), tc.protected)
+		})
+	}
+}
+
+func TestAssembleFromSortedBase_RandomKeys(t *testing.T) {
+	rng := rand.New(rand.NewPCG(1, 2))
+	for range 50 {
+		assertAssembleMatchesConcat(t, randomDoc(rng, 20), randomDoc(rng, 8), nil)
+	}
+}
+
+func TestAssembleFromSortedBase_DoesNotMutateBase(t *testing.T) {
+	var nested Document
+	nested.AddInt("a", 1)
+	nested.AddString("a.b", "nested")
+	var base Document
+	base.Add("obj", Value{kind: KindObject, doc: nested})
+	base.Sort()
+
+	var extra Document
+	extra.AddInt("n", 1)
+	_ = assembleFromSortedBase(base, extra, nil)
+
+	require.Equal(t, "a", nestedFirstKey(t, base, "obj"))
+}
+
+func assertAssembleMatchesConcat(t *testing.T, base, extra Document, protected map[string]struct{}) {
+	t.Helper()
+
+	concat := cloneDocument(base)
+	concat.fields = append(concat.fields, cloneDocument(extra).fields...)
+	var want strings.Builder
+	require.NoError(t, concat.Serialize(&want, true, protected))
+
+	sorted := cloneDocument(base)
+	sorted.Sort()
+	gotDoc := assembleFromSortedBase(sorted, cloneDocument(extra), protected)
+	var got strings.Builder
+	require.NoError(t, gotDoc.writeJSON(&got, true))
+
+	require.Equal(t, want.String(), got.String())
+	require.Equal(t, concat.fields, gotDoc.fields)
+	require.Equal(t, concat.dynamicTemplates, gotDoc.dynamicTemplates)
+}
+
+func randomDoc(rng *rand.Rand, n int) Document {
+	var doc Document
+	for i := range n {
+		key := "k" + strconv.Itoa(rng.IntN(12))
+		if rng.IntN(4) == 0 {
+			key += ".a"
+		}
+		doc.AddString(key, "v"+strconv.Itoa(i))
+	}
+	return doc
+}
+
+func nestedFirstKey(t *testing.T, doc Document, key string) string {
+	t.Helper()
+	for i := range doc.fields {
+		if doc.fields[i].key != key {
+			continue
+		}
+		v := doc.fields[i].value
+		switch v.kind {
+		case KindObject:
+			require.NotEmpty(t, v.doc.fields)
+			return v.doc.fields[0].key
+		case KindArr:
+			require.NotEmpty(t, v.arr)
+			require.Equal(t, KindObject, v.arr[0].kind)
+			require.NotEmpty(t, v.arr[0].doc.fields)
+			return v.arr[0].doc.fields[0].key
+		}
+	}
+	t.Fatalf("key %q not found", key)
+	return ""
 }

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
@@ -5,7 +5,6 @@ package objmodel
 
 import (
 	"math"
-	"math/rand/v2"
 	"strconv"
 	"strings"
 	"testing"
@@ -401,229 +400,55 @@ func TestValue_Serialize(t *testing.T) {
 	}
 }
 
-func TestCloneDocument_NestedValuesAreIndependent(t *testing.T) {
-	cases := []struct {
-		name  string
-		build func() Document
-		key   string
-	}{
-		{
-			name: "nested object",
-			build: func() Document {
-				var nested Document
-				nested.AddInt("a", 1)
-				nested.AddString("a.b", "nested")
-				var src Document
-				src.Add("obj", Value{kind: KindObject, doc: nested})
-				return src
-			},
-			key: "obj",
-		},
-		{
-			name: "array of objects",
-			build: func() Document {
-				var nested Document
-				nested.AddInt("a", 1)
-				nested.AddString("a.b", "nested")
-				var src Document
-				src.Add("arr", ArrValue(Value{kind: KindObject, doc: nested}))
-				return src
-			},
-			key: "arr",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			src := tc.build()
-			cloned := cloneDocument(src)
-			cloned.Dedup(nil)
-
-			require.Equal(t, "a", nestedFirstKey(t, src, tc.key))
-		})
-	}
-}
-
-func TestAssembleFromSortedBase_MatchesConcatDedup(t *testing.T) {
-	cases := []struct {
-		name      string
-		base      func() Document
-		extra     func() Document
-		protected map[string]struct{}
-	}{
-		{
-			name: "prefix conflict keeps resource and record value",
-			base: func() Document {
-				var doc Document
-				doc.AddString("x", "resource")
-				doc.AddString("x.a", "scope")
-				return doc
-			},
-			extra: func() Document {
-				var doc Document
-				doc.AddString("x", "record")
-				return doc
-			},
-		},
-		{
-			name: "equal key last-wins keeps extra",
-			base: func() Document {
-				var doc Document
-				doc.AddString("service.name", "from-resource")
-				return doc
-			},
-			extra: func() Document {
-				var doc Document
-				doc.AddString("service.name", "from-record")
-				return doc
-			},
-		},
-		{
-			name: "duplicate keys inside extra",
-			base: func() Document {
-				var doc Document
-				doc.AddInt("a", 1)
-				return doc
-			},
-			extra: func() Document {
-				var doc Document
-				doc.AddInt("b", 2)
-				doc.AddInt("b", 3)
-				return doc
-			},
-		},
-		{
-			name: "protected prefix ignores nested extra",
-			base: func() Document {
-				var doc Document
-				doc.AddString("host", "from-resource")
-				return doc
-			},
-			extra: func() Document {
-				var doc Document
-				doc.AddString("host.name", "from-record")
-				return doc
-			},
-			protected: map[string]struct{}{"host": {}},
-		},
-		{
-			name: "empty extra",
-			base: func() Document {
-				var doc Document
-				doc.AddInt("a", 1)
-				doc.AddInt("c", 3)
-				return doc
-			},
-			extra: func() Document {
-				return Document{}
-			},
-		},
-		{
-			name: "empty base",
-			base: func() Document {
-				return Document{}
-			},
-			extra: func() Document {
-				var doc Document
-				doc.AddInt("a", 1)
-				doc.AddInt("c", 3)
-				return doc
-			},
-		},
-		{
-			name: "dynamic templates copy from base",
-			base: func() Document {
-				var doc Document
-				doc.AddInt("a", 1)
-				doc.AddDynamicTemplate("a", "histogram")
-				return doc
-			},
-			extra: func() Document {
-				var doc Document
-				doc.AddInt("b", 2)
-				return doc
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assertAssembleMatchesConcat(t, tc.base(), tc.extra(), tc.protected)
-		})
-	}
-}
-
-func TestAssembleFromSortedBase_RandomKeys(t *testing.T) {
-	rng := rand.New(rand.NewPCG(1, 2))
-	for range 50 {
-		assertAssembleMatchesConcat(t, randomDoc(rng, 20), randomDoc(rng, 8), nil)
-	}
-}
-
-func TestAssembleFromSortedBase_DoesNotMutateBase(t *testing.T) {
-	var nested Document
-	nested.AddInt("a", 1)
-	nested.AddString("a.b", "nested")
-	var base Document
-	base.Add("obj", Value{kind: KindObject, doc: nested})
-	base.Sort()
-
-	var extra Document
-	extra.AddInt("n", 1)
-	_ = assembleFromSortedBase(base, extra, nil)
-
-	require.Equal(t, "a", nestedFirstKey(t, base, "obj"))
-}
-
-func assertAssembleMatchesConcat(t *testing.T, base, extra Document, protected map[string]struct{}) {
-	t.Helper()
-
-	concat := cloneDocument(base)
-	concat.fields = append(concat.fields, cloneDocument(extra).fields...)
-	var want strings.Builder
-	require.NoError(t, concat.Serialize(&want, true, protected))
-
-	sorted := cloneDocument(base)
-	sorted.Sort()
-	gotDoc := assembleFromSortedBase(sorted, cloneDocument(extra), protected)
-	var got strings.Builder
-	require.NoError(t, gotDoc.writeJSON(&got, true))
-
-	require.Equal(t, want.String(), got.String())
-	require.Equal(t, concat.fields, gotDoc.fields)
-	require.Equal(t, concat.dynamicTemplates, gotDoc.dynamicTemplates)
-}
-
-func randomDoc(rng *rand.Rand, n int) Document {
+func TestDocument_Reset(t *testing.T) {
 	var doc Document
-	for i := range n {
-		key := "k" + strconv.Itoa(rng.IntN(12))
-		if rng.IntN(4) == 0 {
-			key += ".a"
-		}
-		doc.AddString(key, "v"+strconv.Itoa(i))
-	}
-	return doc
+	doc.Grow(8)
+	doc.AddInt("a", 1)
+	doc.AddDynamicTemplate("a", "histogram")
+	capBefore := cap(doc.fields)
+
+	doc.Reset()
+
+	require.Empty(t, doc.fields)
+	require.Equal(t, capBefore, cap(doc.fields))
+	require.Empty(t, doc.dynamicTemplates)
+
+	doc.AddInt("b", 2)
+	require.Len(t, doc.fields, 1)
+	require.Equal(t, "b", doc.fields[0].key)
+	require.Equal(t, capBefore, cap(doc.fields))
 }
 
-func nestedFirstKey(t *testing.T, doc Document, key string) string {
-	t.Helper()
-	for i := range doc.fields {
-		if doc.fields[i].key != key {
-			continue
-		}
-		v := doc.fields[i].value
-		switch v.kind {
-		case KindObject:
-			require.NotEmpty(t, v.doc.fields)
-			return v.doc.fields[0].key
-		case KindArr:
-			require.NotEmpty(t, v.arr)
-			require.Equal(t, KindObject, v.arr[0].kind)
-			require.NotEmpty(t, v.arr[0].doc.fields)
-			return v.arr[0].doc.fields[0].key
-		}
+func TestDocument_Grow(t *testing.T) {
+	cases := []struct {
+		name string
+		n    int
+		adds int
+	}{
+		{
+			name: "zero",
+			n:    0,
+			adds: 0,
+		},
+		{
+			name: "prealloc then fill",
+			n:    8,
+			adds: 8,
+		},
 	}
-	t.Fatalf("key %q not found", key)
-	return ""
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var doc Document
+			doc.Grow(tc.n)
+			require.GreaterOrEqual(t, cap(doc.fields), tc.n)
+			require.Empty(t, doc.fields)
+
+			for i := range tc.adds {
+				doc.AddInt(strconv.Itoa(i), int64(i))
+			}
+			require.Len(t, doc.fields, tc.adds)
+			require.GreaterOrEqual(t, cap(doc.fields), tc.n)
+		})
+	}
 }

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -184,7 +184,8 @@ func startECSDocument(ec encodingContext, recordAttrs pcommon.Map) *objmodel.Doc
 	} else {
 		document = new(objmodel.Document)
 	}
-	document.Grow(ec.resource.Attributes().Len() + ec.scope.Attributes().Len() + recordAttrs.Len())
+	// +10 covers fixed ECS fields (@timestamp, data_stream.*, trace.id, ...).
+	document.Grow(ec.resource.Attributes().Len() + ec.scope.Attributes().Len() + recordAttrs.Len() + 10)
 	// First, try to map resource-level attributes to ECS fields.
 	encodeAttributesECSMode(document, ec.resource.Attributes(), resourceAttrsConversionMap)
 	// Then, try to map scope-level attributes to ECS fields.

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -184,7 +184,7 @@ func startECSDocument(ec encodingContext, recordAttrs pcommon.Map) *objmodel.Doc
 	} else {
 		document = new(objmodel.Document)
 	}
-	document.Grow(ec.resource.Attributes().Len() + ec.scope.Attributes().Len() + recordAttrs.Len() + 16)
+	document.Grow(ec.resource.Attributes().Len() + ec.scope.Attributes().Len() + recordAttrs.Len())
 	// First, try to map resource-level attributes to ECS fields.
 	encodeAttributesECSMode(document, ec.resource.Attributes(), resourceAttrsConversionMap)
 	// Then, try to map scope-level attributes to ECS fields.

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -165,6 +165,50 @@ type encodingContext struct {
 	resourceSchemaURL string
 	scope             pcommon.InstrumentationScope
 	scopeSchemaURL    string
+	// ecsBase maps resource and scope attributes once per Resource+Scope
+	// batch. Nil maps on each call. The exporter sets this only for MappingECS.
+	ecsBase *ecsAttributeBase
+}
+
+// ecsAttributeBase holds ECS-mapped resource and scope fields for one
+// Resource+Scope batch. Fields are sorted once. Per-record encode merges
+// the record into this base, then runs the rest of Dedup.
+type ecsAttributeBase struct {
+	doc   objmodel.Document
+	ready bool
+}
+
+func newECSAttributeBase(mode MappingMode) *ecsAttributeBase {
+	if mode != MappingECS {
+		return nil
+	}
+	return &ecsAttributeBase{}
+}
+
+func (b *ecsAttributeBase) mapped(resource pcommon.Resource, scope pcommon.InstrumentationScope) objmodel.Document {
+	if !b.ready {
+		// First, try to map resource-level attributes to ECS fields.
+		encodeAttributesECSMode(&b.doc, resource.Attributes(), resourceAttrsConversionMap)
+		// Then, try to map scope-level attributes to ECS fields.
+		encodeAttributesECSMode(&b.doc, scope.Attributes(), scopeAttrsConversionMap)
+		b.doc.Sort()
+		b.ready = true
+	}
+	return b.doc
+}
+
+func serializeECSDocument(
+	ec encodingContext,
+	recordDoc objmodel.Document,
+	protected map[string]struct{},
+	buf *bytes.Buffer,
+) error {
+	b := ec.ecsBase
+	if b == nil {
+		b = &ecsAttributeBase{}
+	}
+	mapped := b.mapped(ec.resource, ec.scope)
+	return objmodel.SerializeFromSortedBase(mapped, recordDoc, protected, buf, true)
 }
 
 func newEncoder(mode MappingMode) (documentEncoder, error) {
@@ -265,11 +309,7 @@ func (ecsModeEncoder) encodeLog(
 ) error {
 	var document objmodel.Document
 
-	// First, try to map resource-level attributes to ECS fields.
-	encodeAttributesECSMode(&document, ec.resource.Attributes(), resourceAttrsConversionMap)
-	// Then, try to map scope-level attributes to ECS fields.
-	encodeAttributesECSMode(&document, ec.scope.Attributes(), scopeAttrsConversionMap)
-	// Finally, try to map record-level attributes to ECS fields.
+	// Try to map record-level attributes to ECS fields.
 	encodeAttributesECSMode(&document, record.Attributes(), logRecordAttrsConversionMap)
 	addDataStreamAttributes(&document, "", idx)
 
@@ -287,7 +327,7 @@ func (ecsModeEncoder) encodeLog(
 		document.AddAttribute("message", record.Body())
 	}
 
-	return document.Serialize(buf, true, logProtectedFields)
+	return serializeECSDocument(ec, document, logProtectedFields, buf)
 }
 
 func (ecsModeEncoder) encodeSpan(
@@ -298,11 +338,7 @@ func (ecsModeEncoder) encodeSpan(
 ) error {
 	var document objmodel.Document
 
-	// First, try to map resource-level attributes to ECS fields.
-	encodeAttributesECSMode(&document, ec.resource.Attributes(), resourceAttrsConversionMap)
-	// Then, try to map scope-level attributes to ECS fields.
-	encodeAttributesECSMode(&document, ec.scope.Attributes(), scopeAttrsConversionMap)
-	// Finally, try to map span-level attributes to ECS fields.
+	// Try to map span-level attributes to ECS fields.
 	encodeAttributesECSMode(&document, span.Attributes(), spanAttrsConversionMap)
 	addDataStreamAttributes(&document, "", idx)
 
@@ -321,7 +357,7 @@ func (ecsModeEncoder) encodeSpan(
 		document.AddString("span.kind", spanKind)
 	}
 
-	return document.Serialize(buf, true, spanProtectedFields)
+	return serializeECSDocument(ec, document, spanProtectedFields, buf)
 }
 
 // spanKindToECSStr converts an OTel SpanKind to its ECS equivalent string representation defined here:
@@ -554,8 +590,6 @@ func (ecsModeEncoder) encodeSpanEvent(
 	idx := elasticsearch.NewDataStreamIndex(defaultDataStreamTypeLogs, dataset, namespace)
 
 	var document objmodel.Document
-	encodeAttributesECSMode(&document, ec.resource.Attributes(), resourceAttrsConversionMap)
-	encodeAttributesECSMode(&document, ec.scope.Attributes(), scopeAttrsConversionMap)
 	encodeAttributesECSMode(&document, event.Attributes(), ecsSpanEventAttrsConversionMap)
 	addDataStreamAttributes(&document, "", idx)
 
@@ -585,7 +619,7 @@ func (ecsModeEncoder) encodeSpanEvent(
 		document.AddString("message", event.Name())
 	}
 
-	return idx, document.Serialize(buf, true, spanEventProtectedFields)
+	return idx, serializeECSDocument(ec, document, spanEventProtectedFields, buf)
 }
 
 func isExceptionSpanEvent(event ptrace.SpanEvent) bool {

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -165,50 +165,31 @@ type encodingContext struct {
 	resourceSchemaURL string
 	scope             pcommon.InstrumentationScope
 	scopeSchemaURL    string
-	// ecsBase maps resource and scope attributes once per Resource+Scope
-	// batch. Nil maps on each call. The exporter sets this only for MappingECS.
-	ecsBase *ecsAttributeBase
+	// ecsDoc is reused across records in one Resource+Scope batch for MappingECS.
+	ecsDoc *objmodel.Document
 }
 
-// ecsAttributeBase holds ECS-mapped resource and scope fields for one
-// Resource+Scope batch. Fields are sorted once. Per-record encode merges
-// the record into this base, then runs the rest of Dedup.
-type ecsAttributeBase struct {
-	doc   objmodel.Document
-	ready bool
-}
-
-func newECSAttributeBase(mode MappingMode) *ecsAttributeBase {
+func newECSDocument(mode MappingMode) *objmodel.Document {
 	if mode != MappingECS {
 		return nil
 	}
-	return &ecsAttributeBase{}
+	return &objmodel.Document{}
 }
 
-func (b *ecsAttributeBase) mapped(resource pcommon.Resource, scope pcommon.InstrumentationScope) objmodel.Document {
-	if !b.ready {
-		// First, try to map resource-level attributes to ECS fields.
-		encodeAttributesECSMode(&b.doc, resource.Attributes(), resourceAttrsConversionMap)
-		// Then, try to map scope-level attributes to ECS fields.
-		encodeAttributesECSMode(&b.doc, scope.Attributes(), scopeAttrsConversionMap)
-		b.doc.Sort()
-		b.ready = true
+func startECSDocument(ec encodingContext, recordAttrs pcommon.Map) *objmodel.Document {
+	var document *objmodel.Document
+	if ec.ecsDoc != nil {
+		ec.ecsDoc.Reset()
+		document = ec.ecsDoc
+	} else {
+		document = new(objmodel.Document)
 	}
-	return b.doc
-}
-
-func serializeECSDocument(
-	ec encodingContext,
-	recordDoc objmodel.Document,
-	protected map[string]struct{},
-	buf *bytes.Buffer,
-) error {
-	b := ec.ecsBase
-	if b == nil {
-		b = &ecsAttributeBase{}
-	}
-	mapped := b.mapped(ec.resource, ec.scope)
-	return objmodel.SerializeFromSortedBase(mapped, recordDoc, protected, buf, true)
+	document.Grow(ec.resource.Attributes().Len() + ec.scope.Attributes().Len() + recordAttrs.Len() + 16)
+	// First, try to map resource-level attributes to ECS fields.
+	encodeAttributesECSMode(document, ec.resource.Attributes(), resourceAttrsConversionMap)
+	// Then, try to map scope-level attributes to ECS fields.
+	encodeAttributesECSMode(document, ec.scope.Attributes(), scopeAttrsConversionMap)
+	return document
 }
 
 func newEncoder(mode MappingMode) (documentEncoder, error) {
@@ -307,14 +288,14 @@ func (ecsModeEncoder) encodeLog(
 	idx elasticsearch.Index,
 	buf *bytes.Buffer,
 ) error {
-	var document objmodel.Document
+	document := startECSDocument(ec, record.Attributes())
 
-	// Try to map record-level attributes to ECS fields.
-	encodeAttributesECSMode(&document, record.Attributes(), logRecordAttrsConversionMap)
-	addDataStreamAttributes(&document, "", idx)
+	// Finally, try to map record-level attributes to ECS fields.
+	encodeAttributesECSMode(document, record.Attributes(), logRecordAttrsConversionMap)
+	addDataStreamAttributes(document, "", idx)
 
 	// Handle special cases.
-	encodeLogTimestampECSMode(&document, record)
+	encodeLogTimestampECSMode(document, record)
 	document.AddTraceID("trace.id", record.TraceID())
 	document.AddSpanID("span.id", record.SpanID())
 	if n := record.SeverityNumber(); n != plog.SeverityNumberUnspecified {
@@ -327,7 +308,7 @@ func (ecsModeEncoder) encodeLog(
 		document.AddAttribute("message", record.Body())
 	}
 
-	return serializeECSDocument(ec, document, logProtectedFields, buf)
+	return document.Serialize(buf, true, logProtectedFields)
 }
 
 func (ecsModeEncoder) encodeSpan(
@@ -336,11 +317,11 @@ func (ecsModeEncoder) encodeSpan(
 	idx elasticsearch.Index,
 	buf *bytes.Buffer,
 ) error {
-	var document objmodel.Document
+	document := startECSDocument(ec, span.Attributes())
 
-	// Try to map span-level attributes to ECS fields.
-	encodeAttributesECSMode(&document, span.Attributes(), spanAttrsConversionMap)
-	addDataStreamAttributes(&document, "", idx)
+	// Finally, try to map span-level attributes to ECS fields.
+	encodeAttributesECSMode(document, span.Attributes(), spanAttrsConversionMap)
+	addDataStreamAttributes(document, "", idx)
 
 	document.AddTimestamp("@timestamp", span.StartTimestamp())
 	document.AddTraceID("trace.id", span.TraceID())
@@ -357,7 +338,7 @@ func (ecsModeEncoder) encodeSpan(
 		document.AddString("span.kind", spanKind)
 	}
 
-	return serializeECSDocument(ec, document, spanProtectedFields, buf)
+	return document.Serialize(buf, true, spanProtectedFields)
 }
 
 // spanKindToECSStr converts an OTel SpanKind to its ECS equivalent string representation defined here:
@@ -589,9 +570,9 @@ func (ecsModeEncoder) encodeSpanEvent(
 	namespace := ecsSpanEventNamespace(ec, event)
 	idx := elasticsearch.NewDataStreamIndex(defaultDataStreamTypeLogs, dataset, namespace)
 
-	var document objmodel.Document
-	encodeAttributesECSMode(&document, event.Attributes(), ecsSpanEventAttrsConversionMap)
-	addDataStreamAttributes(&document, "", idx)
+	document := startECSDocument(ec, event.Attributes())
+	encodeAttributesECSMode(document, event.Attributes(), ecsSpanEventAttrsConversionMap)
+	addDataStreamAttributes(document, "", idx)
 
 	document.AddTimestamp("@timestamp", event.Timestamp())
 	document.AddTraceID("trace.id", span.TraceID())
@@ -619,7 +600,7 @@ func (ecsModeEncoder) encodeSpanEvent(
 		document.AddString("message", event.Name())
 	}
 
-	return idx, serializeECSDocument(ec, document, spanEventProtectedFields, buf)
+	return idx, document.Serialize(buf, true, spanEventProtectedFields)
 }
 
 func isExceptionSpanEvent(event ptrace.SpanEvent) bool {
@@ -690,6 +671,7 @@ func scopeToAttributes(scope pcommon.InstrumentationScope) pcommon.Map {
 }
 
 func encodeAttributesECSMode(document *objmodel.Document, attrs pcommon.Map, conversionMap map[string]conversionEntry) {
+	document.Grow(attrs.Len())
 	if len(conversionMap) == 0 {
 		// No conversions to be done; add all attributes at top level of
 		// document.

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -945,163 +945,43 @@ func TestEncodeLogECSMode(t *testing.T) {
 	}`, buf.String())
 }
 
-func TestEncodeECSMode_CachedBaseMatchesUncached(t *testing.T) {
+func TestEncodeECSMode_PooledDocumentMatchesUnpooled(t *testing.T) {
 	encoder, err := newEncoder(MappingECS)
 	require.NoError(t, err)
 	idx := elasticsearch.Index{}
 	ts := pcommon.Timestamp(1710273641123456789)
 
-	cases := []struct {
-		name   string
-		setup  func(t *testing.T) (pcommon.Resource, pcommon.InstrumentationScope)
-		encode func(ec encodingContext) ([]string, error)
-	}{
-		{
-			name: "log record overwrites resource key",
-			setup: func(_ *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
-				r := pcommon.NewResource()
-				r.Attributes().PutStr("service.name", "from-resource")
-				return r, pcommon.NewInstrumentationScope()
-			},
-			encode: func(ec encodingContext) ([]string, error) {
-				rec := plog.NewLogRecord()
-				rec.SetObservedTimestamp(ts)
-				rec.Attributes().PutStr("service.name", "from-record")
-				var buf bytes.Buffer
-				err := encoder.encodeLog(ec, rec, idx, &buf)
-				return []string{buf.String()}, err
-			},
+	resource := pcommon.NewResource()
+	require.NoError(t, resource.Attributes().PutEmptySlice("items").FromRaw([]any{
+		map[string]any{
+			"a":   int64(1),
+			"a.b": "nested",
 		},
-		{
-			name: "log prefix conflict across resource scope and record",
-			setup: func(_ *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
-				r := pcommon.NewResource()
-				r.Attributes().PutStr("x", "resource")
-				s := pcommon.NewInstrumentationScope()
-				s.Attributes().PutStr("x.a", "scope")
-				return r, s
-			},
-			encode: func(ec encodingContext) ([]string, error) {
-				rec := plog.NewLogRecord()
-				rec.SetObservedTimestamp(ts)
-				rec.Attributes().PutStr("x", "record")
-				var buf bytes.Buffer
-				err := encoder.encodeLog(ec, rec, idx, &buf)
-				return []string{buf.String()}, err
-			},
-		},
-		{
-			name: "log nested array is isolated across records",
-			setup: func(t *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
-				r := pcommon.NewResource()
-				require.NoError(t, r.Attributes().PutEmptySlice("items").FromRaw([]any{
-					map[string]any{
-						"a":   int64(1),
-						"a.b": "nested",
-					},
-				}))
-				return r, pcommon.NewInstrumentationScope()
-			},
-			encode: func(ec encodingContext) ([]string, error) {
-				docs := make([]string, 2)
-				for i := range docs {
-					rec := plog.NewLogRecord()
-					rec.SetObservedTimestamp(ts)
-					rec.Attributes().PutInt("n", int64(i))
-					var buf bytes.Buffer
-					if err := encoder.encodeLog(ec, rec, idx, &buf); err != nil {
-						return nil, err
-					}
-					docs[i] = buf.String()
-				}
-				return docs, nil
-			},
-		},
-		{
-			name: "span prefix conflict across resource scope and record",
-			setup: func(_ *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
-				r := pcommon.NewResource()
-				r.Attributes().PutStr("x", "resource")
-				s := pcommon.NewInstrumentationScope()
-				s.Attributes().PutStr("x.a", "scope")
-				return r, s
-			},
-			encode: func(ec encodingContext) ([]string, error) {
-				sp := ptrace.NewSpan()
-				sp.SetName("GET")
-				sp.SetStartTimestamp(ts)
-				sp.Attributes().PutStr("x", "record")
-				var buf bytes.Buffer
-				err := encoder.encodeSpan(ec, sp, idx, &buf)
-				return []string{buf.String()}, err
-			},
-		},
-		{
-			name: "span event prefix conflict across resource scope and record",
-			setup: func(_ *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
-				r := pcommon.NewResource()
-				r.Attributes().PutStr("x", "resource")
-				s := pcommon.NewInstrumentationScope()
-				s.Attributes().PutStr("x.a", "scope")
-				return r, s
-			},
-			encode: func(ec encodingContext) ([]string, error) {
-				sp := ptrace.NewSpan()
-				ev := ptrace.NewSpanEvent()
-				ev.SetName("custom")
-				ev.SetTimestamp(ts)
-				ev.Attributes().PutStr("x", "record")
-				var buf bytes.Buffer
-				_, err := encoder.encodeSpanEvent(ec, sp, ev, idx, &buf)
-				return []string{buf.String()}, err
-			},
-		},
-		{
-			name: "span then span event share cached base",
-			setup: func(t *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
-				r := pcommon.NewResource()
-				require.NoError(t, r.Attributes().PutEmptySlice("items").FromRaw([]any{
-					map[string]any{
-						"http.response.encoded_body_size":   int64(1),
-						"http.response.encoded_body_size.x": "nested",
-					},
-				}))
-				return r, pcommon.NewInstrumentationScope()
-			},
-			encode: func(ec encodingContext) ([]string, error) {
-				sp := ptrace.NewSpan()
-				sp.SetName("GET")
-				sp.SetStartTimestamp(ts)
-				var spanBuf bytes.Buffer
-				if err := encoder.encodeSpan(ec, sp, idx, &spanBuf); err != nil {
-					return nil, err
-				}
-				ev := ptrace.NewSpanEvent()
-				ev.SetName("custom")
-				ev.SetTimestamp(ts)
-				var eventBuf bytes.Buffer
-				if _, err := encoder.encodeSpanEvent(ec, sp, ev, idx, &eventBuf); err != nil {
-					return nil, err
-				}
-				return []string{spanBuf.String(), eventBuf.String()}, nil
-			},
-		},
+	}))
+	scope := pcommon.NewInstrumentationScope()
+
+	encodeTwo := func(ec encodingContext) ([]string, error) {
+		docs := make([]string, 2)
+		for i := range docs {
+			rec := plog.NewLogRecord()
+			rec.SetObservedTimestamp(ts)
+			rec.Attributes().PutInt("n", int64(i))
+			var buf bytes.Buffer
+			if encodeErr := encoder.encodeLog(ec, rec, idx, &buf); encodeErr != nil {
+				return nil, encodeErr
+			}
+			docs[i] = buf.String()
+		}
+		return docs, nil
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			resource, scope := tc.setup(t)
-			cached := encodingContext{resource: resource, scope: scope, ecsBase: &ecsAttributeBase{}}
-			uncached := encodingContext{resource: resource, scope: scope}
-			got, err := tc.encode(cached)
-			require.NoError(t, err)
-			want, err := tc.encode(uncached)
-			require.NoError(t, err)
-			require.Len(t, got, len(want))
-			for i := range got {
-				require.JSONEq(t, want[i], got[i], "doc %d", i)
-			}
-		})
+	got, err := encodeTwo(encodingContext{resource: resource, scope: scope, ecsDoc: &objmodel.Document{}})
+	require.NoError(t, err)
+	want, err := encodeTwo(encodingContext{resource: resource, scope: scope})
+	require.NoError(t, err)
+	require.Len(t, got, len(want))
+	for i := range got {
+		require.JSONEq(t, want[i], got[i])
 	}
 }
 

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -757,10 +757,8 @@ func TestEncodeSpanECSMode(t *testing.T) {
 	}`, buf.String())
 }
 
-func TestEncodeLogECSMode(t *testing.T) {
-	logs := plog.NewLogs()
-	resource := logs.ResourceLogs().AppendEmpty().Resource()
-	err := resource.Attributes().FromRaw(map[string]any{
+func ecsModeResourceAttributes() map[string]any {
+	return map[string]any{
 		"agent.name":                  "custom-agent",
 		"agent.version":               "1.2.3",
 		"service.name":                "foo.bar",
@@ -779,6 +777,7 @@ func TestEncodeLogECSMode(t *testing.T) {
 		"container.name":              "happy-seger",
 		"container.id":                "e69cc5d3dda",
 		"container.image.name":        "my-app",
+		"container.image.tags":        []any{"v3.4.0"},
 		"container.runtime":           "docker",
 		"host.name":                   "i-103de39e0a.gke.us-west-1b.cloud.google.com",
 		"host.hostname":               "hostname.example.com",
@@ -816,11 +815,19 @@ func TestEncodeLogECSMode(t *testing.T) {
 		"source.address":              "12.53.12.1",
 		"faas.instance":               "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime",
 		"faas.trigger":                "api-gateway",
-	})
-	require.NoError(t, err)
+	}
+}
 
-	resourceContainerImageTags := resource.Attributes().PutEmptySlice("container.image.tags")
-	err = resourceContainerImageTags.FromRaw([]any{"v3.4.0"})
+func ecsModeResource(tb testing.TB) pcommon.Resource {
+	resource := pcommon.NewResource()
+	require.NoError(tb, resource.Attributes().FromRaw(ecsModeResourceAttributes()))
+	return resource
+}
+
+func TestEncodeLogECSMode(t *testing.T) {
+	logs := plog.NewLogs()
+	resource := logs.ResourceLogs().AppendEmpty().Resource()
+	err := resource.Attributes().FromRaw(ecsModeResourceAttributes())
 	require.NoError(t, err)
 
 	scope := pcommon.NewInstrumentationScope()
@@ -936,6 +943,166 @@ func TestEncodeLogECSMode(t *testing.T) {
 		     "trigger": { "type": "api-gateway" }
 	  }
 	}`, buf.String())
+}
+
+func TestEncodeECSMode_CachedBaseMatchesUncached(t *testing.T) {
+	encoder, err := newEncoder(MappingECS)
+	require.NoError(t, err)
+	idx := elasticsearch.Index{}
+	ts := pcommon.Timestamp(1710273641123456789)
+
+	cases := []struct {
+		name   string
+		setup  func(t *testing.T) (pcommon.Resource, pcommon.InstrumentationScope)
+		encode func(ec encodingContext) ([]string, error)
+	}{
+		{
+			name: "log record overwrites resource key",
+			setup: func(_ *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
+				r := pcommon.NewResource()
+				r.Attributes().PutStr("service.name", "from-resource")
+				return r, pcommon.NewInstrumentationScope()
+			},
+			encode: func(ec encodingContext) ([]string, error) {
+				rec := plog.NewLogRecord()
+				rec.SetObservedTimestamp(ts)
+				rec.Attributes().PutStr("service.name", "from-record")
+				var buf bytes.Buffer
+				err := encoder.encodeLog(ec, rec, idx, &buf)
+				return []string{buf.String()}, err
+			},
+		},
+		{
+			name: "log prefix conflict across resource scope and record",
+			setup: func(_ *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
+				r := pcommon.NewResource()
+				r.Attributes().PutStr("x", "resource")
+				s := pcommon.NewInstrumentationScope()
+				s.Attributes().PutStr("x.a", "scope")
+				return r, s
+			},
+			encode: func(ec encodingContext) ([]string, error) {
+				rec := plog.NewLogRecord()
+				rec.SetObservedTimestamp(ts)
+				rec.Attributes().PutStr("x", "record")
+				var buf bytes.Buffer
+				err := encoder.encodeLog(ec, rec, idx, &buf)
+				return []string{buf.String()}, err
+			},
+		},
+		{
+			name: "log nested array is isolated across records",
+			setup: func(t *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
+				r := pcommon.NewResource()
+				require.NoError(t, r.Attributes().PutEmptySlice("items").FromRaw([]any{
+					map[string]any{
+						"a":   int64(1),
+						"a.b": "nested",
+					},
+				}))
+				return r, pcommon.NewInstrumentationScope()
+			},
+			encode: func(ec encodingContext) ([]string, error) {
+				docs := make([]string, 2)
+				for i := range docs {
+					rec := plog.NewLogRecord()
+					rec.SetObservedTimestamp(ts)
+					rec.Attributes().PutInt("n", int64(i))
+					var buf bytes.Buffer
+					if err := encoder.encodeLog(ec, rec, idx, &buf); err != nil {
+						return nil, err
+					}
+					docs[i] = buf.String()
+				}
+				return docs, nil
+			},
+		},
+		{
+			name: "span prefix conflict across resource scope and record",
+			setup: func(_ *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
+				r := pcommon.NewResource()
+				r.Attributes().PutStr("x", "resource")
+				s := pcommon.NewInstrumentationScope()
+				s.Attributes().PutStr("x.a", "scope")
+				return r, s
+			},
+			encode: func(ec encodingContext) ([]string, error) {
+				sp := ptrace.NewSpan()
+				sp.SetName("GET")
+				sp.SetStartTimestamp(ts)
+				sp.Attributes().PutStr("x", "record")
+				var buf bytes.Buffer
+				err := encoder.encodeSpan(ec, sp, idx, &buf)
+				return []string{buf.String()}, err
+			},
+		},
+		{
+			name: "span event prefix conflict across resource scope and record",
+			setup: func(_ *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
+				r := pcommon.NewResource()
+				r.Attributes().PutStr("x", "resource")
+				s := pcommon.NewInstrumentationScope()
+				s.Attributes().PutStr("x.a", "scope")
+				return r, s
+			},
+			encode: func(ec encodingContext) ([]string, error) {
+				sp := ptrace.NewSpan()
+				ev := ptrace.NewSpanEvent()
+				ev.SetName("custom")
+				ev.SetTimestamp(ts)
+				ev.Attributes().PutStr("x", "record")
+				var buf bytes.Buffer
+				_, err := encoder.encodeSpanEvent(ec, sp, ev, idx, &buf)
+				return []string{buf.String()}, err
+			},
+		},
+		{
+			name: "span then span event share cached base",
+			setup: func(t *testing.T) (pcommon.Resource, pcommon.InstrumentationScope) {
+				r := pcommon.NewResource()
+				require.NoError(t, r.Attributes().PutEmptySlice("items").FromRaw([]any{
+					map[string]any{
+						"http.response.encoded_body_size":   int64(1),
+						"http.response.encoded_body_size.x": "nested",
+					},
+				}))
+				return r, pcommon.NewInstrumentationScope()
+			},
+			encode: func(ec encodingContext) ([]string, error) {
+				sp := ptrace.NewSpan()
+				sp.SetName("GET")
+				sp.SetStartTimestamp(ts)
+				var spanBuf bytes.Buffer
+				if err := encoder.encodeSpan(ec, sp, idx, &spanBuf); err != nil {
+					return nil, err
+				}
+				ev := ptrace.NewSpanEvent()
+				ev.SetName("custom")
+				ev.SetTimestamp(ts)
+				var eventBuf bytes.Buffer
+				if _, err := encoder.encodeSpanEvent(ec, sp, ev, idx, &eventBuf); err != nil {
+					return nil, err
+				}
+				return []string{spanBuf.String(), eventBuf.String()}, nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource, scope := tc.setup(t)
+			cached := encodingContext{resource: resource, scope: scope, ecsBase: &ecsAttributeBase{}}
+			uncached := encodingContext{resource: resource, scope: scope}
+			got, err := tc.encode(cached)
+			require.NoError(t, err)
+			want, err := tc.encode(uncached)
+			require.NoError(t, err)
+			require.Len(t, got, len(want))
+			for i := range got {
+				require.JSONEq(t, want[i], got[i], "doc %d", i)
+			}
+		})
+	}
 }
 
 func TestEncodeLogECSModeTimestamps(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`Document.Dedup` / `sort` can be improved. I checked a CPU pprof, and it takes 23.22%. Almost all of that is `slices.SortStableFunc` on document fields (`22.67%`). `insertionSortCmpFunc` alone is `16.86%`. See:

<img width="1319" height="107" alt="image" src="https://github.com/user-attachments/assets/ace9f88b-4a04-45f3-a78b-fc1542c38131" />

<img width="763" height="97" alt="image" src="https://github.com/user-attachments/assets/d879ebd0-292a-4bf8-b859-a4dc36ae7772" />

ECS `encodeLog` / `encodeSpan` / `encodeSpanEvent` allocated a new `Document` field slice on every record. 

This change keeps one `Serialize` path and reuses the root field slice for one Resource+Scope batch:

1. Add `Document.Grow` (`slices.Grow` on the field slice) and `Document.Reset` (truncate, keep capacity).
2. Allocate one `Document` per Resource+Scope batch in ECS mode.
3. `Reset` and reuse that document for each record in the batch.
4. `Grow` the field slice for resource + scope + record fields before encode.

Output stays the same.

Results for encoding (`old.txt` vs Grow+pool, `count=10`):

```
goos: linux
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
cpu: Intel(R) Core(TM) Ultra 7 258V
                     │    old.txt    │            grow+pool             │
                     │    sec/op     │   sec/op     vs base             │
EncodeECS/log/small    13.255µ ± 20%   5.720µ ±  8%  -56.85% (p=0.000 n=10)
EncodeECS/log/large     63.07µ ± 38%   27.31µ ± 10%  -56.70% (p=0.000 n=10)
EncodeECS/span/small    9.367µ ± 12%   5.037µ ± 27%  -46.22% (p=0.000 n=10)
EncodeECS/span/large    52.08µ ±  5%   23.96µ ± 17%  -53.99% (p=0.000 n=10)
geomean                 25.27µ         11.72µ        -53.63%

                     │   old.txt    │           grow+pool            │
                     │     B/op     │    B/op     vs base            │
EncodeECS/log/small     5264.0 ± 0%   355.0 ± 0%  -93.26% (p=0.000 n=10)
EncodeECS/log/large    21648.0 ± 0%   739.0 ± 0%  -96.59% (p=0.000 n=10)
EncodeECS/span/small    5312.0 ± 0%   375.0 ± 0%  -92.94% (p=0.000 n=10)
EncodeECS/span/large   21696.0 ± 0%   787.0 ± 0%  -96.37% (p=0.000 n=10)
geomean                10.45Ki        527.5       -95.07%

                     │   old.txt   │          grow+pool           │
                     │  allocs/op  │ allocs/op   vs base          │
EncodeECS/log/small     9.000 ± 0%   4.000 ± 0%  -55.56% (p=0.000 n=10)
EncodeECS/log/large    12.000 ± 0%   5.000 ± 0%  -58.33% (p=0.000 n=10)
EncodeECS/span/small   11.000 ± 0%   6.000 ± 0%  -45.45% (p=0.000 n=10)
EncodeECS/span/large   14.000 ± 0%   7.000 ± 0%  -50.00% (p=0.000 n=10)
geomean                 11.36        5.384       -52.59%
```


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
-

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests and benchmarks added.

<!--Describe the documentation added.-->
#### Documentation

-

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
