### PR TITLE
Keep multiple timestamped series in a single scrape

### DIFF
--- a/.chloggen/prometheusreceiver-multiple-timestamped-samples.yaml
+++ b/.chloggen/prometheusreceiver-multiple-timestamped-samples.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve multiple explicitly timestamped samples for the same gauge or counter series within a single Prometheus scrape.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50089]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -27,10 +27,15 @@ type metricFamily struct {
 	mtype pmetric.MetricType
 	// isMonotonic only applies to sums
 	isMonotonic bool
-	groups      map[uint64]*metricGroup
+	groups      map[metricGroupKey]*metricGroup
 	name        string
 	metadata    *scrape.MetricMetadata
 	groupOrders []*metricGroup
+}
+
+type metricGroupKey struct {
+	seriesRef uint64
+	timestamp int64
 }
 
 // metricGroup, represents a single metric of a metric family. for example a histogram metric is usually represent by
@@ -73,7 +78,7 @@ func newMetricFamily(metricName string, mc scrape.MetricMetadataStore, logger *z
 	return &metricFamily{
 		mtype:       mtype,
 		isMonotonic: isMonotonic,
-		groups:      make(map[uint64]*metricGroup),
+		groups:      make(map[metricGroupKey]*metricGroup),
 		name:        familyName,
 		metadata:    metadata,
 	}
@@ -443,7 +448,16 @@ func populateAttributes(mType pmetric.MetricType, ls labels.Labels, dest pcommon
 	})
 }
 
-func (mf *metricFamily) loadMetricGroupOrCreate(groupKey uint64, ls labels.Labels, ts int64) *metricGroup {
+func (mf *metricFamily) groupKey(seriesRef uint64, ts int64) metricGroupKey {
+	key := metricGroupKey{seriesRef: seriesRef}
+	if mf.mtype == pmetric.MetricTypeGauge || mf.mtype == pmetric.MetricTypeSum {
+		key.timestamp = ts
+	}
+	return key
+}
+
+func (mf *metricFamily) loadMetricGroupOrCreate(seriesRef uint64, ls labels.Labels, ts int64) *metricGroup {
+	groupKey := mf.groupKey(seriesRef, ts)
 	mg, ok := mf.groups[groupKey]
 	if !ok {
 		mg = &metricGroup{
@@ -640,8 +654,8 @@ func (mf *metricFamily) appendMetric(metrics pmetric.MetricSlice, trimSuffixes b
 	metric.MoveTo(metrics.AppendEmpty())
 }
 
-func (mf *metricFamily) addExemplar(seriesRef uint64, e exemplar.Exemplar) {
-	mg := mf.groups[seriesRef]
+func (mf *metricFamily) addExemplar(seriesRef uint64, ts int64, e exemplar.Exemplar) {
+	mg := mf.groups[mf.groupKey(seriesRef, ts)]
 	if mg == nil {
 		return
 	}

--- a/receiver/prometheusreceiver/internal/metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/metricfamily_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
@@ -1181,6 +1182,44 @@ func TestMetricGroupData_toNumberDataUnitTest(t *testing.T) {
 			got := ndpL.At(0)
 			want := tt.want()
 			require.Equal(t, want, got, "Expected the points to be equal")
+		})
+	}
+}
+
+func TestMetricFamilyMultipleScalarSamples(t *testing.T) {
+	for _, metricName := range []string{"counter", "gauge"} {
+		t.Run(metricName, func(t *testing.T) {
+			mf := newMetricFamily(metricName, mc, zap.NewNop(), false, false)
+			ls := labels.FromStrings("a", "A")
+			seriesRef, _ := getSeriesRefWithoutScopeLabels(nil, ls, mf.mtype)
+
+			require.NoError(t, mf.addSeries(seriesRef, metricName, ls, 10, 1))
+			mf.addExemplar(seriesRef, 10, exemplar.Exemplar{Ts: 9, Value: 11})
+			require.NoError(t, mf.addSeries(seriesRef, metricName, ls, 20, 2))
+			mf.addExemplar(seriesRef, 20, exemplar.Exemplar{Ts: 19, Value: 22})
+
+			metrics := pmetric.NewMetricSlice()
+			mf.appendMetric(metrics, false)
+			require.Len(t, mf.groups, 2)
+			require.Equal(t, 1, metrics.Len())
+
+			var points pmetric.NumberDataPointSlice
+			if mf.mtype == pmetric.MetricTypeSum {
+				points = metrics.At(0).Sum().DataPoints()
+			} else {
+				points = metrics.At(0).Gauge().DataPoints()
+			}
+			require.Equal(t, 2, points.Len())
+
+			require.Equal(t, pcommon.Timestamp(10*time.Millisecond), points.At(0).Timestamp())
+			require.Equal(t, 1.0, points.At(0).DoubleValue())
+			require.Equal(t, 1, points.At(0).Exemplars().Len())
+			require.Equal(t, 11.0, points.At(0).Exemplars().At(0).DoubleValue())
+
+			require.Equal(t, pcommon.Timestamp(20*time.Millisecond), points.At(1).Timestamp())
+			require.Equal(t, 2.0, points.At(1).DoubleValue())
+			require.Equal(t, 1, points.At(1).Exemplars().Len())
+			require.Equal(t, 22.0, points.At(1).Exemplars().At(0).DoubleValue())
 		})
 	}
 }

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -255,7 +255,7 @@ func (t *transaction) getOrCreateMetricFamily(key resourceKey, scope scopeID, mn
 	return curMf
 }
 
-func (t *transaction) appendExemplar(l labels.Labels, e exemplar.Exemplar) error {
+func (t *transaction) appendExemplar(l labels.Labels, sampleTimestamp int64, e exemplar.Exemplar) error {
 	select {
 	case <-t.ctx.Done():
 		return errTransactionAborted
@@ -282,7 +282,7 @@ func (t *transaction) appendExemplar(l labels.Labels, e exemplar.Exemplar) error
 	t.addScopeAttributesFromLabels(*rKey, scope, attrs)
 	mf := t.getOrCreateMetricFamily(*rKey, scope, mn)
 	seriesRef := t.getSeriesRef(l, mf.mtype)
-	mf.addExemplar(seriesRef, e)
+	mf.addExemplar(seriesRef, sampleTimestamp, e)
 
 	return nil
 }
@@ -697,7 +697,7 @@ func (t *transaction) Append(_ storage.SeriesRef, ls labels.Labels, stMs, atMs i
 
 	// Append the exemplars, continuing on error to try all exemplars.
 	for _, exemplar := range opts.Exemplars {
-		if err := t.appendExemplar(originalLS, exemplar); err != nil {
+		if err := t.appendExemplar(originalLS, atMs, exemplar); err != nil {
 			continue
 		}
 	}

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -411,7 +411,7 @@ func testAppendExemplarWithNoMetricName(t *testing.T) {
 		model.JobLabel, "test",
 	)
 
-	err := tr.appendExemplar(labels, exemplar.Exemplar{Value: 0})
+	err := tr.appendExemplar(labels, 0, exemplar.Exemplar{Value: 0})
 	assert.Equal(t, errMetricNameNotFound, err)
 }
 
@@ -428,7 +428,7 @@ func testAppendExemplarWithEmptyMetricName(t *testing.T) {
 		model.JobLabel, "test",
 		model.MetricNameLabel, "",
 	)
-	err := tr.appendExemplar(labels, exemplar.Exemplar{Value: 0})
+	err := tr.appendExemplar(labels, 0, exemplar.Exemplar{Value: 0})
 	assert.Equal(t, errMetricNameNotFound, err)
 }
 
@@ -447,7 +447,7 @@ func testAppendExemplarWithDuplicateLabels(t *testing.T) {
 		"a", "b",
 		"a", "c",
 	)
-	err := tr.appendExemplar(labels, exemplar.Exemplar{Value: 0})
+	err := tr.appendExemplar(labels, 0, exemplar.Exemplar{Value: 0})
 	assert.ErrorContains(t, err, `invalid sample: non-unique label names: "a"`)
 }
 
@@ -465,7 +465,7 @@ func testAppendExemplarWithoutAddingMetric(t *testing.T) {
 		model.MetricNameLabel, "counter_test",
 		"a", "b",
 	)
-	err := tr.appendExemplar(labels, exemplar.Exemplar{Value: 0})
+	err := tr.appendExemplar(labels, 0, exemplar.Exemplar{Value: 0})
 	assert.NoError(t, err)
 }
 
@@ -477,7 +477,7 @@ func testAppendExemplarWithNoLabels(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 	tr := newTransaction(scrapeCtx, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
 
-	err := tr.appendExemplar(labels.EmptyLabels(), exemplar.Exemplar{Value: 0})
+	err := tr.appendExemplar(labels.EmptyLabels(), 0, exemplar.Exemplar{Value: 0})
 	assert.Equal(t, errNoJobInstance, err)
 }
 
@@ -489,7 +489,7 @@ func testAppendExemplarWithEmptyLabelArray(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 	tr := newTransaction(scrapeCtx, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
 
-	err := tr.appendExemplar(labels.FromStrings(), exemplar.Exemplar{Value: 0})
+	err := tr.appendExemplar(labels.FromStrings(), 0, exemplar.Exemplar{Value: 0})
 	assert.Equal(t, errNoJobInstance, err)
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

If a scrape target exposes multiple series with the same metric name + label set, they are currently dropped even if they are correctly timestamped to bypass the scrape timestamp.

However, it only does so for Gauges and Counters since it was easier to implement and the compliance test doesn't actually test summaries/histograms. The bug still exists for these types 😅 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to a problem found in #50089 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
