### PR TITLE
[internal/k8sinventory] Bound the List used only to fetch a resourceV…

### DIFF
--- a/.chloggen/k8sinventory-resourceversion-list-limit.yaml
+++ b/.chloggen/k8sinventory-resourceversion-list-limit.yaml
@@ -1,0 +1,30 @@
+change_type: bug_fix
+
+component: internal/k8sinventory
+
+note: Limit the List used solely to obtain a resourceVersion for the watch, avoiding a full collection fetch
+
+issues: [50600]
+
+subtext: |
+  `watch.Observer.fetchListResourceVersion` performed an unbounded List purely to
+  read the collection-level `resourceVersion` from `ListMeta`, decoding every
+  object into `unstructured` and discarding all of them. Cost therefore scaled
+  with cluster object count.
+
+  On a cluster with ~190k Events this retained 2.3GB of heap (98% of process
+  heap) to produce a 10-character string, and OOM-killed a collector running the
+  k8s_events receiver with a 3GiB limit. `GET /api/v1/events` transfers 223MB
+  where `?limit=1` transfers 1355 bytes.
+
+  `ListMeta.resourceVersion` is the revision of the read's snapshot, not a
+  property of the returned items, so `Limit: 1` yields an identical watch
+  starting point. Affects the k8s_events receiver (which always takes this path,
+  hardcoding `IncludeInitialState: false`) and the k8sobjects receiver in
+  `mode: watch`. Both also take it on every watch re-establishment, since after a
+  410 Gone the observer clears `initialListRV` and falls back to
+  `getResourceVersion`.
+
+  `sendInitialState` is deliberately unchanged — it emits the items it lists.
+
+change_logs: [user]

--- a/.chloggen/k8sinventory-resourceversion-list-limit.yaml
+++ b/.chloggen/k8sinventory-resourceversion-list-limit.yaml
@@ -6,25 +6,6 @@ note: Limit the List used solely to obtain a resourceVersion for the watch, avoi
 
 issues: [50600]
 
-subtext: |
-  `watch.Observer.fetchListResourceVersion` performed an unbounded List purely to
-  read the collection-level `resourceVersion` from `ListMeta`, decoding every
-  object into `unstructured` and discarding all of them. Cost therefore scaled
-  with cluster object count.
-
-  On a cluster with ~190k Events this retained 2.3GB of heap (98% of process
-  heap) to produce a 10-character string, and OOM-killed a collector running the
-  k8s_events receiver with a 3GiB limit. `GET /api/v1/events` transfers 223MB
-  where `?limit=1` transfers 1355 bytes.
-
-  `ListMeta.resourceVersion` is the revision of the read's snapshot, not a
-  property of the returned items, so `Limit: 1` yields an identical watch
-  starting point. Affects the k8s_events receiver (which always takes this path,
-  hardcoding `IncludeInitialState: false`) and the k8sobjects receiver in
-  `mode: watch`. Both also take it on every watch re-establishment, since after a
-  410 Gone the observer clears `initialListRV` and falls back to
-  `getResourceVersion`.
-
-  `sendInitialState` is deliberately unchanged — it emits the items it lists.
+subtext: "Affects the `k8s_events` receiver and the `k8sobjects` receiver in `mode: watch`."
 
 change_logs: [user]

--- a/internal/k8sinventory/watch/observer.go
+++ b/internal/k8sinventory/watch/observer.go
@@ -378,10 +378,17 @@ func (o *Observer) doWatch(ctx context.Context, resourceVersion, _ string, watch
 
 // fetchListResourceVersion performs a List operation and returns the latest resourceVersion.
 // Returns defaultResourceVersion if the API returns an empty or zero version.
+//
+// Limit is set to 1 because only the collection-level resourceVersion from
+// ListMeta is used; the returned items are discarded. ListMeta.resourceVersion
+// is the revision of the read's snapshot rather than a property of the items,
+// so a limited List yields an equally valid watch starting point while avoiding
+// materializing the whole collection into unstructured objects.
 func (o *Observer) fetchListResourceVersion(ctx context.Context, resource dynamic.ResourceInterface) (string, error) {
 	objects, err := resource.List(ctx, metav1.ListOptions{
 		FieldSelector: o.config.FieldSelector,
 		LabelSelector: o.config.LabelSelector,
+		Limit:         1,
 	})
 	if err != nil {
 		return "", fmt.Errorf("could not perform initial list for watch on %s, %w", o.config.Gvr.String(), err)

--- a/internal/k8sinventory/watch/observer.go
+++ b/internal/k8sinventory/watch/observer.go
@@ -378,13 +378,9 @@ func (o *Observer) doWatch(ctx context.Context, resourceVersion, _ string, watch
 
 // fetchListResourceVersion performs a List operation and returns the latest resourceVersion.
 // Returns defaultResourceVersion if the API returns an empty or zero version.
-//
-// Limit is set to 1 because only the collection-level resourceVersion from
-// ListMeta is used; the returned items are discarded. ListMeta.resourceVersion
-// is the revision of the read's snapshot rather than a property of the items,
-// so a limited List yields an equally valid watch starting point while avoiding
-// materializing the whole collection into unstructured objects.
 func (o *Observer) fetchListResourceVersion(ctx context.Context, resource dynamic.ResourceInterface) (string, error) {
+	// Only ListMeta.resourceVersion is used, which is the revision of the read's snapshot
+	// rather than a property of the returned items, so the items themselves aren't needed.
 	objects, err := resource.List(ctx, metav1.ListOptions{
 		FieldSelector: o.config.FieldSelector,
 		LabelSelector: o.config.LabelSelector,

--- a/internal/k8sinventory/watch/observer_test.go
+++ b/internal/k8sinventory/watch/observer_test.go
@@ -397,6 +397,70 @@ func TestSendInitialStateReturnsListRV(t *testing.T) {
 	assert.Equal(t, "999", listRV, "sendInitialState should return the list's own ResourceVersion")
 }
 
+// TestFetchListResourceVersionBoundsList verifies the List issued purely to obtain a
+// resourceVersion is bounded. An unbounded List decodes the whole collection into
+// unstructured objects just to read a single string from ListMeta.
+func TestFetchListResourceVersionBoundsList(t *testing.T) {
+	mockClient := newMockDynamicClient()
+	mockClient.setListResourceVersion("999")
+	mockClient.createPods(
+		generatePod("pod1", "default", nil, "100"),
+		generatePod("pod2", "default", nil, "200"),
+	)
+
+	cfg := Config{
+		Config: k8sinventory.Config{
+			Gvr:           schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Namespaces:    []string{"default"},
+			LabelSelector: "environment=test",
+			FieldSelector: "metadata.name=pod1",
+		},
+	}
+
+	obs, err := New(mockClient, cfg, zap.NewNop(), nil, nil)
+	require.NoError(t, err)
+
+	recorder := &listOptionsRecorder{ResourceInterface: mockClient.Resource(cfg.Gvr).Namespace("default")}
+	version, err := obs.fetchListResourceVersion(t.Context(), recorder)
+	require.NoError(t, err)
+	assert.Equal(t, "999", version, "the collection-level RV should still be returned")
+
+	require.Len(t, recorder.opts, 1)
+	assert.Equal(t, int64(1), recorder.opts[0].Limit, "List must be bounded, see #50600")
+	// The selectors still have to be forwarded: they scope which collection is read,
+	// and therefore which snapshot revision the watch starts from.
+	assert.Equal(t, "environment=test", recorder.opts[0].LabelSelector)
+	assert.Equal(t, "metadata.name=pod1", recorder.opts[0].FieldSelector)
+}
+
+// TestSendInitialStateListsUnbounded guards the counterpart to the bound above:
+// sendInitialState emits the items it lists, so bounding it would drop initial state.
+func TestSendInitialStateListsUnbounded(t *testing.T) {
+	mockClient := newMockDynamicClient()
+	mockClient.setListResourceVersion("999")
+	mockClient.createPods(
+		generatePod("pod1", "default", nil, "100"),
+		generatePod("pod2", "default", nil, "200"),
+	)
+
+	cfg := Config{
+		Config: k8sinventory.Config{
+			Gvr:        schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Namespaces: []string{"default"},
+		},
+		IncludeInitialState: true,
+	}
+
+	obs, err := New(mockClient, cfg, zap.NewNop(), nil, nil)
+	require.NoError(t, err)
+
+	recorder := &listOptionsRecorder{ResourceInterface: mockClient.Resource(cfg.Gvr).Namespace("default")}
+	obs.sendInitialState(t.Context(), recorder, "default", func(string) {})
+
+	require.Len(t, recorder.opts, 1)
+	assert.Zero(t, recorder.opts[0].Limit, "sendInitialState must list every object, not just the first")
+}
+
 // TestInitialStateListRVPersistedAsCheckpoint verifies that after sendInitialState
 // the checkpoint is updated with the list's RV (via setLatestRV in startWatch),
 // which is more accurate than the highest individual object RV.
@@ -620,6 +684,18 @@ func (r *resourceInterceptor) List(ctx context.Context, opts v1.ListOptions) (*u
 		list.SetResourceVersion(r.resourceVersion)
 	}
 	return list, err
+}
+
+// listOptionsRecorder records the ListOptions of each List call. The fake client's
+// action log cannot be used here: ListRestrictions carries only the selectors.
+type listOptionsRecorder struct {
+	dynamic.ResourceInterface
+	opts []v1.ListOptions
+}
+
+func (r *listOptionsRecorder) List(ctx context.Context, opts v1.ListOptions) (*unstructured.UnstructuredList, error) {
+	r.opts = append(r.opts, opts)
+	return r.ResourceInterface.List(ctx, opts)
 }
 
 func generatePod(name, namespace string, labels map[string]any, resourceVersion string) *unstructured.Unstructured {


### PR DESCRIPTION
watch.Observer.fetchListResourceVersion performed an unbounded List purely to read the collection-level resourceVersion from ListMeta, decoding every object into unstructured and discarding all of them. Cost scaled with cluster object count.

On a cluster with ~190k Events this retained 2.3GB of heap (98% of process heap) to produce a 10-character string, and OOM-killed a collector running the k8s_events receiver against a 3GiB limit. GET /api/v1/events transfers 223MB where ?limit=1 transfers 1355 bytes.

ListMeta.resourceVersion is the revision of the read's snapshot, not a property of the returned items, so Limit: 1 yields an identical watch starting point. Verified by starting a watch from a limit=1 revision: accepted, streamed changes only with no replay.

sendInitialState is deliberately unchanged - it emits the items it lists.

Fixes #50600

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
