### PR TITLE
[exporter/doris] Drop non-finite metric values instead of failing the batch

### DIFF
--- a/.chloggen/50569-doris-nonfinite.yaml
+++ b/.chloggen/50569-doris-nonfinite.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/doris
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Drop metric data points carrying non-finite float values (NaN, +Inf, -Inf) instead of failing the whole export batch.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50569]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  encoding/json cannot serialize NaN, +Inf or -Inf, so a single such data point
+  previously made the entire batch fail before it reached Doris. Data points with
+  non-finite values are now skipped with a warning while the remaining valid
+  data points are still exported.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/dorisexporter/exporter_common.go
+++ b/exporter/dorisexporter/exporter_common.go
@@ -149,7 +149,12 @@ func toJSONLines[T dLog | dTrace | metric](data []*T) ([]byte, error) {
 	for _, d := range data {
 		err := enc.Encode(d)
 		if err != nil {
-			return nil, err
+			// A single non-serializable entry (e.g. a NaN/±Inf float,
+			// which encoding/json rejects) must not fail the whole batch.
+			// Skip it and keep the remaining valid entries. The add()
+			// methods already drop such data points and log a warning,
+			// so this is a defensive fallback. See #50569.
+			continue
 		}
 	}
 	return buf.Bytes(), nil

--- a/exporter/dorisexporter/metrics_exponential_histogram.go
+++ b/exporter/dorisexporter/metrics_exponential_histogram.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_exponential_histogram_ddl.sql
@@ -60,10 +61,18 @@ func (m *metricModelExponentialHistogram) add(pm pmetric.Metric, dm *dMetric, e 
 		for j := 0; j < exemplars.Len(); j++ {
 			exemplar := exemplars.At(j)
 
+			value := e.getExemplarValue(exemplar)
+			if !isFiniteNumber(value) {
+				e.logger.Warn("dropping exemplar with non-finite value",
+					zap.String("metric", pm.Name()),
+					zap.Float64("value", value))
+				continue
+			}
+
 			newExemplar := &dExemplar{
 				FilteredAttributes: exemplar.FilteredAttributes().AsRaw(),
 				Timestamp:          e.formatTime(exemplar.Timestamp().AsTime()),
-				Value:              e.getExemplarValue(exemplar),
+				Value:              value,
 				SpanID:             exemplar.SpanID().String(),
 				TraceID:            exemplar.TraceID().String(),
 			}
@@ -101,6 +110,15 @@ func (m *metricModelExponentialHistogram) add(pm pmetric.Metric, dm *dMetric, e 
 			Max:                    dp.Max(),
 			ZeroThreshold:          dp.ZeroThreshold(),
 			AggregationTemporality: pm.ExponentialHistogram().AggregationTemporality().String(),
+		}
+		if !isFiniteNumber(metric.Sum) || !isFiniteNumber(metric.Min) || !isFiniteNumber(metric.Max) ||
+			!isFiniteNumber(metric.ZeroThreshold) {
+			e.logger.Warn("dropping exponential histogram data point with non-finite value",
+				zap.String("metric", pm.Name()),
+				zap.Float64("sum", metric.Sum),
+				zap.Float64("min", metric.Min),
+				zap.Float64("max", metric.Max))
+			continue
 		}
 		m.data = append(m.data, metric)
 	}

--- a/exporter/dorisexporter/metrics_gauge.go
+++ b/exporter/dorisexporter/metrics_gauge.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_gauge_ddl.sql
@@ -49,10 +50,18 @@ func (m *metricModelGauge) add(pm pmetric.Metric, dm *dMetric, e *metricsExporte
 		for j := 0; j < exemplars.Len(); j++ {
 			exemplar := exemplars.At(j)
 
+			value := e.getExemplarValue(exemplar)
+			if !isFiniteNumber(value) {
+				e.logger.Warn("dropping exemplar with non-finite value",
+					zap.String("metric", pm.Name()),
+					zap.Float64("value", value))
+				continue
+			}
+
 			newExemplar := &dExemplar{
 				FilteredAttributes: exemplar.FilteredAttributes().AsRaw(),
 				Timestamp:          e.formatTime(exemplar.Timestamp().AsTime()),
-				Value:              e.getExemplarValue(exemplar),
+				Value:              value,
 				SpanID:             exemplar.SpanID().String(),
 				TraceID:            exemplar.TraceID().String(),
 			}
@@ -67,6 +76,12 @@ func (m *metricModelGauge) add(pm pmetric.Metric, dm *dMetric, e *metricsExporte
 			StartTime:  e.formatTime(dp.StartTimestamp().AsTime()),
 			Value:      e.getNumberDataPointValue(dp),
 			Exemplars:  newExemplars,
+		}
+		if !isFiniteNumber(metric.Value) {
+			e.logger.Warn("dropping gauge data point with non-finite value",
+				zap.String("metric", pm.Name()),
+				zap.Float64("value", metric.Value))
+			continue
 		}
 		m.data = append(m.data, metric)
 	}

--- a/exporter/dorisexporter/metrics_histogram.go
+++ b/exporter/dorisexporter/metrics_histogram.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_histogram_ddl.sql
@@ -55,10 +56,18 @@ func (m *metricModelHistogram) add(pm pmetric.Metric, dm *dMetric, e *metricsExp
 		for j := 0; j < exemplars.Len(); j++ {
 			exemplar := exemplars.At(j)
 
+			value := e.getExemplarValue(exemplar)
+			if !isFiniteNumber(value) {
+				e.logger.Warn("dropping exemplar with non-finite value",
+					zap.String("metric", pm.Name()),
+					zap.Float64("value", value))
+				continue
+			}
+
 			newExemplar := &dExemplar{
 				FilteredAttributes: exemplar.FilteredAttributes().AsRaw(),
 				Timestamp:          e.formatTime(exemplar.Timestamp().AsTime()),
-				Value:              e.getExemplarValue(exemplar),
+				Value:              value,
 				SpanID:             exemplar.SpanID().String(),
 				TraceID:            exemplar.TraceID().String(),
 			}
@@ -91,6 +100,14 @@ func (m *metricModelHistogram) add(pm pmetric.Metric, dm *dMetric, e *metricsExp
 			Min:                    dp.Min(),
 			Max:                    dp.Max(),
 			AggregationTemporality: pm.Histogram().AggregationTemporality().String(),
+		}
+		if !isFiniteNumber(metric.Sum) || !isFiniteNumber(metric.Min) || !isFiniteNumber(metric.Max) {
+			e.logger.Warn("dropping histogram data point with non-finite value",
+				zap.String("metric", pm.Name()),
+				zap.Float64("sum", metric.Sum),
+				zap.Float64("min", metric.Min),
+				zap.Float64("max", metric.Max))
+			continue
 		}
 		m.data = append(m.data, metric)
 	}

--- a/exporter/dorisexporter/metrics_model.go
+++ b/exporter/dorisexporter/metrics_model.go
@@ -3,7 +3,19 @@
 
 package dorisexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter"
 
-import "go.opentelemetry.io/collector/pdata/pmetric"
+import (
+	"math"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// isFiniteNumber reports whether v is a normal finite IEEE-754 value.
+// NaN, +Inf and -Inf cannot be serialized by encoding/json and would
+// otherwise fail the whole export batch (see #50569), so data points
+// carrying such values must be dropped before serialization.
+func isFiniteNumber(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}
 
 type metricModel interface {
 	metricType() pmetric.MetricType

--- a/exporter/dorisexporter/metrics_nonfinite_test.go
+++ b/exporter/dorisexporter/metrics_nonfinite_test.go
@@ -1,0 +1,86 @@
+package dorisexporter
+
+// Regression tests for #50569: the Doris exporter must not fail the whole
+// export batch when a metric data point carries a non-finite float value
+// (NaN, +Inf, -Inf), because encoding/json cannot serialize such values.
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+func testMetricsExporter() *metricsExporter {
+	return &metricsExporter{
+		commonExporter: &commonExporter{
+			TelemetrySettings: componenttest.NewNopTelemetrySettings(),
+			logger:            zap.NewNop(),
+			timeZone:          time.UTC,
+		},
+	}
+}
+
+// buildGaugeMetrics returns a pmetric.Metrics containing one Gauge metric
+// with three data points whose values are NaN, +Inf and 42 respectively.
+func buildGaugeMetricsWithNonFinite() pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	m := sm.Metrics().AppendEmpty()
+	m.SetName("test_metric")
+	m.SetDescription("desc")
+	m.SetUnit("1")
+	gauge := m.SetEmptyGauge()
+
+	dpNaN := gauge.DataPoints().AppendEmpty()
+	dpNaN.SetDoubleValue(math.NaN())
+
+	dpInf := gauge.DataPoints().AppendEmpty()
+	dpInf.SetDoubleValue(math.Inf(1))
+
+	dpValid := gauge.DataPoints().AppendEmpty()
+	dpValid.SetDoubleValue(42.0)
+	return md
+}
+
+func TestGaugeModelDropsNonFiniteDataPoints(t *testing.T) {
+	e := testMetricsExporter()
+	model := &metricModelGauge{}
+	dm := &dMetric{ServiceName: "svc", MetricName: "test_metric"}
+
+	pm := buildGaugeMetricsWithNonFinite().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	require.NoError(t, model.add(pm, dm, e))
+
+	require.Equal(t, 1, model.size(), "only the finite data point should be kept")
+	require.Equal(t, 42.0, model.data[0].Value)
+
+	// serialization must succeed and contain exactly the valid data point
+	out, err := model.bytes()
+	require.NoError(t, err, "bytes() must not fail when non-finite data points are dropped")
+	body := string(out)
+	assert.True(t, strings.Contains(body, "\"value\":42"))
+	assert.False(t, strings.Contains(body, "NaN"), "NaN must not appear in output")
+}
+
+func TestToJSONLinesSkipsNonFiniteWhenAlreadyInBatch(t *testing.T) {
+	// Defense in depth: even if a non-finite value slips into the internal
+	// structures, serialization must not fail the whole batch.
+	data := []*dMetricGauge{
+		{Value: 1.0},
+		{Value: math.NaN()},
+		{Value: math.Inf(-1)},
+		{Value: 2.0},
+	}
+	out, err := toJSONLines(data)
+	require.NoError(t, err, "toJSONLines must not fail on non-finite values")
+	body := string(out)
+	assert.True(t, strings.Contains(body, "\"value\":1"))
+	assert.True(t, strings.Contains(body, "\"value\":2"))
+}

--- a/exporter/dorisexporter/metrics_sum.go
+++ b/exporter/dorisexporter/metrics_sum.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_sum_ddl.sql
@@ -51,10 +52,18 @@ func (m *metricModelSum) add(pm pmetric.Metric, dm *dMetric, e *metricsExporter)
 		for j := 0; j < exemplars.Len(); j++ {
 			exemplar := exemplars.At(j)
 
+			value := e.getExemplarValue(exemplar)
+			if !isFiniteNumber(value) {
+				e.logger.Warn("dropping exemplar with non-finite value",
+					zap.String("metric", pm.Name()),
+					zap.Float64("value", value))
+				continue
+			}
+
 			newExemplar := &dExemplar{
 				FilteredAttributes: exemplar.FilteredAttributes().AsRaw(),
 				Timestamp:          e.formatTime(exemplar.Timestamp().AsTime()),
-				Value:              e.getExemplarValue(exemplar),
+				Value:              value,
 				SpanID:             exemplar.SpanID().String(),
 				TraceID:            exemplar.TraceID().String(),
 			}
@@ -71,6 +80,12 @@ func (m *metricModelSum) add(pm pmetric.Metric, dm *dMetric, e *metricsExporter)
 			Exemplars:              newExemplars,
 			AggregationTemporality: pm.Sum().AggregationTemporality().String(),
 			IsMonotonic:            pm.Sum().IsMonotonic(),
+		}
+		if !isFiniteNumber(metric.Value) {
+			e.logger.Warn("dropping sum data point with non-finite value",
+				zap.String("metric", pm.Name()),
+				zap.Float64("value", metric.Value))
+			continue
 		}
 		m.data = append(m.data, metric)
 	}

--- a/exporter/dorisexporter/metrics_summary.go
+++ b/exporter/dorisexporter/metrics_summary.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_summary_ddl.sql
@@ -72,6 +73,25 @@ func (m *metricModelSummary) add(pm pmetric.Metric, dm *dMetric, e *metricsExpor
 			Count:          int64(dp.Count()),
 			Sum:            dp.Sum(),
 			QuantileValues: newQuantileValues,
+		}
+		if !isFiniteNumber(metric.Sum) {
+			e.logger.Warn("dropping summary data point with non-finite sum",
+				zap.String("metric", pm.Name()),
+				zap.Float64("sum", metric.Sum))
+			continue
+		}
+		for _, qv := range metric.QuantileValues {
+			if !isFiniteNumber(qv.Quantile) || !isFiniteNumber(qv.Value) {
+				e.logger.Warn("dropping summary data point with non-finite quantile value",
+					zap.String("metric", pm.Name()),
+					zap.Float64("quantile", qv.Quantile),
+					zap.Float64("value", qv.Value))
+				metric = nil
+				break
+			}
+		}
+		if metric == nil {
+			continue
 		}
 		m.data = append(m.data, metric)
 	}


### PR DESCRIPTION
#### Description

The Doris exporter fails the whole export batch when a metric data point carries a non-finite float value (NaN, +Inf, -Inf). `encoding/json` cannot serialize these values, so `json.NewEncoder(...).Encode()` returns `json: unsupported value: NaN` and the batch is dropped before reaching Doris. This commonly occurs when collecting from Prometheus-compatible endpoints, where NaN appears in Gauge, Summary, Histogram or stale-metric scenarios.

The fix skips data points with non-finite values in all five metric models (gauge, sum, histogram, exponential histogram, summary) — including exemplars and summary quantile values — and logs a warning. `toJSONLines` is also made defensive: a single non-serializable entry is skipped instead of failing the whole batch, so the remaining valid data points are still exported.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50569

#### Testing

- Reproduced the failure: `toJSONLines` returned `json: unsupported value: NaN` for a data point with NaN and for a mixed batch containing one NaN + valid values.
- Added `TestGaugeModelDropsNonFiniteDataPoints` (constructs a Gauge with NaN, +Inf and 42 data points; asserts only the finite point is kept and serialization succeeds without NaN) and `TestToJSONLinesSkipsNonFiniteWhenAlreadyInBatch` (defense in depth).
- `go build ./...`, `go vet ./...`, `go test ./... -race` all pass.

#### Documentation

No documentation changes needed. Changelog entry added in `.chloggen/50569-doris-nonfinite.yaml`.

#### Authorship

This PR was prepared with AI assistance. The human author has reviewed and takes responsibility for the content.
