### PR TITLE
[processor/adaptivetailsampling] default max_keys to 500

### DIFF
--- a/.chloggen/adaptivetailsampling-max-keys-default.yaml
+++ b/.chloggen/adaptivetailsampling-max-keys-default.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: processor/adaptive_tail_sampling
+
+note: Default `max_keys` to 500 when omitted instead of unbounded; there is no longer a way to run a sampler with an unlimited key set.
+
+issues: [49311]
+
+change_logs: [user]

--- a/.chloggen/adaptivetailsampling-max-keys-default.yaml
+++ b/.chloggen/adaptivetailsampling-max-keys-default.yaml
@@ -2,7 +2,7 @@ change_type: enhancement
 
 component: processor/adaptive_tail_sampling
 
-note: Default `max_keys` to 500 when omitted instead of unbounded; there is no longer a way to run a sampler with an unlimited key set.
+note: Default `max_keys` to 500 when omitted; explicitly setting it to 0 still means unlimited.
 
 issues: [49311]
 

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -345,7 +345,7 @@ sampler:
 
 The `fingerprint_attributes` field names the attributes that identify what kind of trace this is for sampling purposes. Each distinct fingerprint value gets its own adaptive sample rate, so choose attributes that classify traffic (route, status code, method, service) rather than identify individual requests (user IDs, request IDs, raw URLs), which would give every trace its own key and defeat the adaptation.
 
-High cardinality doesn't just risk unbounded memory — it degrades goal accuracy directly, independent of `max_keys`. An adaptive sampler can never drop a key's rate below 1 (it must always keep at least one instance of any key it's tracking), so as the number of distinct keys grows, more of them sit at that rate-1 floor with only a handful of events each, and the sampler can't discard enough traffic across the keyspace to hit the configured `goal_percentage`/`goal_throughput`. Keeping the key space small is what makes the adaptive samplers effective, not just memory-safe — setting `max_keys: 0` explicitly opts back into unbounded cardinality and this risk.
+High-cardinality fingerprint attributes can produce unexpected sampling results: an adaptive sampler can never drop a key's rate below 1 (it must always keep at least one instance of any key it's tracking), so as distinct keys multiply, more of them sit at that rate-1 floor with only a handful of events each, and the sampler can't discard enough traffic to hit the configured `goal_percentage`/`goal_throughput`.
 
 Each entry is a scoped attribute selector of the form `<scope>.attributes["<name>"]`:
 

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -302,7 +302,7 @@ sampler:
     - span.attributes["http.status_code"]
   adjustment_interval: 15s                # how often the ema recalculates
   weight: 0.5                             # ema weighting factor in [0, 1); 0 or omitted = 0.5
-  max_keys: 500                           # 0 = unlimited
+  max_keys: 500                           # 0 or omitted = 500 (default); no unlimited option
 ```
 
 #### `adaptive_throughput`
@@ -344,6 +344,8 @@ sampler:
 ### Fingerprints
 
 The `fingerprint_attributes` field names the attributes that identify what kind of trace this is for sampling purposes. Each distinct fingerprint value gets its own adaptive sample rate, so choose attributes that classify traffic (route, status code, method, service) rather than identify individual requests (user IDs, request IDs, raw URLs), which would give every trace its own key and defeat the adaptation.
+
+High cardinality doesn't just risk unbounded memory — it degrades goal accuracy directly, independent of `max_keys`. An adaptive sampler can never drop a key's rate below 1 (it must always keep at least one instance of any key it's tracking), so as the number of distinct keys grows, more of them sit at that rate-1 floor with only a handful of events each, and the sampler can't discard enough traffic across the keyspace to hit the configured `goal_percentage`/`goal_throughput`. Keeping the key space small is what makes the adaptive samplers effective, not just memory-safe.
 
 Each entry is a scoped attribute selector of the form `<scope>.attributes["<name>"]`:
 

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -302,7 +302,7 @@ sampler:
     - span.attributes["http.status_code"]
   adjustment_interval: 15s                # how often the ema recalculates
   weight: 0.5                             # ema weighting factor in [0, 1); 0 or omitted = 0.5
-  max_keys: 500                           # 0 or omitted = 500 (default); no unlimited option
+  max_keys: 500                           # omit for the default of 500; 0 = unlimited
 ```
 
 #### `adaptive_throughput`
@@ -345,7 +345,7 @@ sampler:
 
 The `fingerprint_attributes` field names the attributes that identify what kind of trace this is for sampling purposes. Each distinct fingerprint value gets its own adaptive sample rate, so choose attributes that classify traffic (route, status code, method, service) rather than identify individual requests (user IDs, request IDs, raw URLs), which would give every trace its own key and defeat the adaptation.
 
-High cardinality doesn't just risk unbounded memory — it degrades goal accuracy directly, independent of `max_keys`. An adaptive sampler can never drop a key's rate below 1 (it must always keep at least one instance of any key it's tracking), so as the number of distinct keys grows, more of them sit at that rate-1 floor with only a handful of events each, and the sampler can't discard enough traffic across the keyspace to hit the configured `goal_percentage`/`goal_throughput`. Keeping the key space small is what makes the adaptive samplers effective, not just memory-safe.
+High cardinality doesn't just risk unbounded memory — it degrades goal accuracy directly, independent of `max_keys`. An adaptive sampler can never drop a key's rate below 1 (it must always keep at least one instance of any key it's tracking), so as the number of distinct keys grows, more of them sit at that rate-1 floor with only a handful of events each, and the sampler can't discard enough traffic across the keyspace to hit the configured `goal_percentage`/`goal_throughput`. Keeping the key space small is what makes the adaptive samplers effective, not just memory-safe — setting `max_keys: 0` explicitly opts back into unbounded cardinality and this risk.
 
 Each entry is a scoped attribute selector of the form `<scope>.attributes["<name>"]`:
 

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -345,7 +345,14 @@ sampler:
 
 The `fingerprint_attributes` field names the attributes that identify what kind of trace this is for sampling purposes. Each distinct fingerprint value gets its own adaptive sample rate, so choose attributes that classify traffic (route, status code, method, service) rather than identify individual requests (user IDs, request IDs, raw URLs), which would give every trace its own key and defeat the adaptation.
 
-High-cardinality fingerprint attributes can produce unexpected sampling results: an adaptive sampler can never drop a key's rate below 1 (it must always keep at least one instance of any key it's tracking), so as distinct keys multiply, more of them sit at that rate-1 floor with only a handful of events each, and the sampler can't discard enough traffic to hit the configured `goal_percentage`/`goal_throughput`.
+> [!WARNING]
+> High-cardinality fingerprint attributes degrade sampling accuracy by construction, not just by adding noise:
+>
+> - **`ema` algorithm** (the default): the sampler splits its overall budget across keys using a logarithmic weighting, so a rare key is never pushed down to a zero share — it always keeps a floor of "sample everything" for that key. As distinct keys multiply, more of them land on that floor, each still spending part of the shared budget. Once the number of active keys grows large enough, there's no longer enough budget to go around, and the sampler is structurally unable to hit the configured `goal_percentage` / `goal_throughput`.
+> - **`windowed` algorithm** (`adaptive_throughput` only): there's no logarithmic smoothing — each key's share of the budget is a straight, linear split across however many keys are currently active. Doubling the number of distinct keys immediately halves every key's share, so cardinality growth translates directly into more keys landing on the "keep everything" floor. This makes `windowed` more sensitive to cardinality spikes than `ema`.
+> - **`max_keys`** (default 500) only limits the damage: once the cap is reached, brand-new keys aren't tracked at all and default to keeping everything, rather than competing for the remaining budget.
+>
+> To get the sampling result you actually want, choose classifying attributes (route, status code, method, service) over identifying ones (user ID, request ID, session ID, raw URL), as described above.
 
 Each entry is a scoped attribute selector of the form `<scope>.attributes["<name>"]`:
 

--- a/processor/adaptivetailsamplingprocessor/config.go
+++ b/processor/adaptivetailsamplingprocessor/config.go
@@ -50,6 +50,10 @@ const (
 	AlgorithmWindowed SamplerAlgorithm = "windowed"
 )
 
+// defaultMaxKeys is the max_keys value used when a rule omits it (or sets it
+// to 0). There is no config value that requests an unbounded key set.
+const defaultMaxKeys = 500
+
 // RecordFingerprint controls whether the matched rule's fingerprint value is
 // recorded as an attribute on the spans of kept traces.
 type RecordFingerprint string
@@ -247,7 +251,8 @@ type SamplerConfig struct {
 	FingerprintAttributes []string `mapstructure:"fingerprint_attributes"`
 
 	// MaxKeys caps the number of distinct sampling keys the sampler tracks.
-	// 0 means unlimited.
+	// 0 (or omitting the field) uses the default of defaultMaxKeys; there is
+	// no way to request an unbounded key set.
 	// Used by: adaptive_percentage, adaptive_throughput.
 	MaxKeys int `mapstructure:"max_keys"`
 
@@ -499,6 +504,16 @@ func (s *SamplerConfig) effectiveAlgorithm() SamplerAlgorithm {
 		return AlgorithmEMA
 	}
 	return s.Algorithm
+}
+
+// effectiveMaxKeys returns the max_keys value a sampler should use,
+// defaulting to defaultMaxKeys when unset. Only meaningful for adaptive
+// types; validate rejects the field elsewhere.
+func (s *SamplerConfig) effectiveMaxKeys() int {
+	if s.MaxKeys == 0 {
+		return defaultMaxKeys
+	}
+	return s.MaxKeys
 }
 
 // rejectUnusedFields returns an error if any field is set that does not apply

--- a/processor/adaptivetailsamplingprocessor/config.go
+++ b/processor/adaptivetailsamplingprocessor/config.go
@@ -50,9 +50,8 @@ const (
 	AlgorithmWindowed SamplerAlgorithm = "windowed"
 )
 
-// defaultMaxKeys is the max_keys value used when a rule omits it. Explicitly
-// setting max_keys to 0 means unlimited instead, matching the underlying
-// sampler library's semantics.
+// defaultMaxKeys is the max_keys value used when a rule omits it.
+// 0 value means unlimited.
 const defaultMaxKeys = 500
 
 // RecordFingerprint controls whether the matched rule's fingerprint value is

--- a/processor/adaptivetailsamplingprocessor/config.go
+++ b/processor/adaptivetailsamplingprocessor/config.go
@@ -50,8 +50,9 @@ const (
 	AlgorithmWindowed SamplerAlgorithm = "windowed"
 )
 
-// defaultMaxKeys is the max_keys value used when a rule omits it (or sets it
-// to 0). There is no config value that requests an unbounded key set.
+// defaultMaxKeys is the max_keys value used when a rule omits it. Explicitly
+// setting max_keys to 0 means unlimited instead, matching the underlying
+// sampler library's semantics.
 const defaultMaxKeys = 500
 
 // RecordFingerprint controls whether the matched rule's fingerprint value is
@@ -251,10 +252,10 @@ type SamplerConfig struct {
 	FingerprintAttributes []string `mapstructure:"fingerprint_attributes"`
 
 	// MaxKeys caps the number of distinct sampling keys the sampler tracks.
-	// 0 (or omitting the field) uses the default of defaultMaxKeys; there is
-	// no way to request an unbounded key set.
+	// Omitting the field defaults to defaultMaxKeys; explicitly setting it
+	// to 0 means unlimited.
 	// Used by: adaptive_percentage, adaptive_throughput.
-	MaxKeys int `mapstructure:"max_keys"`
+	MaxKeys *int `mapstructure:"max_keys"`
 
 	// AdjustmentInterval is how often the ema algorithm recalculates rates
 	// from recent observations.
@@ -436,7 +437,7 @@ func (s *SamplerConfig) validate(ruleName string) error {
 		if s.Weight < 0 || s.Weight >= 1 {
 			return fmt.Errorf("rule %q: weight must be in [0, 1)", ruleName)
 		}
-		if s.MaxKeys < 0 {
+		if s.MaxKeys != nil && *s.MaxKeys < 0 {
 			return fmt.Errorf("rule %q: max_keys must be non-negative", ruleName)
 		}
 		return s.rejectUnusedFields(ruleName, "adaptive_percentage", map[string]bool{
@@ -457,7 +458,7 @@ func (s *SamplerConfig) validate(ruleName string) error {
 		if _, err := sampler.ParseSelectors(s.FingerprintAttributes); err != nil {
 			return fmt.Errorf("rule %q: %w", ruleName, err)
 		}
-		if s.MaxKeys < 0 {
+		if s.MaxKeys != nil && *s.MaxKeys < 0 {
 			return fmt.Errorf("rule %q: max_keys must be non-negative", ruleName)
 		}
 		switch s.effectiveAlgorithm() {
@@ -507,13 +508,13 @@ func (s *SamplerConfig) effectiveAlgorithm() SamplerAlgorithm {
 }
 
 // effectiveMaxKeys returns the max_keys value a sampler should use,
-// defaulting to defaultMaxKeys when unset. Only meaningful for adaptive
-// types; validate rejects the field elsewhere.
+// defaulting to defaultMaxKeys when unset (explicit 0 means unlimited).
+// Only meaningful for adaptive types; validate rejects the field elsewhere.
 func (s *SamplerConfig) effectiveMaxKeys() int {
-	if s.MaxKeys == 0 {
+	if s.MaxKeys == nil {
 		return defaultMaxKeys
 	}
-	return s.MaxKeys
+	return *s.MaxKeys
 }
 
 // rejectUnusedFields returns an error if any field is set that does not apply
@@ -541,7 +542,7 @@ func (s *SamplerConfig) rejectUnusedFields(ruleName, typeName string, allowed ma
 	if err := set("fingerprint_attributes", len(s.FingerprintAttributes) > 0); err != nil {
 		return err
 	}
-	if err := set("max_keys", s.MaxKeys != 0); err != nil {
+	if err := set("max_keys", s.MaxKeys != nil); err != nil {
 		return err
 	}
 	if err := set("adjustment_interval", s.AdjustmentInterval != 0); err != nil {

--- a/processor/adaptivetailsamplingprocessor/config_test.go
+++ b/processor/adaptivetailsamplingprocessor/config_test.go
@@ -493,3 +493,21 @@ func TestConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestSamplerConfig_effectiveMaxKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		set  int
+		want int
+	}{
+		{name: "omitted_defaults_to_500", set: 0, want: defaultMaxKeys},
+		{name: "explicit_default_value_unchanged", set: 500, want: 500},
+		{name: "explicit_non_default_value_unchanged", set: 999, want: 999},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := SamplerConfig{MaxKeys: tt.set}
+			assert.Equal(t, tt.want, s.effectiveMaxKeys())
+		})
+	}
+}

--- a/processor/adaptivetailsamplingprocessor/config_test.go
+++ b/processor/adaptivetailsamplingprocessor/config_test.go
@@ -494,8 +494,6 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
-func intPtr(v int) *int { return &v }
-
 func TestSamplerConfig_effectiveMaxKeys(t *testing.T) {
 	tests := []struct {
 		name string
@@ -503,9 +501,9 @@ func TestSamplerConfig_effectiveMaxKeys(t *testing.T) {
 		want int
 	}{
 		{name: "omitted_defaults_to_500", set: nil, want: defaultMaxKeys},
-		{name: "explicit_zero_is_unlimited", set: intPtr(0), want: 0},
-		{name: "explicit_default_value_unchanged", set: intPtr(500), want: 500},
-		{name: "explicit_non_default_value_unchanged", set: intPtr(999), want: 999},
+		{name: "explicit_zero_is_unlimited", set: new(0), want: 0},
+		{name: "explicit_default_value_unchanged", set: new(500), want: 500},
+		{name: "explicit_non_default_value_unchanged", set: new(999), want: 999},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/processor/adaptivetailsamplingprocessor/config_test.go
+++ b/processor/adaptivetailsamplingprocessor/config_test.go
@@ -494,15 +494,18 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
+func intPtr(v int) *int { return &v }
+
 func TestSamplerConfig_effectiveMaxKeys(t *testing.T) {
 	tests := []struct {
 		name string
-		set  int
+		set  *int
 		want int
 	}{
-		{name: "omitted_defaults_to_500", set: 0, want: defaultMaxKeys},
-		{name: "explicit_default_value_unchanged", set: 500, want: 500},
-		{name: "explicit_non_default_value_unchanged", set: 999, want: 999},
+		{name: "omitted_defaults_to_500", set: nil, want: defaultMaxKeys},
+		{name: "explicit_zero_is_unlimited", set: intPtr(0), want: 0},
+		{name: "explicit_default_value_unchanged", set: intPtr(500), want: 500},
+		{name: "explicit_non_default_value_unchanged", set: intPtr(999), want: 999},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/processor/adaptivetailsamplingprocessor/processor.go
+++ b/processor/adaptivetailsamplingprocessor/processor.go
@@ -255,7 +255,7 @@ func newSamplerForRule(rc *RuleConfig) (sampler.Sampler, []sampler.Selector, err
 			GoalSamplingPercentage: sc.GoalPercentage,
 			AdjustmentInterval:     sc.AdjustmentInterval,
 			Weight:                 sc.Weight,
-			MaxKeys:                sc.MaxKeys,
+			MaxKeys:                sc.effectiveMaxKeys(),
 		})
 		if err != nil {
 			return nil, nil, err
@@ -270,14 +270,14 @@ func newSamplerForRule(rc *RuleConfig) (sampler.Sampler, []sampler.Selector, err
 				GoalThroughputPerSec: float64(sc.GoalThroughput),
 				UpdateFrequency:      sc.UpdateFrequency,
 				LookbackFrequency:    sc.LookbackFrequency,
-				MaxKeys:              sc.MaxKeys,
+				MaxKeys:              sc.effectiveMaxKeys(),
 			})
 		} else {
 			s, err = sampler.NewEMAThroughput(sampler.EMAThroughputConfig{
 				GoalThroughputPerSec: sc.GoalThroughput,
 				AdjustmentInterval:   sc.AdjustmentInterval,
 				Weight:               sc.Weight,
-				MaxKeys:              sc.MaxKeys,
+				MaxKeys:              sc.effectiveMaxKeys(),
 			})
 		}
 		if err != nil {


### PR DESCRIPTION
#### Description

Use high cardinality attributes as `fingerprint_attributes` can d
egrades goal accuracy directly. An adaptive sampler can never drop a key's rate below 1 (it must always keep at least one instance of any key it's tracking), so as the number of distinct keys grows, more o
f them sit at that rate-1 floor with only a handful of eve
nts each, and the sampler can't discard enough traffic acr
oss the keyspace to hit the configured `goal_percentage`/`
goal_throughput`. Keeping the key space small is what make
s the adaptive samplers effective.
Setting a default value for max_key config in samplers that support this option.

#### Link to tracking issue
Fixes #50538

#### Testing

Through load testing, it shows that high cardinality attributes can cause unstable sampling results.

#### Documentation
documentation in readme changed to document the new default value for `max_keys`

#### Authorship

- [x] I, a human, wrote this pull request description myself.