### PR TITLE
[chore] Promote `pkg.translator.prometheus.PermissiveLabelSanitization` to beta

### DIFF
--- a/.chloggen/50429-promote-permissive-label-sanitization-beta.yaml
+++ b/.chloggen/50429-promote-permissive-label-sanitization-beta.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote the pkg.translator.prometheus.PermissiveLabelSanitization feature gate from alpha to beta, enabling it by default.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Labels starting with a single underscore (e.g. `_foo`) will no longer be
+  prefixed with `key_` by default. To restore the previous behavior, disable the
+  feature gate: `--feature-gates=-pkg.translator.prometheus.PermissiveLabelSanitization`.
+  This change prepares for the removal of the deprecated
+  `otlptranslator.LabelNamer.UnderscoreLabelSanitization` field upstream.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/translator/prometheus/documentation.md
+++ b/pkg/translator/prometheus/documentation.md
@@ -8,6 +8,6 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `pkg.translator.prometheus.PermissiveLabelSanitization` | alpha | Controls whether to change labels starting with '_' to 'key_'. | v0.55.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8950) |
+| `pkg.translator.prometheus.PermissiveLabelSanitization` | beta | Controls whether to change labels starting with '_' to 'key_'. | v0.55.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8950) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/pkg/translator/prometheus/internal/metadata/generated_feature_gates.go
+++ b/pkg/translator/prometheus/internal/metadata/generated_feature_gates.go
@@ -8,7 +8,7 @@ import (
 
 var PkgTranslatorPrometheusPermissiveLabelSanitizationFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"pkg.translator.prometheus.PermissiveLabelSanitization",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("Controls whether to change labels starting with '_' to 'key_'."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8950"),
 	featuregate.WithRegisterFromVersion("v0.55.0"),

--- a/pkg/translator/prometheus/metadata.yaml
+++ b/pkg/translator/prometheus/metadata.yaml
@@ -9,6 +9,6 @@ status:
 feature_gates:
   - id: pkg.translator.prometheus.PermissiveLabelSanitization
     description: Controls whether to change labels starting with '_' to 'key_'.
-    stage: alpha
+    stage: beta
     from_version: v0.55.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8950


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR promotes the `pkg.translator.prometheus.PermissiveLabelSanitization` feature gate from alpha to beta, enabling it by default.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50429

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
