### PR TITLE
[pkg/expohisto] Add a WithMaxScale option to config

### DIFF
--- a/.chloggen/expohisto-maxscale.yaml
+++ b/.chloggen/expohisto-maxscale.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/expohisto
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a WithMaxScale option to config
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50570]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Histograms only ever downscale, so the starting scale bounds their resolution.
+  Previously it was fixed at the package maximum. Setting a lower max scale keeps
+  bucket boundaries stable across a histogram's lifetime when the recorded range
+  cannot exceed max size, which makes histograms from separate instances directly
+  comparable.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/expohisto/structure/config.go
+++ b/pkg/expohisto/structure/config.go
@@ -14,7 +14,13 @@
 
 package structure // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/expohisto/structure"
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/expohisto/mapping/exponent"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/expohisto/mapping/logarithm"
+)
 
 // DefaultMaxSize is the default maximum number of buckets per
 // positive or negative number range.  The value 160 is specified by
@@ -33,9 +39,31 @@ const MinSize = 2
 // of giant histograms.
 const MaximumMaxSize = 16384
 
+// MaximumMaxScale is the largest scale supported by the mapping
+// functions in this package.  Using this scale means the maximum
+// number of buckets that can fit within the range of a signed 32-bit
+// integer index could be used.
+const MaximumMaxScale int32 = logarithm.MaxScale
+
+// MinimumMaxScale is the smallest scale supported by the mapping
+// functions in this package.  Using this scale means only two buckets
+// will be used.
+const MinimumMaxScale int32 = exponent.MinScale
+
+// DefaultMaxScale is the default scale a histogram starts at.  Since
+// histograms only ever downscale, starting at the maximum scale
+// yields the highest resolution that fits within MaxSize.
+const DefaultMaxScale int32 = MaximumMaxScale
+
 // Config contains configuration for exponential histogram creation.
 type Config struct {
 	maxSize int32
+
+	// maxScale is the scale a histogram starts at.  Because 0 is a
+	// valid scale, maxScaleSet records whether it was set
+	// explicitly.
+	maxScale    int32
+	maxScaleSet bool
 }
 
 // Option is the interface that applies a configuration option.
@@ -59,6 +87,24 @@ func (ms maxSize) apply(cfg Config) Config {
 	return cfg
 }
 
+// WithMaxScale sets the scale a histogram starts at, which bounds its
+// resolution.  Histograms only ever downscale, therefore a value low
+// enough that MaxSize can never be exceeded keeps the bucket
+// boundaries fixed for the lifetime of the histogram.
+func WithMaxScale(scale int32) Option {
+	return maxScale(scale)
+}
+
+// maxScale is an option to set the maximum histogram scale.
+type maxScale int32
+
+// apply implements Option.
+func (ms maxScale) apply(cfg Config) Config {
+	cfg.maxScale = int32(ms)
+	cfg.maxScaleSet = true
+	return cfg
+}
+
 // NewConfig returns an exponential histogram configuration with
 // defaults and limits applied.
 func NewConfig(opts ...Option) Config {
@@ -79,21 +125,39 @@ func (c Config) Valid() bool {
 // boolean indicating whether the the input was a valid
 // configurations.
 func (c Config) Validate() (Config, error) {
-	if c.maxSize >= MinSize && c.maxSize <= MaximumMaxSize {
-		return c, nil
-	}
-	if c.maxSize == 0 {
-		c.maxSize = DefaultMaxSize
-		return c, nil
-	}
-	err := fmt.Errorf("invalid histogram size: %d", c.maxSize)
+	var errs []error
+
 	switch {
-	case c.maxSize < 0:
+	case c.maxSize == 0:
 		c.maxSize = DefaultMaxSize
-	case c.maxSize < MinSize:
-		c.maxSize = MinSize
-	case c.maxSize > MaximumMaxSize:
-		c.maxSize = MaximumMaxSize
+	case c.maxSize >= MinSize && c.maxSize <= MaximumMaxSize:
+		// Valid.
+	default:
+		errs = append(errs, fmt.Errorf("invalid histogram size: %d", c.maxSize))
+		switch {
+		case c.maxSize < 0:
+			c.maxSize = DefaultMaxSize
+		case c.maxSize < MinSize:
+			c.maxSize = MinSize
+		default:
+			c.maxSize = MaximumMaxSize
+		}
 	}
-	return c, err
+
+	switch {
+	case !c.maxScaleSet:
+		c.maxScale = DefaultMaxScale
+		c.maxScaleSet = true
+	case c.maxScale >= MinimumMaxScale && c.maxScale <= MaximumMaxScale:
+		// Valid.
+	default:
+		errs = append(errs, fmt.Errorf("invalid histogram max scale: %d", c.maxScale))
+		if c.maxScale < MinimumMaxScale {
+			c.maxScale = MinimumMaxScale
+		} else {
+			c.maxScale = MaximumMaxScale
+		}
+	}
+
+	return c, errors.Join(errs...)
 }

--- a/pkg/expohisto/structure/config.go
+++ b/pkg/expohisto/structure/config.go
@@ -46,8 +46,9 @@ const MaximumMaxSize = 16384
 const MaximumMaxScale int32 = logarithm.MaxScale
 
 // MinimumMaxScale is the smallest scale supported by the mapping
-// functions in this package.  Using this scale means only two buckets
-// will be used.
+// functions in this package.  At this scale each bucket spans a factor
+// of 2**1024, so the whole float64 range falls into a handful of
+// buckets.
 const MinimumMaxScale int32 = exponent.MinScale
 
 // DefaultMaxScale is the default scale a histogram starts at.  Since
@@ -121,9 +122,9 @@ func (c Config) Valid() bool {
 	return err == nil
 }
 
-// Validate returns the nearest valid Config object to the input and a
-// boolean indicating whether the the input was a valid
-// configurations.
+// Validate returns the nearest valid Config object to the input and an
+// error describing each invalid field, or nil when the input was
+// valid.
 func (c Config) Validate() (Config, error) {
 	var errs []error
 

--- a/pkg/expohisto/structure/config_test.go
+++ b/pkg/expohisto/structure/config_test.go
@@ -30,4 +30,39 @@ func TestConfigValid(t *testing.T) {
 	require.False(t, NewConfig(WithMaxSize(-1)).Valid())
 	require.False(t, NewConfig(WithMaxSize(1<<20)).Valid())
 	require.False(t, NewConfig(WithMaxSize(1)).Valid())
+
+	require.True(t, NewConfig(WithMaxScale(0)).Valid())
+	require.True(t, NewConfig(WithMaxScale(MinimumMaxScale)).Valid())
+	require.True(t, NewConfig(WithMaxScale(MaximumMaxScale)).Valid())
+
+	require.False(t, NewConfig(WithMaxScale(MinimumMaxScale-1)).Valid())
+	require.False(t, NewConfig(WithMaxScale(MaximumMaxScale+1)).Valid())
+}
+
+func TestConfigMaxScaleDefault(t *testing.T) {
+	cfg, err := Config{}.Validate()
+	require.NoError(t, err)
+	require.Equal(t, DefaultMaxScale, cfg.maxScale)
+
+	// An explicit zero is honored, it is not treated as unset.
+	cfg, err = NewConfig(WithMaxScale(0)).Validate()
+	require.NoError(t, err)
+	require.Equal(t, int32(0), cfg.maxScale)
+}
+
+func TestConfigMaxScaleClamped(t *testing.T) {
+	cfg, err := NewConfig(WithMaxScale(MaximumMaxScale + 5)).Validate()
+	require.Error(t, err)
+	require.Equal(t, MaximumMaxScale, cfg.maxScale)
+
+	cfg, err = NewConfig(WithMaxScale(MinimumMaxScale - 5)).Validate()
+	require.Error(t, err)
+	require.Equal(t, MinimumMaxScale, cfg.maxScale)
+}
+
+func TestConfigInvalidSizeAndScale(t *testing.T) {
+	cfg, err := NewConfig(WithMaxSize(1), WithMaxScale(MaximumMaxScale+1)).Validate()
+	require.Error(t, err)
+	require.Equal(t, int32(MinSize), cfg.maxSize)
+	require.Equal(t, MaximumMaxScale, cfg.maxScale)
 }

--- a/pkg/expohisto/structure/exponential.go
+++ b/pkg/expohisto/structure/exponential.go
@@ -37,6 +37,10 @@ type (
 		// Copy and Move.
 		maxSize int32
 
+		// maxScale is the scale the histogram starts at and
+		// returns to when cleared.  it is set by Init().
+		maxScale int32
+
 		// sum is the sum of all Updates reflected in the
 		// aggregator.  It has the same type number as the
 		// corresponding sdkinstrument.Descriptor.
@@ -160,8 +164,9 @@ func (h *Histogram[N]) Init(cfg Config) {
 	cfg, _ = cfg.Validate()
 
 	h.maxSize = cfg.maxSize
+	h.maxScale = cfg.maxScale
 
-	m, _ := newMapping(logarithm.MaxScale)
+	m, _ := newMapping(cfg.maxScale)
 	h.mapping = m
 }
 
@@ -249,7 +254,7 @@ func (h *Histogram[N]) Clear() {
 	h.zeroCount = 0
 	h.min = 0
 	h.max = 0
-	h.mapping, _ = newMapping(logarithm.MaxScale)
+	h.mapping, _ = newMapping(h.maxScale)
 }
 
 // clear zeros the backing array.

--- a/pkg/expohisto/structure/exponential_test.go
+++ b/pkg/expohisto/structure/exponential_test.go
@@ -848,3 +848,57 @@ func TestBoundaryStatistics(t *testing.T) {
 		require.InEpsilon(t, 0.5, float64(below)/float64(total), 0.06)
 	}
 }
+
+// TestMaxScaleStartingResolution checks that WithMaxScale selects the
+// scale a histogram starts at, and that a histogram configured with a
+// low enough max scale keeps that scale as the range of values grows.
+func TestMaxScaleStartingResolution(t *testing.T) {
+	// By default a histogram starts at the maximum scale and
+	// downscales until the index range fits within MaxSize.
+	def := NewFloat64(NewConfig(WithMaxSize(160)), 1, 1e6)
+	require.Less(t, def.Scale(), DefaultMaxScale)
+
+	// At scale 0 the same values span ~20 indices, well within
+	// MaxSize, so no downscaling happens.
+	fixed := NewFloat64(NewConfig(WithMaxSize(160), WithMaxScale(0)), 1, 1e6)
+	require.Equal(t, int32(0), fixed.Scale())
+
+	// Widening the range by orders of magnitude leaves the scale
+	// unchanged, because MaxSize still cannot be exceeded.
+	fixed.Update(1e12)
+	require.Equal(t, int32(0), fixed.Scale())
+}
+
+// TestMaxScaleRestoredByClear checks that Clear returns a histogram to
+// its configured max scale rather than to the package maximum.
+func TestMaxScaleRestoredByClear(t *testing.T) {
+	h := NewFloat64(NewConfig(WithMaxSize(160), WithMaxScale(2)), 1, 2, 4)
+	require.Equal(t, int32(2), h.Scale())
+
+	h.Clear()
+	h.Update(1)
+	require.Equal(t, int32(2), h.Scale())
+}
+
+// TestMaxScaleStillDownscales checks that MaxSize continues to bound
+// the number of buckets when the configured max scale is too fine for
+// the range of values recorded.
+func TestMaxScaleStillDownscales(t *testing.T) {
+	h := NewFloat64(NewConfig(WithMaxSize(2), WithMaxScale(MaximumMaxScale)), 1, 1e6)
+	require.Less(t, h.Scale(), MaximumMaxScale)
+	require.LessOrEqual(t, h.Positive().Len(), uint32(2))
+}
+
+// TestMaxScaleMergeUsesCoarserScale checks that merging into a
+// histogram configured with a coarser max scale does not raise the
+// destination's resolution.
+func TestMaxScaleMergeUsesCoarserScale(t *testing.T) {
+	src := NewFloat64(NewConfig(WithMaxSize(160)), 1, 2)
+	require.Greater(t, src.Scale(), int32(0))
+
+	dst := NewFloat64(NewConfig(WithMaxSize(160), WithMaxScale(0)), 1)
+	dst.MergeFrom(src)
+
+	require.Equal(t, int32(0), dst.Scale())
+	require.Equal(t, uint64(3), dst.Count())
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Previously, maxScale was always set to logarithm.MaxScale.
Add a `WithMaxScale` option to config in `pkg/expohisto` which helps to change maxScale and control the scale for expohisto.

Setting maxScale as 0 and not setting it are distinguished for backward compatibility

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Add test for validate and check maxScale

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
