### PR TITLE
[chore] [extension/sumologicextension] Fix flaky registration retry tests racing with heartbeat

### DIFF
--- a/extension/sumologicextension/extension_test.go
+++ b/extension/sumologicextension/extension_test.go
@@ -1880,6 +1880,12 @@ func TestRegistrationRetriesWithoutInvalidFleetID(t *testing.T) {
 		case 3:
 			assert.Equal(t, metadataURL, req.URL.Path)
 			w.WriteHeader(http.StatusOK)
+
+		// any subsequent request must be a heartbeat fired by the
+		// heartbeat loop that Start() launches in a goroutine
+		default:
+			assert.Equal(t, heartbeatURL, req.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
 		}
 	}))
 
@@ -1901,7 +1907,11 @@ func TestRegistrationRetriesWithoutInvalidFleetID(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, se.Start(t.Context(), componenttest.NewNopHost()))
 
-	assert.Equal(t, int32(3), reqCount.Load(), "expected exactly 3 requests: failed register, successful register, metadata")
+	// The heartbeat loop that Start() launches in a goroutine can fire an
+	// additional request before this assertion runs, so require at least the
+	// three registration/metadata requests rather than an exact count. The
+	// server handler asserts that any extra request is a heartbeat.
+	assert.GreaterOrEqual(t, reqCount.Load(), int32(3), "expected at least 3 requests: failed register, successful register, metadata")
 
 	require.NoError(t, se.Shutdown(t.Context()))
 }
@@ -1949,6 +1959,12 @@ func TestRegistrationRetriesWithoutFleetIDWhenFleetNotFound(t *testing.T) {
 		case 3:
 			assert.Equal(t, metadataURL, req.URL.Path)
 			w.WriteHeader(http.StatusOK)
+
+		// any subsequent request must be a heartbeat fired by the
+		// heartbeat loop that Start() launches in a goroutine
+		default:
+			assert.Equal(t, heartbeatURL, req.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
 		}
 	}))
 
@@ -1970,7 +1986,11 @@ func TestRegistrationRetriesWithoutFleetIDWhenFleetNotFound(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, se.Start(t.Context(), componenttest.NewNopHost()))
 
-	assert.Equal(t, int32(3), reqCount.Load(), "expected exactly 3 requests: failed register, successful register, metadata")
+	// The heartbeat loop that Start() launches in a goroutine can fire an
+	// additional request before this assertion runs, so require at least the
+	// three registration/metadata requests rather than an exact count. The
+	// server handler asserts that any extra request is a heartbeat.
+	assert.GreaterOrEqual(t, reqCount.Load(), int32(3), "expected at least 3 requests: failed register, successful register, metadata")
 
 	require.NoError(t, se.Shutdown(t.Context()))
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR fixes intermittent failures in `TestRegistrationRetriesWithoutFleetIDWhenFleetNotFound` and `TestRegistrationRetriesWithoutInvalidFleetID`, which asserted an exact request count of 3 immediately after `Start()` returns. `Start()` launches the heartbeat loop in a goroutine, whose first iteration fires a heartbeat request right away, so under load the count races to 4 and the tests fail (expected 3, actual 4).

The three registration/metadata requests are synchronous and always complete before `Start()` returns, so only the heartbeat can be request at 4 or later. This PR also asserts `GreaterOrEqual(3)` instead of an exact count, and adds a default case to the test server that asserts any extra request is the heartbeat, so an unexpected extra registration is still caught.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50324

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tuned.
<!--Describe the documentation added.-->
#### Documentation
N/A
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
