### PR TITLE
[chore][*/datadog] use confighttp defaults in tests

### DIFF
--- a/exporter/datadogexporter/internal/logs/sender_test.go
+++ b/exporter/datadogexporter/internal/logs/sender_test.go
@@ -191,9 +191,6 @@ func TestSubmitLogs(t *testing.T) {
 			})
 			defer server.Close()
 			clientConfig := confighttp.NewDefaultClientConfig()
-			// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-			clientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-			clientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
 			clientConfig.ForceAttemptHTTP2 = false
 			clientConfig.Timeout = time.Second * 10
 			clientConfig.TLS = configtls.ClientConfig{InsecureSkipVerify: true}

--- a/exporter/datadogexporter/internal/metrics/consumer.go
+++ b/exporter/datadogexporter/internal/metrics/consumer.go
@@ -85,7 +85,9 @@ func (c *Consumer) runningMetrics(timestamp uint64, buildInfo component.BuildInf
 	}
 
 	for _, lang := range metadata.Languages {
-		tags := append(buildTags, "language:"+lang) //nolint:gocritic
+		tags := make([]string, len(buildTags), len(buildTags)+1)
+		copy(tags, buildTags)
+		tags = append(tags, "language:"+lang)
 		runningMetric := DefaultMetrics("runtime_metrics", "", timestamp, tags)
 		series = append(series, runningMetric...)
 	}

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -673,9 +673,6 @@ func TestNewExporterWithProxy(t *testing.T) {
 	defer proxyServer.Close()
 
 	clientConfig := confighttp.NewDefaultClientConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	clientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-	clientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
 	clientConfig.ForceAttemptHTTP2 = false
 	clientConfig.ProxyURL = proxyServer.URL
 

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -8,7 +8,6 @@ package datadogexporter
 import (
 	"bytes"
 	"compress/gzip"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -163,7 +162,7 @@ func testTracesSource(t *testing.T, enableReceiveResourceSpansV2 bool) {
 	assert := assert.New(t)
 	params := exportertest.NewNopSettings(metadata.Type)
 	f := NewFactory()
-	ctx := context.Background() //nolint:usetesting
+	ctx := t.Context()
 	exporter, err := f.CreateTraces(ctx, params, &cfg)
 	assert.NoError(err)
 
@@ -558,8 +557,9 @@ func genTraces(traceID pcommon.TraceID, rattrs, sattrs map[string]any, kind ptra
 	if rattrs == nil {
 		return traces
 	}
-	//nolint:errcheck
-	rspans.Resource().Attributes().FromRaw(rattrs)
+	if err := rspans.Resource().Attributes().FromRaw(rattrs); err != nil {
+		return traces
+	}
 	if sattrs != nil {
 		err := span.Attributes().FromRaw(sattrs)
 		if err != nil {

--- a/extension/datadogextension/config_test.go
+++ b/extension/datadogextension/config_test.go
@@ -28,11 +28,6 @@ import (
 
 func TestConfig_Validate(t *testing.T) {
 	serverConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	serverConfig.WriteTimeout = 0
-	serverConfig.ReadHeaderTimeout = 0
-	serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	serverConfig.NetAddr = confignet.AddrConfig{
 		Transport: confignet.TransportTypeTCP,
 		Endpoint:  "localhost:8080",
@@ -187,9 +182,6 @@ func TestConfig_Validate(t *testing.T) {
 func TestExtensionWithProxyConfig(t *testing.T) {
 	// Create config with proxy settings
 	clientConfig := confighttp.NewDefaultClientConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	clientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-	clientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
 	clientConfig.ForceAttemptHTTP2 = false
 	clientConfig.ProxyURL = "http://proxy.example.com:8080"
 	clientConfig.Timeout = 30 * time.Second
@@ -241,11 +233,6 @@ func TestExtensionWithProxyConfig(t *testing.T) {
 
 func TestConfig_DeploymentTypeDefault(t *testing.T) {
 	serverConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	serverConfig.WriteTimeout = 0
-	serverConfig.ReadHeaderTimeout = 0
-	serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	serverConfig.NetAddr = confignet.AddrConfig{
 		Transport: confignet.TransportTypeTCP,
 		Endpoint:  "localhost:8080",
@@ -269,11 +256,6 @@ func TestConfig_DeploymentTypeDefault(t *testing.T) {
 
 func TestConfig_InstallationMethodDefault(t *testing.T) {
 	serverConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	serverConfig.WriteTimeout = 0
-	serverConfig.ReadHeaderTimeout = 0
-	serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	serverConfig.NetAddr = confignet.AddrConfig{
 		Transport: confignet.TransportTypeTCP,
 		Endpoint:  "localhost:8080",
@@ -313,11 +295,6 @@ func TestConfig_InstallationMethodValidValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			serverConfig := confighttp.NewDefaultServerConfig()
-			// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-			serverConfig.WriteTimeout = 0
-			serverConfig.ReadHeaderTimeout = 0
-			serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-			serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 			serverConfig.NetAddr = confignet.AddrConfig{
 				Transport: confignet.TransportTypeTCP,
 				Endpoint:  "localhost:8080",
@@ -381,11 +358,6 @@ func TestConfig_DeploymentTypeValidValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			serverConfig := confighttp.NewDefaultServerConfig()
-			// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-			serverConfig.WriteTimeout = 0
-			serverConfig.ReadHeaderTimeout = 0
-			serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-			serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 			serverConfig.NetAddr = confignet.AddrConfig{
 				Transport: confignet.TransportTypeTCP,
 				Endpoint:  "localhost:8080",
@@ -416,11 +388,6 @@ func TestConfig_DeploymentTypeValidValues(t *testing.T) {
 func TestConfig_GatewayTopologyFields(t *testing.T) {
 	baseConfig := func() Config {
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:8080",

--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -94,11 +94,6 @@ func TestExtensionLifecycle(t *testing.T) {
 		hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -177,11 +172,6 @@ func TestNotifyConfig(t *testing.T) {
 		hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -235,11 +225,6 @@ func TestCollectorResourceAttributesArePopulated(t *testing.T) {
 	hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 	uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 	serverConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	serverConfig.WriteTimeout = 0
-	serverConfig.ReadHeaderTimeout = 0
-	serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	serverConfig.NetAddr = confignet.AddrConfig{
 		Transport: confignet.TransportTypeTCP,
 		Endpoint:  "localhost:0",
@@ -287,11 +272,6 @@ func TestCollectorResourceAttributesWithMultipleKeys(t *testing.T) {
 	hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 	uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 	serverConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	serverConfig.WriteTimeout = 0
-	serverConfig.ReadHeaderTimeout = 0
-	serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	serverConfig.NetAddr = confignet.AddrConfig{
 		Transport: confignet.TransportTypeTCP,
 		Endpoint:  "localhost:0",
@@ -351,11 +331,6 @@ func TestNotifyConfigErrorPaths(t *testing.T) {
 		hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -398,11 +373,6 @@ func TestNotifyConfigErrorPaths(t *testing.T) {
 		hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -443,11 +413,6 @@ func TestNotifyConfigErrorPaths(t *testing.T) {
 		hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -534,11 +499,6 @@ func TestExtension_DeploymentTypeInPayload(t *testing.T) {
 			hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 			uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 			serverConfig := confighttp.NewDefaultServerConfig()
-			// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-			serverConfig.WriteTimeout = 0
-			serverConfig.ReadHeaderTimeout = 0
-			serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-			serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 			serverConfig.NetAddr = confignet.AddrConfig{
 				Transport: confignet.TransportTypeTCP,
 				Endpoint:  "localhost:0",
@@ -592,11 +552,6 @@ func TestPeriodicPayloadSending(t *testing.T) {
 		hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -655,11 +610,6 @@ func TestPeriodicPayloadSending(t *testing.T) {
 		hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -720,11 +670,6 @@ func TestPeriodicPayloadSending(t *testing.T) {
 		hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -792,11 +737,6 @@ func TestNotifyConfigConcurrentAccess(t *testing.T) {
 		hostProvider := &mockSourceProvider{source: source.Source{Kind: source.HostnameKind, Identifier: "test-host"}}
 		uuidProvider := &mockUUIDProvider{mockUUID: "test-uuid"}
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -871,9 +811,6 @@ func TestNotifyConfigConcurrentAccess(t *testing.T) {
 func TestBuildAgentConfigPropagatesTLSSetting(t *testing.T) {
 	t.Run("insecure_skip_verify true propagates to skip_ssl_validation", func(t *testing.T) {
 		clientConfig := confighttp.NewDefaultClientConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		clientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-		clientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
 		clientConfig.ForceAttemptHTTP2 = false
 		clientConfig.TLS = configtls.ClientConfig{InsecureSkipVerify: true}
 		cfg := &Config{
@@ -1063,11 +1000,6 @@ func TestExtensionLivenessMetric(t *testing.T) {
 
 		// Create extension with test config
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -1145,11 +1077,6 @@ func TestExtensionLivenessMetric(t *testing.T) {
 
 		// Create extension without configured hostname
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",
@@ -1223,11 +1150,6 @@ func TestExtensionLivenessMetric(t *testing.T) {
 
 		// Create extension
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: confignet.TransportTypeTCP,
 			Endpoint:  "localhost:0",

--- a/extension/datadogextension/integration_test.go
+++ b/extension/datadogextension/integration_test.go
@@ -618,11 +618,6 @@ func TestHTTPServerIntegration(t *testing.T) {
 
 	// Step 3: Create HTTP server configuration
 	httpServerConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	httpServerConfig.WriteTimeout = 0
-	httpServerConfig.ReadHeaderTimeout = 0
-	httpServerConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	httpServerConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	httpServerConfig.NetAddr = confignet.AddrConfig{
 		Transport: confignet.TransportTypeTCP,
 		Endpoint:  "localhost:0",
@@ -757,21 +752,11 @@ func TestHTTPServerConfigIntegration(t *testing.T) {
 
 	// Test different server configurations
 	defaultServerConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	defaultServerConfig.WriteTimeout = 0
-	defaultServerConfig.ReadHeaderTimeout = 0
-	defaultServerConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	defaultServerConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	defaultServerConfig.NetAddr = confignet.AddrConfig{
 		Transport: confignet.TransportTypeTCP,
 		Endpoint:  httpserver.DefaultServerEndpoint,
 	}
 	customServerConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	customServerConfig.WriteTimeout = 0
-	customServerConfig.ReadHeaderTimeout = 0
-	customServerConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	customServerConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	customServerConfig.NetAddr = confignet.AddrConfig{
 		Transport: confignet.TransportTypeTCP,
 		Endpoint:  "localhost:9999",
@@ -867,11 +852,6 @@ func TestHTTPServerConcurrentAccess(t *testing.T) {
 
 	// Create server
 	httpServerConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	httpServerConfig.WriteTimeout = 0
-	httpServerConfig.ReadHeaderTimeout = 0
-	httpServerConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	httpServerConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	httpServerConfig.NetAddr = confignet.AddrConfig{
 		Transport: confignet.TransportTypeTCP,
 		Endpoint:  "localhost:0",

--- a/extension/datadogextension/internal/httpserver/httpserver_test.go
+++ b/extension/datadogextension/internal/httpserver/httpserver_test.go
@@ -47,11 +47,6 @@ func TestServerStart(t *testing.T) {
 				}))
 				defer server.Close()
 				serverConfig := confighttp.NewDefaultServerConfig()
-				// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-				serverConfig.WriteTimeout = 0
-				serverConfig.ReadHeaderTimeout = 0
-				serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-				serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 				serverConfig.NetAddr = confignet.AddrConfig{
 					Transport: "tcp",
 					Endpoint:  endpoint,
@@ -178,11 +173,6 @@ func TestPrepareAndSendFleetAutomationPayloads(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, logs, serializer := tt.setupTest()
 			serverConfig := confighttp.NewDefaultServerConfig()
-			// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-			serverConfig.WriteTimeout = 0
-			serverConfig.ReadHeaderTimeout = 0
-			serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-			serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 			serverConfig.NetAddr = confignet.AddrConfig{
 				Transport: "tcp",
 				Endpoint:  testutil.GetAvailableLocalAddress(t),
@@ -653,11 +643,6 @@ func TestServerStopConcurrency(t *testing.T) {
 func TestServer_SendPayload(t *testing.T) {
 	logger := zap.NewNop()
 	serverConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	serverConfig.WriteTimeout = 0
-	serverConfig.ReadHeaderTimeout = 0
-	serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	serverConfig.NetAddr = confignet.AddrConfig{
 		Transport: "tcp",
 		Endpoint:  "localhost:0",
@@ -689,11 +674,6 @@ func TestServer_SendPayload(t *testing.T) {
 func TestServer_SendPayload_ForwarderNotStarted(t *testing.T) {
 	logger := zap.NewNop()
 	serverConfig := confighttp.NewDefaultServerConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	serverConfig.WriteTimeout = 0
-	serverConfig.ReadHeaderTimeout = 0
-	serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-	serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 	serverConfig.NetAddr = confignet.AddrConfig{
 		Transport: "tcp",
 		Endpoint:  "localhost:0",
@@ -758,11 +738,6 @@ func TestNewServerErrorPaths(t *testing.T) {
 
 		// Create server but don't start it
 		serverConfig := confighttp.NewDefaultServerConfig()
-		// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-		serverConfig.WriteTimeout = 0
-		serverConfig.ReadHeaderTimeout = 0
-		serverConfig.IdleTimeout = 0           //nolint:staticcheck // SA1019: see TODO above
-		serverConfig.KeepAlivesEnabled = false //nolint:staticcheck // SA1019: see TODO above
 		serverConfig.NetAddr = confignet.AddrConfig{
 			Transport: "tcp",
 			Endpoint:  "localhost:0", // Valid endpoint

--- a/pkg/datadog/agentcomponents/agentcomponents_test.go
+++ b/pkg/datadog/agentcomponents/agentcomponents_test.go
@@ -393,9 +393,6 @@ func TestWithProxy(t *testing.T) {
 			}
 
 			clientConfig := confighttp.NewDefaultClientConfig()
-			// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-			clientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-			clientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
 			clientConfig.ForceAttemptHTTP2 = false
 			clientConfig.ProxyURL = tt.proxyURL
 			cfg := &datadogconfig.Config{
@@ -431,9 +428,6 @@ func TestWithTLSSetting(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clientConfig := confighttp.NewDefaultClientConfig()
-			// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-			clientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-			clientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
 			clientConfig.ForceAttemptHTTP2 = false
 			clientConfig.TLS = configtls.ClientConfig{InsecureSkipVerify: tt.insecureSkipVerify}
 			cfg := &datadogconfig.Config{

--- a/pkg/datadog/config/config_test.go
+++ b/pkg/datadog/config/config_test.go
@@ -34,9 +34,6 @@ func TestValidate(t *testing.T) {
 	someAuth := configoptional.Some(configauth.Config{AuthenticatorID: component.NewID(ty)})
 
 	tlsClientConfig := confighttp.NewDefaultClientConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	tlsClientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-	tlsClientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
 	tlsClientConfig.ForceAttemptHTTP2 = false
 	tlsClientConfig.TLS = configtls.ClientConfig{
 		InsecureSkipVerify: true,
@@ -56,9 +53,6 @@ func TestValidate(t *testing.T) {
 	httpClientConfig.TLS = configtls.ClientConfig{InsecureSkipVerify: true}
 
 	unsupportedClientConfig := confighttp.NewDefaultClientConfig()
-	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
-	unsupportedClientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
-	unsupportedClientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
 	unsupportedClientConfig.ForceAttemptHTTP2 = false
 	unsupportedClientConfig.Endpoint = "endpoint"
 	unsupportedClientConfig.Compression = "gzip"


### PR DESCRIPTION
#### Description
Use confighttp defaults in tests and remove setting to 0s
Also a bunch of small linter fixes

#### Link to tracking issue
related to #49316 

#### Authorship

- [x] I, a human, wrote this pull request description myself.

