### PR TITLE
[pkg/datadog] remove deprecated StatisAPIKeyCheck func

### DIFF
--- a/.chloggen/codeboten_cleanup-deprecated-code1.yaml
+++ b/.chloggen/codeboten_cleanup-deprecated-code1.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated func: StaticAPIKeyCheck
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_cleanup-deprecated-code1.yaml
+++ b/.chloggen/codeboten_cleanup-deprecated-code1.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: pkg/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Remove deprecated func: StaticAPIKeyCheck
+note: "Remove deprecated func: StaticAPIKeyCheck"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [50599]

--- a/.chloggen/codeboten_cleanup-deprecated-code1.yaml
+++ b/.chloggen/codeboten_cleanup-deprecated-code1.yaml
@@ -10,7 +10,7 @@ component: pkg/datadog
 note: Remove deprecated func: StaticAPIKeyCheck
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50599]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [api]

--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -181,18 +181,6 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// StaticAPIKey Check checks if api::key is either empty or contains invalid (non-hex) characters
-// It does not validate online; this is handled on startup.
-//
-// Deprecated: [v0.136.0] Do not use, will be removed on the next minor version
-func StaticAPIKeyCheck(key string) error {
-	if key == "" {
-		return ErrUnsetAPIKey
-	}
-
-	return nil
-}
-
 func validateClientConfig(cfg confighttp.ClientConfig) error {
 	var unsupported []string
 	if cfg.Auth.HasValue() {


### PR DESCRIPTION
#### Description

This has been deprecated since v0.136.0, time to remove it.


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
