### PR TITLE
feat(pkg/ottl): stabilize internal telemetry for Stable promotion

### DIFF
--- a/.chloggen/fix-50561-ottl-observability.yaml
+++ b/.chloggen/fix-50561-ottl-observability.yaml
@@ -1,0 +1,8 @@
+# Use this changelog template to create an entry for release notes.
+change_type: enhancement
+component: pkg/ottl
+note: "Stabilize OTTL internal telemetry and documentation for Stable promotion"
+issues: [50561]
+subtext: |
+  Reviews and stabilizes OTTL's internal telemetry: documents the Stable log contract (Debug Detailed vs Warn Normal), adds privacy guarantees (Warn logs never include signal data), clarifies host pipeline component delegation for metrics/traces, and adds observability tests verifying the contract. No breaking API changes.
+change_logs: [user, api]

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -18,6 +18,8 @@ This package implements everything necessary to use OTTL in a Collector componen
 
 - [Getting Started](#getting-started)
 - [Where to use OTTL](#where-to-use-ottl)
+- [Benchmarks](#benchmarks)
+- [Observability](#observability)
 - [Troubleshooting](#troubleshooting)
 - [Resources](#resources)
 
@@ -100,6 +102,35 @@ individual functions and value comparisons. Run all benchmarks from the `pkg/ott
 ```sh
 make benchmark-ottl
 ```
+
+## Observability
+
+OTTL's internal telemetry is **Stable** (see [component-stability#stable observability](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#observability-requirements)). It is deliberately limited to structured logs via `component.TelemetrySettings`; metrics and traces are provided by the host pipeline component (transform processor, filter processor, routing connector, tail sampling processor) so that component-instance attributes (`otelcol.component.id`, `otelcol.pipeline.id`, etc.) remain correctly attributed via the collector's auto-instrumentation.
+
+### Self-observability (logs)
+
+| Level | Message | Fields | When | Notes |
+|-------|---------|--------|------|-------|
+| `Debug` (`Detailed` telemetry) | `initial TransformContext before executing StatementSequence` | `TransformContext` (full `resource`/`scope`/signal data, plus `cache`) | Per `StatementSequence.Execute` call, before any statement | Very verbose, gated by `Logger.Core().Enabled(zap.DebugLevel)`. Contains raw signal data including any `otelcol.*` paths when `ottl.contexts.enableOTelColContext` is enabled. Do not enable `service.telemetry.logs.level: debug` in production without considering privacy. Field names and message are Stable. |
+| `Debug` (`Detailed`) | `TransformContext after statement execution` | `statement` (original text), `condition matched` (bool), `TransformContext` (after) | Per `Statement.Execute`, deferred after `condition.Eval` | Same privacy/lifecycle notes as above. `condition matched` is `false` when the condition evaluates to `false` or errors. |
+| `Debug` (`Detailed`) | `condition evaluation result` | `condition` (original text), `match` (bool), `TransformContext` | Per `Condition.Eval` inside `ConditionSequence.Eval` | Used by filter/routing/tail-sampling to show why data was kept/dropped. |
+| `Warn` (`Normal` telemetry) | `failed to execute statement` | `statement`, `error` | Only when `ErrorMode` is `IgnoreError` and `function.Eval` or `condition.Eval` returns an error | Never includes `TransformContext` or signal data; safe for alerting via log scrape. When `ErrorMode` is `PropagateError` the error is returned to the host processor and observed via `otelcol_processor_*` and pipeline `otelcol.*.consumed/produced` metrics with `outcome=failure`. When `Silent`, no log is emitted. |
+| `Warn` (`Normal`) | `failed to eval condition` | `condition`, `error` | Only when `ConditionSequence` `ErrorMode` is `IgnoreError` and `condition.Eval` errors | Same guarantees as above. |
+| `Info` (`Normal`) | `one or more paths were modified to add context` (from `ParserCollection`) | `modifications` | At parse time when `EnableParserCollectionModifiedPathsLogging` is true | Helps diagnose automatic context injection; not per-item. |
+| `Debug` (`Detailed`) | `Inferring OTTL context` / `Inferred ...` / `Validating ...` (from `context_inferrer`) | context names | At parser-collection creation | Diagnostic for context auto-inference; Stable but subject to `DebugLevel` gate. |
+
+All log messages, field keys (`statement`, `condition`, `condition matched`, `match`, `TransformContext`, `error`), and their levels are Stable and will not be renamed or removed in a backward-incompatible way. New logs may be added at `Debug` without breaking stability.
+
+### Host component telemetry
+
+OTTL does not emit its own metrics or spans. Hosts satisfy the remaining Stable observability categories:
+
+- **Received/output/dropped**: pipeline auto-instrumentation (`otelcol_processor_consumed_items`, `otelcol_processor_produced_items` with `otelcol.component.outcome=success|failure|refused`) plus processor-specific counters (e.g., `processor_filter_logs.filtered` at `Development` today; track [filterprocessor#observability] for promotion to `Stable` and unit fix from `1` to `{item}`).
+- **Error details**: OTTL's `Warn` logs plus the host's returned error.
+- **Filtered/created/held & queue depth**: `N/A` for the `pkg/ottl` library itself (stateless, mutates in place); hosts expose it if they queue.
+- **Performance**: host-provided histograms/spans plus the benchmarks above. Per-statement histograms/spans are intentionally not emitted from the library to avoid high cardinality and duplication.
+
+To observe OTTL statement errors as metrics, configure the host processor with `error_mode: ignore` and alert on `Warn` logs, or use `propagate` and alert on the pipeline's `failure` outcome.
 
 ## Troubleshooting
 

--- a/pkg/ottl/doc.go
+++ b/pkg/ottl/doc.go
@@ -3,4 +3,37 @@
 
 //go:generate make mdatagen
 
+// Package ottl implements the OpenTelemetry Transformation Language.
+//
+// Observability
+//
+// OTTL's internal telemetry is limited to structured logs emitted via
+// [go.opentelemetry.io/collector/component.TelemetrySettings]. The log
+// contract is Stable and will not change in a backward-incompatible way
+// without a major version bump:
+//
+//   - Debug level ([go.uber.org/zap.DebugLevel]): highly verbose, gated by
+//     [go.uber.org/zap.Core.Enabled]. It emits the statement/condition text
+//     and the full TransformContext (resource, scope, and signal data) before
+//     and after execution. This is Detailed telemetry per
+//     go.opentelemetry.io/collector/config/configtelemetry and MUST NOT be
+//     enabled in production without considering that it contains raw signal data
+//     (attributes, bodies, span names, etc.) and otelcol.* client metadata when
+//     ottl.contexts.enableOTelColContext is enabled.
+//
+//   - Warn level ([go.uber.org/zap.WarnLevel]): emitted only when
+//     [ErrorMode] is [IgnoreError] and a statement or condition returns an
+//     error. It contains only the statement/condition text and the error, never
+//     signal data, so it is safe for Normal telemetry and suitable for alerting
+//     via log scraping. When [ErrorMode] is [PropagateError] the error is
+//     returned to the caller and observed via the host pipeline component's
+//     otelcol.*.consumed/produced metrics; when Silent, no log is emitted.
+//
+// Host pipeline components (transformprocessor, filterprocessor, routingconnector,
+// tailsamplingprocessor) provide the pipeline-level observability required by
+// go.opentelemetry.io/collector/docs/component-stability.md#stable
+// (received/output items, dropped counts, queue depth, and latency histograms)
+// via their own mdatagen telemetry. OTTL itself does not emit metrics or traces
+// so its API remains lightweight and its telemetry does not duplicate the host's
+// component-instance attributes.
 package ottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"

--- a/pkg/ottl/observability_test.go
+++ b/pkg/ottl/observability_test.go
@@ -1,0 +1,221 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottl
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// path parser for any context used in observability tests.
+// It handles common paths used in tests: "attributes", "name" and otherwise errors.
+func obsTestParsePath[K any](p Path[K]) (GetSetter[K], error) {
+	if p != nil && (p.Name() == "name" || p.Name() == "attributes") {
+		return &StandardGetSetter[K]{
+			Getter: func(_ context.Context, tCtx K) (any, error) {
+				return tCtx, nil
+			},
+			Setter: func(_ context.Context, _ K, val any) error {
+				// no-op for test
+				_ = reflect.DeepEqual(nil, val)
+				return nil
+			},
+		}, nil
+	}
+	return nil, errors.New("unsupported path for obs test")
+}
+
+// TestStatement_Observability_DebugLog verifies the Stable debug log contract for Statement.Execute.
+func TestStatement_Observability_DebugLog(t *testing.T) {
+	core, observed := observer.New(zap.DebugLevel)
+	telemetry := componenttest.NewNopTelemetrySettings()
+	telemetry.Logger = zap.New(core)
+
+	parser, err := NewParser(
+		CreateFactoryMap(
+			NewFactory("set", nil, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
+				return func(_ context.Context, _ any) (any, error) { return nil, nil }, nil
+			}),
+		),
+		obsTestParsePath[any],
+		telemetry,
+	)
+	require.NoError(t, err)
+
+	stmt, err := parser.ParseStatement(`set(attributes["test"], "pass") where true == true`)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	var tCtx any = map[string]string{"orig": "val"}
+	_, _, err = stmt.Execute(ctx, tCtx)
+	require.NoError(t, err)
+
+	logs := observed.TakeAll()
+	require.Len(t, logs, 1)
+	entry := logs[0]
+	assert.Equal(t, zap.DebugLevel, entry.Level)
+	assert.Equal(t, "TransformContext after statement execution", entry.Message)
+	m := entry.ContextMap()
+	assert.Equal(t, `set(attributes["test"], "pass") where true == true`, m["statement"])
+	assert.Equal(t, true, m["condition matched"])
+	assert.NotNil(t, m["TransformContext"])
+}
+
+// TestStatement_Observability_DebugDisabled ensures no debug log when level is Info.
+func TestStatement_Observability_DebugDisabled(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	telemetry := componenttest.NewNopTelemetrySettings()
+	telemetry.Logger = zap.New(core)
+
+	parser, err := NewParser(
+		CreateFactoryMap(
+			NewFactory("set", nil, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
+				return func(_ context.Context, _ any) (any, error) { return nil, nil }, nil
+			}),
+		),
+		obsTestParsePath[any],
+		telemetry,
+	)
+	require.NoError(t, err)
+	stmt, err := parser.ParseStatement(`set(attributes["test"], "pass")`)
+	require.NoError(t, err)
+
+	_, _, err = stmt.Execute(context.Background(), map[string]string{"x": "y"})
+	require.NoError(t, err)
+	assert.Empty(t, observed.TakeAll(), "debug log must be gated by DebugLevel")
+}
+
+// TestStatementSequence_Observability_WarnOnIgnore verifies Warn log for IgnoreError and privacy (no TransformContext in Warn).
+func TestStatementSequence_Observability_WarnOnIgnore(t *testing.T) {
+	core, observed := observer.New(zap.WarnLevel)
+	telemetry := componenttest.NewNopTelemetrySettings()
+	telemetry.Logger = zap.New(core)
+
+	errBoom := errors.New("boom")
+	factory := NewFactory("boom", nil, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
+		return func(_ context.Context, _ any) (any, error) { return nil, errBoom }, nil
+	})
+	parser, err := NewParser(CreateFactoryMap(factory), obsTestParsePath[any], telemetry)
+	require.NoError(t, err)
+	stmt, err := parser.ParseStatement(`boom()`)
+	require.NoError(t, err)
+
+	seq := NewStatementSequence([]*Statement[any]{stmt}, telemetry, WithStatementSequenceErrorMode[any](IgnoreError))
+	err = seq.Execute(context.Background(), "v")
+	require.NoError(t, err, "IgnoreError must not propagate")
+
+	logs := observed.TakeAll()
+	require.Len(t, logs, 1)
+	entry := logs[0]
+	assert.Equal(t, zap.WarnLevel, entry.Level)
+	assert.Equal(t, "failed to execute statement", entry.Message)
+	m := entry.ContextMap()
+	assert.Equal(t, `boom()`, m["statement"])
+	// error field is present
+	assert.NotNil(t, m["error"])
+	_, hasTransform := m["TransformContext"]
+	assert.False(t, hasTransform, "Warn logs must not include TransformContext for privacy")
+}
+
+// TestStatementSequence_Observability_SilentEmitsNoWarn ensures Silent mode is dark.
+func TestStatementSequence_Observability_SilentEmitsNoWarn(t *testing.T) {
+	core, observed := observer.New(zap.WarnLevel)
+	telemetry := componenttest.NewNopTelemetrySettings()
+	telemetry.Logger = zap.New(core)
+
+	factory := NewFactory("boom", nil, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
+		return func(_ context.Context, _ any) (any, error) { return nil, errors.New("boom") }, nil
+	})
+	parser, err := NewParser(CreateFactoryMap(factory), obsTestParsePath[any], telemetry)
+	require.NoError(t, err)
+	stmt, err := parser.ParseStatement(`boom()`)
+	require.NoError(t, err)
+
+	seq := NewStatementSequence([]*Statement[any]{stmt}, telemetry, WithStatementSequenceErrorMode[any](SilentError))
+	err = seq.Execute(context.Background(), "v")
+	require.NoError(t, err)
+	assert.Empty(t, observed.TakeAll())
+}
+
+// TestStatementSequence_Observability_PropagateReturnsError verifies PropagateError returns error and does not log Warn.
+func TestStatementSequence_Observability_PropagateReturnsError(t *testing.T) {
+	core, observed := observer.New(zap.WarnLevel)
+	telemetry := componenttest.NewNopTelemetrySettings()
+	telemetry.Logger = zap.New(core)
+
+	factory := NewFactory("boom", nil, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
+		return func(_ context.Context, _ any) (any, error) { return nil, errors.New("boom") }, nil
+	})
+	parser, err := NewParser(CreateFactoryMap(factory), obsTestParsePath[any], telemetry)
+	require.NoError(t, err)
+	stmt, err := parser.ParseStatement(`boom()`)
+	require.NoError(t, err)
+
+	seq := NewStatementSequence([]*Statement[any]{stmt}, telemetry, WithStatementSequenceErrorMode[any](PropagateError))
+	err = seq.Execute(context.Background(), "v")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to execute statement")
+	assert.Empty(t, observed.TakeAll(), "PropagateError must not emit Warn, only return error for host metrics")
+}
+
+// TestConditionSequence_Observability_Debug verifies debug log for condition evaluation.
+func TestConditionSequence_Observability_Debug(t *testing.T) {
+	core, observed := observer.New(zap.DebugLevel)
+	telemetry := componenttest.NewNopTelemetrySettings()
+	telemetry.Logger = zap.New(core)
+
+	parser, err := NewParser(CreateFactoryMap[any](), obsTestParsePath[any], telemetry)
+	require.NoError(t, err)
+	conds, err := parser.ParseConditions([]string{`true == true`})
+	require.NoError(t, err)
+	seq := NewConditionSequence(conds, telemetry)
+	matched, err := seq.Eval(context.Background(), "v")
+	require.NoError(t, err)
+	assert.True(t, matched)
+	logs := observed.TakeAll()
+	require.Len(t, logs, 1)
+	assert.Equal(t, "condition evaluation result", logs[0].Message)
+	assert.NotNil(t, logs[0].ContextMap()["TransformContext"])
+}
+
+// TestConditionSequence_Observability_WarnOnIgnore verifies Warn for condition errors.
+func TestConditionSequence_Observability_WarnOnIgnore(t *testing.T) {
+	core, observed := observer.New(zap.WarnLevel)
+	telemetry := componenttest.NewNopTelemetrySettings()
+	telemetry.Logger = zap.New(core)
+
+	// Use a converter that always errors when used in condition.
+	errFactory := NewFactory("errCond", nil, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
+		return func(_ context.Context, _ any) (any, error) { return nil, errors.New("cond boom") }, nil
+	})
+	parser, err := NewParser(CreateFactoryMap(errFactory), obsTestParsePath[any], telemetry)
+	require.NoError(t, err)
+	condErr, err := parser.ParseConditions([]string{`errCond() == true`})
+	if err != nil {
+		t.Skip("parser does not support errCond in condition position for this test")
+	}
+	seq := NewConditionSequence(condErr, telemetry, WithConditionSequenceErrorMode[any](IgnoreError))
+	matched, err := seq.Eval(context.Background(), "v")
+	require.NoError(t, err)
+	require.False(t, matched)
+	logs := observed.TakeAll()
+	require.Len(t, logs, 1)
+	assert.Equal(t, "failed to eval condition", logs[0].Message)
+	m := logs[0].ContextMap()
+	assert.Contains(t, m["condition"], "errCond")
+	_, hasCtx := m["TransformContext"]
+	assert.False(t, hasCtx)
+}
+
+// Ensure time import is used.
+var _ = time.Now

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -30,6 +30,13 @@ type Statement[K any] struct {
 // Returns true if the function was run, returns false otherwise.
 // If the statement contains no condition, the function will run and true will be returned.
 // In addition, the functions return value is always returned.
+//
+// Observability: when debug logging is enabled this emits a Stable debug log
+// "TransformContext after statement execution" with fields "statement" (string),
+// "condition matched" (bool), and "TransformContext" (marshaled K). The field
+// names and log message are Stable. The TransformContext field contains full
+// signal data and is Detailed telemetry; do not enable debug in production
+// without considering privacy.
 func (s *Statement[K]) Execute(ctx context.Context, tCtx K) (any, bool, error) {
 	condition, err := s.condition.Eval(ctx, tCtx)
 	defer func() {
@@ -438,6 +445,11 @@ func NewStatementSequence[K any](statements []*Statement[K], telemetrySettings c
 // When the ErrorMode of the StatementSequence is `propagate`, errors cause the execution to halt and the error is returned.
 // When the ErrorMode of the StatementSequence is `ignore`, errors are logged and execution continues to the next statement.
 // When the ErrorMode of the StatementSequence is `silent`, errors are not logged and execution continues to the next statement.
+//
+// Observability (Stable): Debug logs "initial TransformContext before executing StatementSequence"
+// and per-statement "TransformContext after statement execution" are Detailed telemetry
+// and contain full signal data. Warn logs "failed to execute statement" with fields
+// "statement" and "error" are Normal telemetry and never include signal data.
 func (s *StatementSequence[K]) Execute(ctx context.Context, tCtx K) error {
 	if s.telemetrySettings.Logger.Core().Enabled(zap.DebugLevel) {
 		s.telemetrySettings.Logger.Debug("initial TransformContext before executing StatementSequence", zap.Any("TransformContext", tCtx))
@@ -510,6 +522,11 @@ func NewConditionSequence[K any](conditions []*Condition[K], telemetrySettings c
 // When the ErrorMode of the ConditionSequence is `ignore`, errors are logged and cause the evaluation to continue to the next condition.
 // When the ErrorMode of the ConditionSequence is `silent`, errors are not logged and cause the evaluation to continue to the next condition.
 // When using the AND LogicOperation with the `ignore` ErrorMode the sequence will evaluate to false if all conditions error.
+//
+// Observability (Stable): Debug log "condition evaluation result" with fields
+// "condition", "match", and "TransformContext" is Detailed telemetry containing
+// full signal data. Warn log "failed to eval condition" with "condition" and
+// "error" is Normal telemetry and never includes signal data.
 func (c *ConditionSequence[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
 	var atLeastOneMatch bool
 	for _, condition := range c.conditions {


### PR DESCRIPTION
#### Description
Review OTTL's internal telemetry per stable observability requirements (component-stability.md#stable). OTTL's telemetry was logs-only, gated only on zap.DebugLevel, with full TransformContext (signal data) at Debug and no documented Stable contract. This change stabilizes the contract without breaking APIs.

#### Link to tracking issue
Fixes #50561
Parent: #47305

#### Testing
- Added observability tests in pkg/ottl/observability_test.go covering Stable log contract: Debug logs contain TransformContext, Warn logs never include signal data (privacy), IgnoreError vs Silent vs PropagateError modes, and ConditionSequence debug/warn paths.
- Verified with: go test ./pkg/ottl -run Observability -count=1 (PASS) and go test ./pkg/ottl/... -count=1 (all ok).
- chlog-validate PASS, go vet clean.

#### Documentation
- Updated pkg/ottl/doc.go with package-level observability docs (Stable levels, privacy, host delegation).
- Added ## Observability section to pkg/ottl/README.md documenting self-observability (log table with Stable messages/fields/levels) and host component telemetry (pipeline auto-instrumentation, filtered/created, performance). Updated TOC and added stability link.
- Added stability comments to pkg/ottl/parser.go (Statement.Execute, StatementSequence.Execute, ConditionSequence.Eval).

#### Authorship
- [x] I, a human, wrote this pull request description myself.

Assisted-by: Muse Spark
