### PR TITLE
[receiver/prometheusremotewrite] Validate exemplar trace and span ID length

### DIFF
--- a/.chloggen/50547-prw-exemplar-trace-span-validation.yaml
+++ b/.chloggen/50547-prw-exemplar-trace-span-validation.yaml
@@ -1,0 +1,8 @@
+change_type: bug_fix
+component: receiver/prometheusremotewrite
+note: Validate exemplar trace and span ID length and preserve invalid IDs as filtered attributes.
+issues: [50547]
+subtext: |
+  trace_id and span_id labels are now validated for exact length (32 hex characters for Trace ID and 16 hex characters for Span ID).
+  Invalid IDs are no longer padded or truncated into synthetic IDs, and are preserved in the exemplar's filtered attributes.
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/exemplars.go
+++ b/receiver/prometheusremotewritereceiver/exemplars.go
@@ -111,36 +111,64 @@ func extractScopeFromLabels(settings receiver.Settings, ls labels.Labels) (strin
 	return name, version
 }
 
-// setTraceAndSpan extracts trace ID and span ID from exemplar labels
-// and sets them on the provided Exemplar.
-//
-// The function expects hexadecimal-encoded IDs using Prometheus
-// exemplar label keys and silently ignores invalid values.
-func setTraceAndSpan(exemplar pmetric.Exemplar, labels labels.Labels) {
-	if tid := labels.Get(prometheus.ExemplarTraceIDKey); tid != "" {
-		var t [16]byte
-		if b, err := hex.DecodeString(tid); err == nil {
-			copy(t[:], b)
-			exemplar.SetTraceID(pcommon.TraceID(t))
+// decodeTraceID decodes a trace ID string and returns a valid pcommon.TraceID
+// if the string is exactly 32 hex characters and not an all-zero ID.
+func decodeTraceID(tid string) (pcommon.TraceID, bool) {
+	if len(tid) != 32 {
+		return pcommon.TraceID{}, false
+	}
+	var t [16]byte
+	if b, err := hex.DecodeString(tid); err == nil {
+		copy(t[:], b)
+		id := pcommon.TraceID(t)
+		if !id.IsEmpty() {
+			return id, true
 		}
 	}
-	if sid := labels.Get(prometheus.ExemplarSpanIDKey); sid != "" {
-		var s [8]byte
-		if b, err := hex.DecodeString(sid); err == nil {
-			copy(s[:], b)
-			exemplar.SetSpanID(pcommon.SpanID(s))
+	return pcommon.TraceID{}, false
+}
+
+// decodeSpanID decodes a span ID string and returns a valid pcommon.SpanID
+// if the string is exactly 16 hex characters and not an all-zero ID.
+func decodeSpanID(sid string) (pcommon.SpanID, bool) {
+	if len(sid) != 16 {
+		return pcommon.SpanID{}, false
+	}
+	var s [8]byte
+	if b, err := hex.DecodeString(sid); err == nil {
+		copy(s[:], b)
+		id := pcommon.SpanID(s)
+		if !id.IsEmpty() {
+			return id, true
 		}
+	}
+	return pcommon.SpanID{}, false
+}
+
+// setTraceAndSpan extracts trace ID and span ID from exemplar labels
+// and sets them on the provided Exemplar if they are valid non-zero hex-encoded IDs.
+func setTraceAndSpan(exemplar pmetric.Exemplar, labels labels.Labels) {
+	if id, ok := decodeTraceID(labels.Get(prometheus.ExemplarTraceIDKey)); ok {
+		exemplar.SetTraceID(id)
+	}
+	if id, ok := decodeSpanID(labels.Get(prometheus.ExemplarSpanIDKey)); ok {
+		exemplar.SetSpanID(id)
 	}
 }
 
-// copyExemplarAttributes copies all labels into the destination attribute map
-// except for trace ID and span ID labels, which are handled separately.
-//
-// The destination map is typically the exemplar's filtered attributes.
+// copyExemplarAttributes copies labels into the destination attribute map.
+// Valid trace_id and span_id labels that were converted to the exemplar's
+// TraceID and SpanID are omitted, while invalid or other labels are preserved.
 func copyExemplarAttributes(dest pcommon.Map, labels labels.Labels) {
 	for k, v := range labels.Map() {
-		if k == prometheus.ExemplarTraceIDKey || k == prometheus.ExemplarSpanIDKey {
-			continue
+		if k == prometheus.ExemplarTraceIDKey {
+			if _, ok := decodeTraceID(v); ok {
+				continue
+			}
+		} else if k == prometheus.ExemplarSpanIDKey {
+			if _, ok := decodeSpanID(v); ok {
+				continue
+			}
 		}
 		dest.PutStr(k, v)
 	}

--- a/receiver/prometheusremotewritereceiver/exemplars_test.go
+++ b/receiver/prometheusremotewritereceiver/exemplars_test.go
@@ -4,13 +4,16 @@
 package prometheusremotewritereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver"
 
 import (
+	"encoding/hex"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	promremote "github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -196,6 +199,113 @@ func TestCollectExemplars_ErrorsAndEdgeCases(t *testing.T) {
 
 			for i, msg := range tt.expectedWarnMsgs {
 				assert.Equal(t, msg, warns[i].Message)
+			}
+		})
+	}
+}
+
+func TestSetTraceAndSpan_ValidationAndAttributePreservation(t *testing.T) {
+	tests := []struct {
+		name                 string
+		labels               labels.Labels
+		expectedTraceIDEmpty bool
+		expectedSpanIDEmpty  bool
+		expectedTraceIDHex   string
+		expectedSpanIDHex    string
+		expectedFiltered     map[string]string
+	}{
+		{
+			name: "valid trace_id and span_id are mapped and omitted from filtered attributes",
+			labels: labels.FromStrings(
+				"trace_id", "4bf92f3577b34da6a3ce929d0e0e4736",
+				"span_id", "00f067aa0ba902b7",
+				"custom_label", "value1",
+			),
+			expectedTraceIDHex: "4bf92f3577b34da6a3ce929d0e0e4736",
+			expectedSpanIDHex:  "00f067aa0ba902b7",
+			expectedFiltered: map[string]string{
+				"custom_label": "value1",
+			},
+		},
+		{
+			name: "over-long trace_id (48 chars) is not truncated and kept as filtered attribute",
+			labels: labels.FromStrings(
+				"trace_id", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"span_id", "00f067aa0ba902b7",
+			),
+			expectedTraceIDEmpty: true,
+			expectedSpanIDHex:    "00f067aa0ba902b7",
+			expectedFiltered: map[string]string{
+				"trace_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		},
+		{
+			name: "short trace_id (8 chars) is not zero-padded and kept as filtered attribute",
+			labels: labels.FromStrings(
+				"trace_id", "aaaaaaaa",
+				"span_id", "bbbb",
+			),
+			expectedTraceIDEmpty: true,
+			expectedSpanIDEmpty:  true,
+			expectedFiltered: map[string]string{
+				"trace_id": "aaaaaaaa",
+				"span_id":  "bbbb",
+			},
+		},
+		{
+			name: "invalid non-hex trace_id of length 32 is kept as filtered attribute",
+			labels: labels.FromStrings(
+				"trace_id", "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+				"span_id", "xxxxxxxxxxxxxxxx",
+			),
+			expectedTraceIDEmpty: true,
+			expectedSpanIDEmpty:  true,
+			expectedFiltered: map[string]string{
+				"trace_id": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+				"span_id":  "xxxxxxxxxxxxxxxx",
+			},
+		},
+		{
+			name: "all-zero trace_id and span_id are invalid in OTel and kept as filtered attribute",
+			labels: labels.FromStrings(
+				"trace_id", "00000000000000000000000000000000",
+				"span_id", "0000000000000000",
+			),
+			expectedTraceIDEmpty: true,
+			expectedSpanIDEmpty:  true,
+			expectedFiltered: map[string]string{
+				"trace_id": "00000000000000000000000000000000",
+				"span_id":  "0000000000000000",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			slice := pmetric.NewExemplarSlice()
+			ex := slice.AppendEmpty()
+
+			setTraceAndSpan(ex, tt.labels)
+			copyExemplarAttributes(ex.FilteredAttributes(), tt.labels)
+
+			if tt.expectedTraceIDEmpty {
+				assert.True(t, ex.TraceID().IsEmpty())
+			} else {
+				tid := ex.TraceID()
+				assert.Equal(t, tt.expectedTraceIDHex, hex.EncodeToString(tid[:]))
+			}
+
+			if tt.expectedSpanIDEmpty {
+				assert.True(t, ex.SpanID().IsEmpty())
+			} else {
+				sid := ex.SpanID()
+				assert.Equal(t, tt.expectedSpanIDHex, hex.EncodeToString(sid[:]))
+			}
+
+			attrs := ex.FilteredAttributes().AsRaw()
+			assert.Equal(t, len(tt.expectedFiltered), len(attrs))
+			for k, v := range tt.expectedFiltered {
+				assert.Equal(t, v, attrs[k])
 			}
 		})
 	}

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -3114,9 +3114,9 @@ func TestTranslateV2(t *testing.T) {
 					"instance", "host1", // 3, 4
 					"__name__", "http_requests_total", // 5, 6
 					"status", "200", "500", // 7, 8, 9
-					"trace_id", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 10, 11
+					"trace_id", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 10, 11
 					"span_id", "aaaaaaaaaaaaaaaa", // 12, 13
-					"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", // 14
+					"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", // 14
 					"bbbbbbbbbbbbbbbb", // 15
 				},
 				Timeseries: []writev2.TimeSeries{
@@ -3180,7 +3180,7 @@ func TestTranslateV2(t *testing.T) {
 				ex200 := dp200.Exemplars().AppendEmpty()
 				ex200.SetDoubleValue(100)
 				ex200.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				traceA, _ := hex.DecodeString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"[:32])
+				traceA, _ := hex.DecodeString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 				var tidA [16]byte
 				copy(tidA[:], traceA)
 				ex200.SetTraceID(pcommon.TraceID(tidA))
@@ -3197,7 +3197,7 @@ func TestTranslateV2(t *testing.T) {
 				ex500 := dp500.Exemplars().AppendEmpty()
 				ex500.SetDoubleValue(5)
 				ex500.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				traceB, _ := hex.DecodeString("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"[:32])
+				traceB, _ := hex.DecodeString("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 				var tidB [16]byte
 				copy(tidB[:], traceB)
 				ex500.SetTraceID(pcommon.TraceID(tidB))


### PR DESCRIPTION
#### Description
In `receiver/prometheusremotewrite`, `setTraceAndSpan` previously decoded any hex string into a fixed-size byte array without verifying that `trace_id` had length 32 (16 bytes) or `span_id` had length 16 (8 bytes). Consequently:
- Short IDs were zero-padded to 16/8 bytes.
- Over-long IDs were silently truncated to 16/8 bytes.
- `copyExemplarAttributes` unconditionally stripped `trace_id` and `span_id` labels from the exemplar's filtered attributes, losing the sender's original values entirely.

According to the OpenTelemetry compatibility specification:
> If present, and if the values are valid Trace and Span IDs, the `trace_id` and `span_id` labels MUST be converted to the OpenTelemetry Exemplar's Trace ID and Span ID, respectively. All labels other than `trace_id` and `span_id` MUST be added to the OpenTelemetry exemplar as filtered attributes.

#### Fix
1. `setTraceAndSpan`: Only sets `TraceID` if `len(trace_id) == 32` and sets `SpanID` if `len(span_id) == 16` and both decode cleanly as hex.
2. `copyExemplarAttributes`: Only filters out `trace_id` and `span_id` if they are valid IDs (length 32 and 16 respectively and valid hex). Invalid/unconverted IDs are retained in the exemplar's filtered attributes.
3. Added unit tests for validation and attribute preservation.
4. Added changelog fragment under `.chloggen/`.

#### Link to tracking issue
Fixes #50547

#### Testing
```bash
go test -v ./receiver/prometheusremotewritereceiver/...
```
All tests pass.