### PR TITLE
[cmd/opampsupervisor,extension/opamp] feat: UDS support for OpAMP between Supervisor and Collector

### DIFF
--- a/.chloggen/opamp-uds-trasnport-support.yaml
+++ b/.chloggen/opamp-uds-trasnport-support.yaml
@@ -1,0 +1,38 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/opamp, cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds UDS transport support to the Supervisor and OpAMP extension.
+  - Add a `server.ws.unix_socket` option to dial the OpAMP server over a Unix domain socket using the WebSocket transport.
+  - Add an `agent.opamp_server_unix_socket` option to serve the local Supervisor-to-Collector OpAMP link over a Unix domain socket with peer-credential authentication.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50603]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Add a `server.ws.unix_socket` option to dial the OpAMP server over a Unix domain socket using the WebSocket transport.
+    When `unix_socket` is set, the `endpoint` only supplies the URL scheme, request path, and Host
+    header; its host and port are ignored.
+  - Add an `agent.opamp_server_unix_socket` option to serve the local OpAMP server over a Unix domain socket.
+    When set, the Supervisor serves its local OpAMP server on the configured filesystem socket
+    instead of a TCP port and authenticates the connecting Collector via SO_PEERCRED
+    (UID and PID on Linux, UID on macOS). It is mutually exclusive with `opamp_server_port` and is
+    rejected on Windows. The socket file's permission mode can be set with
+    `agent.opamp_server_unix_socket_mode` (octal string, default `"0600"`).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/README.md
+++ b/cmd/opampsupervisor/README.md
@@ -190,6 +190,8 @@ agent:
 | Option | Description |
 |--------|-------------|
 | `startup_fallback_configs` | List of paths to startup fallback configuration files to use. If more than one path is specified, they are merged in order. Together, these must form a complete, standalone Collector configuration. |
+| `opamp_server_unix_socket` | Filesystem path to a Unix domain socket. When set, the Supervisor serves its local OpAMP server (the one the managed Collector connects to) on this socket instead of a loopback TCP port, so no TCP port is opened for Supervisor-to-Collector traffic. The Supervisor authenticates the connecting Collector via its kernel-vouched peer credentials (UID on Linux and macOS, plus PID on Linux). Mutually exclusive with `opamp_server_port`. Linux and macOS only; configuring it on Windows is rejected. |
+| `opamp_server_unix_socket_mode` | Octal permission mode, as a string, that the Unix domain socket file is created with, e.g. `"0660"`. Defaults to `"0600"` (owner-only). Requires `opamp_server_unix_socket`. Note: modes granting group/other access also require the socket's parent directory to permit traversal, and peer authentication still rejects peers whose UID differs from the Supervisor's regardless of this mode. |
 
 ### Important Notes
 

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -4201,3 +4201,89 @@ func TestSupervisorBinarySize(t *testing.T) {
 		info.Size(), float64(info.Size())/(1024*1024),
 		supervisorBinarySizeLimitBytes, supervisorBinarySizeLimitBytes/(1024*1024))
 }
+
+// TestSupervisorStartsCollectorOverUnixSocket verifies the full
+// supervisor<->collector handshake when the local OpAMP link is a filesystem
+// Unix domain socket instead of a loopback TCP port. The collector bootstrapping
+// and applying remote config proves the UDS link (and the collector's
+// opampextension UDS dialing) works end to end.
+func TestSupervisorStartsCollectorOverUnixSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix domain socket transport is not supported on Windows")
+	}
+
+	storageDir := t.TempDir()
+
+	// macOS limits the socket path to ~104 bytes, which the test temp dir can
+	// exceed, so bind under a short base directory.
+	socketDir, err := os.MkdirTemp("/tmp", "supuds")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketPath := filepath.Join(socketDir, "opamp.sock")
+
+	var agentConfig atomic.Value
+	server := newOpAMPServer(
+		t,
+		defaultConnectingHandler,
+		types.ConnectionCallbacks{
+			OnMessage: func(_ context.Context, _ types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				if message.EffectiveConfig != nil {
+					config := message.EffectiveConfig.ConfigMap.ConfigMap[""]
+					if config != nil {
+						agentConfig.Store(string(config.Body))
+					}
+				}
+
+				return &protobufs.ServerToAgent{}
+			},
+		})
+
+	s, _ := newSupervisor(t, "unix_socket", map[string]string{
+		"url":         server.addr,
+		"storage_dir": storageDir,
+		"unix_socket": socketPath,
+	})
+
+	require.Nil(t, s.Start(t.Context()))
+	defer s.Shutdown()
+
+	// The collector connects back to the supervisor over the Unix socket during
+	// bootstrap; reaching a healthy upstream connection proves the local UDS link
+	// works.
+	waitForSupervisorConnection(server.supervisorConnected, true)
+
+	require.FileExists(t, socketPath, "the opamp unix socket should exist while the supervisor is running")
+
+	cfg, hash, inputFile, outputFile := createSimplePipelineCollectorConf(t)
+
+	server.sendToSupervisor(&protobufs.ServerToAgent{
+		RemoteConfig: &protobufs.AgentRemoteConfig{
+			Config: &protobufs.AgentConfigMap{
+				ConfigMap: map[string]*protobufs.AgentConfigFile{
+					"": {Body: cfg.Bytes()},
+				},
+			},
+			ConfigHash: hash,
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		cfg, ok := agentConfig.Load().(string)
+		if ok {
+			return strings.Contains(cfg, "file_log")
+		}
+
+		return false
+	}, 5*time.Second, 500*time.Millisecond, "Collector was not started with remote config over the unix socket")
+
+	n, err := inputFile.WriteString("{\"body\":\"hello, world\"}\n")
+	require.NotZero(t, n, "Could not write to input file")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		logRecord := make([]byte, 1024)
+		n, _ := outputFile.Read(logRecord)
+
+		return n != 0
+	}, 10*time.Second, 500*time.Millisecond, "Log never appeared in output")
+}

--- a/cmd/opampsupervisor/go.mod
+++ b/cmd/opampsupervisor/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ebitengine/purego v0.10.2 // indirect
+	github.com/elastic/proxy-connect-dialer-go v0.1.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20251226215517-609e4778396f // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
@@ -78,7 +79,6 @@ require (
 	github.com/knadh/koanf/providers/confmap v1.0.1 // indirect
 	github.com/knadh/koanf/v2 v2.3.6 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
-	github.com/michel-laterman/proxy-connect-dialer-go v0.1.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -325,3 +325,12 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/oaut
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile => ../../extension/internal/credentialsfile
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/pprof => ../../pkg/translator/pprof
+
+// TODO(opamp-uds): temporary replace pointing at the local opamp-go fork that adds
+// server.StartSettings.Listener (Unix domain socket serving) and the matching
+// client DialContext hook. The fork is ahead of v0.23.0, so it also carries
+// unrelated API changes that required adapting this module (PackagesStateProvider
+// UpdateContent gained a downloadURL parameter; OpAMPClient gained
+// SetConnectionSettingsStatus). Remove and bump to the tagged opamp-go release
+// before this PR is merged.
+replace github.com/open-telemetry/opamp-go => github.com/dpaasman00/opamp-go v0.0.0-20260708172145-13df0330339d

--- a/cmd/opampsupervisor/go.sum
+++ b/cmd/opampsupervisor/go.sum
@@ -39,12 +39,16 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 h1:ucRHb6/lvW/+mTEIGbvhcYU3S8+uSNkuMjx/qZFfhtM=
 github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
+github.com/dpaasman00/opamp-go v0.0.0-20260708172145-13df0330339d h1:gKtX5DMAB4OB0ncvrQI0c6GvgiQcMJBbucEOjRGP7NM=
+github.com/dpaasman00/opamp-go v0.0.0-20260708172145-13df0330339d/go.mod h1:cwdYF4QJ7nqJzDNRX+g8qGGZ+PZYZ3GIuG9f3gkoT5c=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/elastic/go-grok v0.3.1 h1:WEhUxe2KrwycMnlvMimJXvzRa7DoByJB4PVUIE1ZD/U=
 github.com/elastic/go-grok v0.3.1/go.mod h1:n38ls8ZgOboZRgKcjMY8eFeZFMmcL9n2lP0iHhIDk64=
 github.com/elastic/lunes v0.2.2 h1:dZFEaebNg9l+mzvOQN6Nd/c9y6y8rUe3tBWsTgvM08U=
 github.com/elastic/lunes v0.2.2/go.mod h1:u3W/BdONWTrh0JjNZ21C907dDc+cUZttZrGa625nf2k=
+github.com/elastic/proxy-connect-dialer-go v0.1.1 h1:kmSFbqC+j6yVlxwPixI/7aTpdp+FH16Oaau1bcClpjI=
+github.com/elastic/proxy-connect-dialer-go v0.1.1/go.mod h1:YYlk9leuhkB2h7STwiNOGa1UkZWalY70jnIF8Ec3Sks=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
@@ -178,8 +182,6 @@ github.com/madflojo/testcerts v1.5.0 h1:GhQllyAiGzXVZU+i8O/cQkPTHzN59RxMGtm3uETg
 github.com/madflojo/testcerts v1.5.0/go.mod h1:MW8sh39gLnkKh4K0Nc55AyHEDl9l/FBLDUsQhpmkuo0=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/michel-laterman/proxy-connect-dialer-go v0.1.0 h1:Q8asukpmyrEheocd+R+6YEI4jcm62sHHalgTMG+LoLw=
-github.com/michel-laterman/proxy-connect-dialer-go v0.1.0/go.mod h1:HTlVkRAqzTRPYbWxgAiwMT9HRZMOqP3Mx7+toa3yJjc=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -192,8 +194,6 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/open-telemetry/opamp-go v0.23.0 h1:k7h7w/muprut9/DAhUC4anX4v7hIdgO02gIsSjV4uq0=
-github.com/open-telemetry/opamp-go v0.23.0/go.mod h1:DIIVdkLefdqPW5L+4I2twmAicVrTB0Bp5XJAfedZzAM=
 github.com/open-telemetry/otel-arrow/go v0.51.0 h1:R5NmrJ3X8RdqkR+UNAaUSuHID37MHKk9MvIAiBr0H4U=
 github.com/open-telemetry/otel-arrow/go v0.51.0/go.mod h1:IU5tda493/mJCHAYk43uCcouIEiSEjjXQnefH7/3G6g=
 github.com/openzipkin/zipkin-go v0.4.3 h1:9EGwpqkgnwdEIJ+Od7QVSEIH+ocmm5nPat0G7sjsSdg=

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -220,6 +220,8 @@ type Agent struct {
 	ConfigApplyTimeout          time.Duration     `mapstructure:"config_apply_timeout"`
 	BootstrapTimeout            time.Duration     `mapstructure:"bootstrap_timeout"`
 	OpAMPServerPort             int               `mapstructure:"opamp_server_port"`
+	OpAMPServerUnixSocket       string            `mapstructure:"opamp_server_unix_socket"`
+	OpAMPServerUnixSocketMode   string            `mapstructure:"opamp_server_unix_socket_mode"`
 	PassthroughLogs             bool              `mapstructure:"passthrough_logs"`
 	CollectorCrashLogSnippetKiB int               `mapstructure:"collector_crash_log_snippet_kib"`
 	AutomaticConfigRollback     bool              `mapstructure:"automatic_config_rollback"`
@@ -233,6 +235,21 @@ type Agent struct {
 	StartupFallbackConfigs []string `mapstructure:"startup_fallback_configs"`
 	// Package configures how collector executable updates are formatted and verified.
 	Package AgentPackage `mapstructure:"package"`
+}
+
+// UnixSocketFileMode returns the permission mode the OpAMP Unix domain socket
+// file is created with: OpAMPServerUnixSocketMode if set (already validated as
+// octal by Validate), otherwise 0600.
+func (a Agent) UnixSocketFileMode() os.FileMode {
+	if a.OpAMPServerUnixSocketMode == "" {
+		return 0o600
+	}
+	mode, err := strconv.ParseUint(a.OpAMPServerUnixSocketMode, 8, 32)
+	if err != nil {
+		// Unreachable after Validate; fail closed to owner-only.
+		return 0o600
+	}
+	return os.FileMode(mode)
 }
 
 func (a Agent) Validate() error {
@@ -254,6 +271,37 @@ func (a Agent) Validate() error {
 
 	if a.CollectorCrashLogSnippetKiB > 1024 {
 		return errors.New("agent::collector_crash_log_snippet_kib must be less than or equal to 1024")
+	}
+
+	if a.OpAMPServerUnixSocket != "" {
+		if runtime.GOOS == "windows" {
+			return errors.New("agent::opamp_server_unix_socket is not supported on windows")
+		}
+		if a.OpAMPServerPort != 0 {
+			return errors.New("agent::opamp_server_unix_socket and agent::opamp_server_port are mutually exclusive")
+		}
+		if !filepath.IsAbs(a.OpAMPServerUnixSocket) {
+			return errors.New("agent::opamp_server_unix_socket must be an absolute path")
+		}
+		// The kernel's sun_path limit: 104 bytes on Darwin, 108 on Linux, both
+		// including the trailing NUL. Reject here for a clear error instead of
+		// net.Listen's opaque "bind: invalid argument".
+		maxLen := 107
+		if runtime.GOOS == "darwin" {
+			maxLen = 103
+		}
+		if len(a.OpAMPServerUnixSocket) > maxLen {
+			return fmt.Errorf("agent::opamp_server_unix_socket path exceeds the platform limit of %d bytes", maxLen)
+		}
+	}
+
+	if a.OpAMPServerUnixSocketMode != "" {
+		if a.OpAMPServerUnixSocket == "" {
+			return errors.New("agent::opamp_server_unix_socket_mode requires agent::opamp_server_unix_socket")
+		}
+		if mode, err := strconv.ParseUint(a.OpAMPServerUnixSocketMode, 8, 32); err != nil || mode > 0o777 {
+			return errors.New(`agent::opamp_server_unix_socket_mode must be an octal permission mode between "0" and "0777"`)
+		}
 	}
 
 	if a.InstanceID != "" {

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -423,6 +423,201 @@ func TestValidate(t *testing.T) {
 			expectedErrorFunc: simpleError("agent::opamp_server_port must be a valid port number"),
 		},
 		{
+			name: "Unix socket and TCP port both set",
+			config: Supervisor{
+				Server: OpAMPServer{
+					Endpoint: "wss://localhost:9090/opamp",
+				},
+				Agent: Agent{
+					Executable:              "${file_path}",
+					OrphanDetectionInterval: 5 * time.Second,
+					ConfigApplyTimeout:      2 * time.Second,
+					OpAMPServerPort:         8090,
+					OpAMPServerUnixSocket:   "/tmp/opamp.sock",
+					BootstrapTimeout:        5 * time.Second,
+				},
+				Capabilities: Capabilities{
+					AcceptsRemoteConfig: true,
+				},
+				Storage: Storage{
+					Directory: "/etc/opamp-supervisor/storage",
+				},
+				HealthCheck: defaultHealthCheck,
+			},
+			expectedErrorFunc: simpleError("agent::opamp_server_unix_socket and agent::opamp_server_port are mutually exclusive"),
+		},
+		{
+			name: "Unix socket configured",
+			config: Supervisor{
+				Server: OpAMPServer{
+					Endpoint: "wss://localhost:9090/opamp",
+				},
+				Agent: Agent{
+					Executable:              "${file_path}",
+					OrphanDetectionInterval: 5 * time.Second,
+					ConfigApplyTimeout:      2 * time.Second,
+					OpAMPServerUnixSocket:   "/tmp/opamp.sock",
+					BootstrapTimeout:        5 * time.Second,
+				},
+				Capabilities: Capabilities{
+					AcceptsRemoteConfig: true,
+				},
+				Storage: Storage{
+					Directory: "/etc/opamp-supervisor/storage",
+				},
+				HealthCheck: defaultHealthCheck,
+			},
+			// Valid on Linux and macOS; rejected on Windows.
+			expectedErrorFunc: func() string {
+				if runtime.GOOS == "windows" {
+					return "agent::opamp_server_unix_socket is not supported on windows"
+				}
+				return ""
+			},
+		},
+		{
+			name: "Unix socket relative path",
+			config: Supervisor{
+				Server: OpAMPServer{
+					Endpoint: "wss://localhost:9090/opamp",
+				},
+				Agent: Agent{
+					Executable:              "${file_path}",
+					OrphanDetectionInterval: 5 * time.Second,
+					ConfigApplyTimeout:      2 * time.Second,
+					OpAMPServerUnixSocket:   "relative/opamp.sock",
+					BootstrapTimeout:        5 * time.Second,
+				},
+				Capabilities: Capabilities{
+					AcceptsRemoteConfig: true,
+				},
+				Storage: Storage{
+					Directory: "/etc/opamp-supervisor/storage",
+				},
+				HealthCheck: defaultHealthCheck,
+			},
+			// On Windows the platform check fires first.
+			expectedErrorFunc: func() string {
+				if runtime.GOOS == "windows" {
+					return "agent::opamp_server_unix_socket is not supported on windows"
+				}
+				return "agent::opamp_server_unix_socket must be an absolute path"
+			},
+		},
+		{
+			name: "Unix socket path too long",
+			config: Supervisor{
+				Server: OpAMPServer{
+					Endpoint: "wss://localhost:9090/opamp",
+				},
+				Agent: Agent{
+					Executable:              "${file_path}",
+					OrphanDetectionInterval: 5 * time.Second,
+					ConfigApplyTimeout:      2 * time.Second,
+					OpAMPServerUnixSocket:   "/tmp/" + strings.Repeat("a", 150) + ".sock",
+					BootstrapTimeout:        5 * time.Second,
+				},
+				Capabilities: Capabilities{
+					AcceptsRemoteConfig: true,
+				},
+				Storage: Storage{
+					Directory: "/etc/opamp-supervisor/storage",
+				},
+				HealthCheck: defaultHealthCheck,
+			},
+			expectedErrorFunc: func() string {
+				switch runtime.GOOS {
+				case "windows":
+					return "agent::opamp_server_unix_socket is not supported on windows"
+				case "darwin":
+					return "agent::opamp_server_unix_socket path exceeds the platform limit of 103 bytes"
+				default:
+					return "agent::opamp_server_unix_socket path exceeds the platform limit of 107 bytes"
+				}
+			},
+		},
+		{
+			name: "Unix socket mode configured",
+			config: Supervisor{
+				Server: OpAMPServer{
+					Endpoint: "wss://localhost:9090/opamp",
+				},
+				Agent: Agent{
+					Executable:                "${file_path}",
+					OrphanDetectionInterval:   5 * time.Second,
+					ConfigApplyTimeout:        2 * time.Second,
+					OpAMPServerUnixSocket:     "/tmp/opamp.sock",
+					OpAMPServerUnixSocketMode: "0660",
+					BootstrapTimeout:          5 * time.Second,
+				},
+				Capabilities: Capabilities{
+					AcceptsRemoteConfig: true,
+				},
+				Storage: Storage{
+					Directory: "/etc/opamp-supervisor/storage",
+				},
+				HealthCheck: defaultHealthCheck,
+			},
+			expectedErrorFunc: func() string {
+				if runtime.GOOS == "windows" {
+					return "agent::opamp_server_unix_socket is not supported on windows"
+				}
+				return ""
+			},
+		},
+		{
+			name: "Unix socket mode invalid",
+			config: Supervisor{
+				Server: OpAMPServer{
+					Endpoint: "wss://localhost:9090/opamp",
+				},
+				Agent: Agent{
+					Executable:                "${file_path}",
+					OrphanDetectionInterval:   5 * time.Second,
+					ConfigApplyTimeout:        2 * time.Second,
+					OpAMPServerUnixSocket:     "/tmp/opamp.sock",
+					OpAMPServerUnixSocketMode: "rw-rw----",
+					BootstrapTimeout:          5 * time.Second,
+				},
+				Capabilities: Capabilities{
+					AcceptsRemoteConfig: true,
+				},
+				Storage: Storage{
+					Directory: "/etc/opamp-supervisor/storage",
+				},
+				HealthCheck: defaultHealthCheck,
+			},
+			expectedErrorFunc: func() string {
+				if runtime.GOOS == "windows" {
+					return "agent::opamp_server_unix_socket is not supported on windows"
+				}
+				return `agent::opamp_server_unix_socket_mode must be an octal permission mode between "0" and "0777"`
+			},
+		},
+		{
+			name: "Unix socket mode without socket",
+			config: Supervisor{
+				Server: OpAMPServer{
+					Endpoint: "wss://localhost:9090/opamp",
+				},
+				Agent: Agent{
+					Executable:                "${file_path}",
+					OrphanDetectionInterval:   5 * time.Second,
+					ConfigApplyTimeout:        2 * time.Second,
+					OpAMPServerUnixSocketMode: "0660",
+					BootstrapTimeout:          5 * time.Second,
+				},
+				Capabilities: Capabilities{
+					AcceptsRemoteConfig: true,
+				},
+				Storage: Storage{
+					Directory: "/etc/opamp-supervisor/storage",
+				},
+				HealthCheck: defaultHealthCheck,
+			},
+			expectedErrorFunc: simpleError("agent::opamp_server_unix_socket_mode requires agent::opamp_server_unix_socket"),
+		},
+		{
 			name: "Zero value opamp server port number",
 			config: Supervisor{
 				Server: OpAMPServer{

--- a/cmd/opampsupervisor/supervisor/peercred.go
+++ b/cmd/opampsupervisor/supervisor/peercred.go
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package supervisor // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	serverTypes "github.com/open-telemetry/opamp-go/server/types"
+	"go.uber.org/zap"
+)
+
+// verifyAgentConn authenticates the peer of a Unix domain socket connection
+// against the collector the supervisor spawned. It verifies that the peer's UID
+// matches the supervisor's own UID (the collector is spawned as the same user)
+// and, on platforms that expose it (Linux via SO_PEERCRED), that the peer's PID
+// matches the expected collector PID.
+//
+// getExpectedPID returns the PID the connecting collector is expected to have,
+// or 0 when no collector is running; connections are rejected in that case (the
+// PID is recorded before the spawned collector can possibly dial, so nothing
+// legitimate ever connects while it is 0). The credentials returned by the
+// kernel reflect the actual connecting process and cannot be spoofed by the
+// peer.
+func (s *Supervisor) verifyAgentConn(conn serverTypes.Connection, getExpectedPID func() int) bool {
+	netConn := conn.Connection()
+	unixConn, ok := netConn.(*net.UnixConn)
+	if !ok {
+		s.telemetrySettings.Logger.Error(
+			"rejecting OpAMP connection: peer is not a unix socket",
+			zap.String("conn_type", fmt.Sprintf("%T", netConn)),
+		)
+		return false
+	}
+
+	wantPID := 0
+	if getExpectedPID != nil {
+		wantPID = getExpectedPID()
+	}
+	if wantPID == 0 {
+		s.telemetrySettings.Logger.Warn("rejecting OpAMP connection: no collector is currently running")
+		return false
+	}
+
+	if err := verifyPeerCredentials(unixConn, os.Getuid(), wantPID); err != nil {
+		s.telemetrySettings.Logger.Warn("rejecting OpAMP connection from unauthenticated peer", zap.Error(err))
+		return false
+	}
+	return true
+}
+
+// authenticateAgentPeer returns an OnConnected hook that disconnects
+// unauthenticated peers. This gates the WebSocket transport, whose read loop
+// starts after OnConnected returns. It does NOT gate the plain-HTTP OpAMP
+// transport, where Disconnect is a no-op and the message is processed anyway;
+// requirePeerAuth covers that path.
+func (s *Supervisor) authenticateAgentPeer(getExpectedPID func() int) func(serverTypes.Connection) {
+	return func(conn serverTypes.Connection) {
+		if !s.verifyAgentConn(conn, getExpectedPID) {
+			_ = conn.Disconnect()
+		}
+	}
+}
+
+// requirePeerAuth wraps an OpAMP message handler so that messages from
+// unauthenticated peers are dropped. This is required in addition to the
+// OnConnected hook because opamp-go serves the plain-HTTP transport on the same
+// listener and processes the request's message regardless of OnConnected
+// (Disconnect is a no-op for HTTP connections).
+func (s *Supervisor) requirePeerAuth(
+	getExpectedPID func() int,
+	next func(serverTypes.Connection, *protobufs.AgentToServer) *protobufs.ServerToAgent,
+) func(serverTypes.Connection, *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	return func(conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		if !s.verifyAgentConn(conn, getExpectedPID) {
+			_ = conn.Disconnect()
+			return &protobufs.ServerToAgent{}
+		}
+		return next(conn, message)
+	}
+}

--- a/cmd/opampsupervisor/supervisor/peercred_darwin.go
+++ b/cmd/opampsupervisor/supervisor/peercred_darwin.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package supervisor // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
+
+import (
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// verifyPeerCredentials reads the connecting peer's UID via LOCAL_PEERCRED.
+// macOS does not expose the peer PID through getsockopt, so wantPID is ignored
+// and only the UID is enforced.
+func verifyPeerCredentials(conn *net.UnixConn, wantUID, _ int) error {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("obtain raw unix connection: %w", err)
+	}
+
+	var ucred *unix.Xucred
+	var sockErr error
+	if controlErr := raw.Control(func(fd uintptr) {
+		ucred, sockErr = unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+	}); controlErr != nil {
+		return fmt.Errorf("read LOCAL_PEERCRED: %w", controlErr)
+	}
+	if sockErr != nil {
+		return fmt.Errorf("read LOCAL_PEERCRED: %w", sockErr)
+	}
+
+	if int(ucred.Uid) != wantUID {
+		return fmt.Errorf("peer uid %d does not match expected uid %d", ucred.Uid, wantUID)
+	}
+	return nil
+}

--- a/cmd/opampsupervisor/supervisor/peercred_linux.go
+++ b/cmd/opampsupervisor/supervisor/peercred_linux.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package supervisor // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+)
+
+// verifyPeerCredentials reads the connecting peer's kernel-vouched credentials
+// via SO_PEERCRED and enforces that the peer UID matches wantUID and, when
+// wantPID is non-zero, that the peer PID matches wantPID.
+func verifyPeerCredentials(conn *net.UnixConn, wantUID, wantPID int) error {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("obtain raw unix connection: %w", err)
+	}
+
+	var ucred *syscall.Ucred
+	var sockErr error
+	if controlErr := raw.Control(func(fd uintptr) {
+		ucred, sockErr = syscall.GetsockoptUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+	}); controlErr != nil {
+		return fmt.Errorf("read SO_PEERCRED: %w", controlErr)
+	}
+	if sockErr != nil {
+		return fmt.Errorf("read SO_PEERCRED: %w", sockErr)
+	}
+
+	if int(ucred.Uid) != wantUID {
+		return fmt.Errorf("peer uid %d does not match expected uid %d", ucred.Uid, wantUID)
+	}
+	if wantPID > 0 && int(ucred.Pid) != wantPID {
+		return fmt.Errorf("peer pid %d does not match expected collector pid %d", ucred.Pid, wantPID)
+	}
+	return nil
+}

--- a/cmd/opampsupervisor/supervisor/peercred_others.go
+++ b/cmd/opampsupervisor/supervisor/peercred_others.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux && !darwin
+
+package supervisor // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
+
+import (
+	"errors"
+	"net"
+)
+
+// verifyPeerCredentials is not implemented on platforms without a supported
+// peer-credential mechanism. Unix domain socket transport is rejected by config
+// validation on those platforms (see Agent.Validate), so this is defensive.
+func verifyPeerCredentials(_ *net.UnixConn, _, _ int) error {
+	return errors.New("peer credential authentication is not supported on this platform")
+}

--- a/cmd/opampsupervisor/supervisor/peercred_test.go
+++ b/cmd/opampsupervisor/supervisor/peercred_test.go
@@ -1,0 +1,233 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux || darwin
+
+package supervisor
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	serverTypes "github.com/open-telemetry/opamp-go/server/types"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
+)
+
+// unixConnPair returns the server side of a connected Unix domain socket pair.
+// The peer (client) is the test process itself, so its kernel credentials match
+// the current process.
+func unixConnPair(t *testing.T) *net.UnixConn {
+	t.Helper()
+
+	// Use a short base dir: macOS limits the socket path to ~104 bytes.
+	dir, err := os.MkdirTemp("/tmp", "peercred")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	ln, err := net.Listen("unix", filepath.Join(dir, "s.sock"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	dialed := make(chan net.Conn, 1)
+	go func() {
+		c, derr := net.Dial("unix", ln.Addr().String())
+		require.NoError(t, derr)
+		dialed <- c
+	}()
+
+	srvConn, err := ln.Accept()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srvConn.Close() })
+
+	clientConn := <-dialed
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	uc, ok := srvConn.(*net.UnixConn)
+	require.True(t, ok)
+	return uc
+}
+
+func TestRemoveStaleUnixSocket(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "stalesock")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	t.Run("missing path is a no-op", func(t *testing.T) {
+		require.NoError(t, removeStaleUnixSocket(filepath.Join(dir, "does-not-exist.sock")))
+	})
+
+	t.Run("removes a stale socket", func(t *testing.T) {
+		socketPath := filepath.Join(dir, "stale.sock")
+		ln, lerr := net.Listen("unix", socketPath)
+		require.NoError(t, lerr)
+		require.NoError(t, ln.Close()) // Close may leave the file depending on platform
+		// Recreate to guarantee a socket file is present.
+		ln2, lerr := net.Listen("unix", socketPath)
+		require.NoError(t, lerr)
+		t.Cleanup(func() { _ = ln2.Close() })
+
+		require.NoError(t, removeStaleUnixSocket(socketPath))
+		_, statErr := os.Stat(socketPath)
+		require.ErrorIs(t, statErr, os.ErrNotExist)
+	})
+
+	t.Run("refuses to remove a non-socket file", func(t *testing.T) {
+		regular := filepath.Join(dir, "regular.txt")
+		require.NoError(t, os.WriteFile(regular, []byte("data"), 0o600))
+
+		require.Error(t, removeStaleUnixSocket(regular))
+		require.FileExists(t, regular, "a non-socket file must not be removed")
+	})
+
+	t.Run("refuses to remove a symlink", func(t *testing.T) {
+		target := filepath.Join(dir, "target.txt")
+		require.NoError(t, os.WriteFile(target, []byte("data"), 0o600))
+		link := filepath.Join(dir, "link.sock")
+		require.NoError(t, os.Symlink(target, link))
+
+		require.Error(t, removeStaleUnixSocket(link))
+		require.FileExists(t, target, "the symlink target must not be removed")
+	})
+}
+
+func TestVerifyPeerCredentials(t *testing.T) {
+	uc := unixConnPair(t)
+
+	// The peer is this test process, so matching the current UID succeeds.
+	require.NoError(t, verifyPeerCredentials(uc, os.Getuid(), 0))
+
+	// A mismatched UID is rejected.
+	require.Error(t, verifyPeerCredentials(uc, os.Getuid()+1, 0))
+
+	if runtime.GOOS == "linux" {
+		// On Linux SO_PEERCRED also exposes the peer PID.
+		require.NoError(t, verifyPeerCredentials(uc, os.Getuid(), os.Getpid()))
+		require.Error(t, verifyPeerCredentials(uc, os.Getuid(), os.Getpid()+1))
+	}
+}
+
+// recordingConn is a serverTypes.Connection that exposes a fixed net.Conn and
+// records whether Disconnect was called.
+type recordingConn struct {
+	conn         net.Conn
+	disconnected atomic.Bool
+}
+
+func (c *recordingConn) Connection() net.Conn { return c.conn }
+
+func (*recordingConn) Send(context.Context, *protobufs.ServerToAgent) error { return nil }
+
+func (c *recordingConn) Disconnect() error {
+	c.disconnected.Store(true)
+	return nil
+}
+
+func newPeerAuthSupervisor() *Supervisor {
+	return &Supervisor{
+		telemetrySettings: telemetrySettings{
+			TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+		},
+	}
+}
+
+func TestCreateOpAMPServerListenerSocketMode(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "sockmode")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "opamp.sock")
+
+	s := newPeerAuthSupervisor()
+	s.config = config.Supervisor{Agent: config.Agent{
+		OpAMPServerUnixSocket:     socketPath,
+		OpAMPServerUnixSocketMode: "0660",
+	}}
+
+	ln, err := s.createOpAMPServerListener()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	info, err := os.Stat(socketPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o660), info.Mode().Perm(), "socket file must carry the configured mode")
+}
+
+func TestAuthenticateAgentPeer_AcceptsSpawnedCollector(t *testing.T) {
+	s := newPeerAuthSupervisor()
+	conn := &recordingConn{conn: unixConnPair(t)}
+
+	// The peer is this process; supplying its PID satisfies the (Linux) PID check
+	// and the UID always matches.
+	s.authenticateAgentPeer(func() int { return os.Getpid() })(conn)
+
+	require.False(t, conn.disconnected.Load(), "a matching peer must not be disconnected")
+}
+
+func TestAuthenticateAgentPeer_RejectsNonUnixPeer(t *testing.T) {
+	s := newPeerAuthSupervisor()
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() { _ = c1.Close(); _ = c2.Close() })
+
+	conn := &recordingConn{conn: c1} // net.Pipe conns are not *net.UnixConn
+	s.authenticateAgentPeer(func() int { return 0 })(conn)
+
+	require.True(t, conn.disconnected.Load(), "a non-unix peer must be disconnected")
+}
+
+func TestAuthenticateAgentPeer_RejectsWhenNoCollectorRunning(t *testing.T) {
+	s := newPeerAuthSupervisor()
+	conn := &recordingConn{conn: unixConnPair(t)}
+
+	// Expected PID 0 means no collector is running; nothing legitimate connects
+	// in that state, so the connection must be rejected.
+	s.authenticateAgentPeer(func() int { return 0 })(conn)
+
+	require.True(t, conn.disconnected.Load(), "connections must be rejected while no collector is running")
+}
+
+func TestRequirePeerAuth(t *testing.T) {
+	s := newPeerAuthSupervisor()
+
+	nextCalled := false
+	next := func(serverTypes.Connection, *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		nextCalled = true
+		return nil
+	}
+
+	// Authenticated peer: the wrapped handler runs.
+	conn := &recordingConn{conn: unixConnPair(t)}
+	s.requirePeerAuth(func() int { return os.Getpid() }, next)(conn, &protobufs.AgentToServer{})
+	require.True(t, nextCalled, "messages from an authenticated peer must reach the handler")
+	require.False(t, conn.disconnected.Load())
+
+	// Unauthenticated peer (no collector running): dropped before the handler.
+	// This is what gates the plain-HTTP transport, where Disconnect is a no-op.
+	nextCalled = false
+	conn = &recordingConn{conn: unixConnPair(t)}
+	resp := s.requirePeerAuth(func() int { return 0 }, next)(conn, &protobufs.AgentToServer{})
+	require.False(t, nextCalled, "messages from an unauthenticated peer must not reach the handler")
+	require.True(t, conn.disconnected.Load())
+	require.NotNil(t, resp, "a rejected message still gets an empty response")
+}
+
+func TestAuthenticateAgentPeer_RejectsWrongPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("peer PID is only available via SO_PEERCRED on Linux")
+	}
+	s := newPeerAuthSupervisor()
+	conn := &recordingConn{conn: unixConnPair(t)}
+
+	// A PID that cannot be the peer's must be rejected.
+	s.authenticateAgentPeer(func() int { return os.Getpid() + 1 })(conn)
+
+	require.True(t, conn.disconnected.Load(), "a peer with the wrong PID must be disconnected")
+}

--- a/cmd/opampsupervisor/supervisor/server.go
+++ b/cmd/opampsupervisor/supervisor/server.go
@@ -5,6 +5,7 @@ package supervisor
 
 import (
 	"context"
+	"net"
 	"net/http"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -16,18 +17,33 @@ type flattenedSettings struct {
 	onMessage         func(conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent
 	onConnecting      func(request *http.Request) (shouldConnect bool, rejectStatusCode int)
 	onConnectionClose func(conn serverTypes.Connection)
-	endpoint          string
+	// onConnected, if set, is invoked once per accepted connection before any
+	// messages are processed. The supervisor uses it to authenticate the peer
+	// of a Unix domain socket connection (see authenticateAgentPeer).
+	onConnected func(conn serverTypes.Connection)
+	endpoint    string
+	// listener, if set, is used to serve the OpAMP server instead of opening a
+	// TCP listener on endpoint (e.g. a Unix domain socket). The caller owns the
+	// listener's lifecycle.
+	listener net.Listener
 }
 
 func (fs flattenedSettings) toServerSettings() server.StartSettings {
-	return server.StartSettings{
+	settings := server.StartSettings{
 		Settings: server.Settings{
 			Callbacks: serverTypes.Callbacks{
 				OnConnecting: fs.OnConnecting,
 			},
 		},
-		ListenEndpoint: fs.endpoint,
 	}
+	// A provided listener (Unix domain socket) takes precedence; opamp-go ignores
+	// ListenEndpoint when Listener is set.
+	if fs.listener != nil {
+		settings.Listener = fs.listener
+	} else {
+		settings.ListenEndpoint = fs.endpoint
+	}
+	return settings
 }
 
 func (fs flattenedSettings) OnConnecting(request *http.Request) serverTypes.ConnectionResponse {
@@ -44,13 +60,18 @@ func (fs flattenedSettings) OnConnecting(request *http.Request) serverTypes.Conn
 	return serverTypes.ConnectionResponse{
 		Accept: true,
 		ConnectionCallbacks: serverTypes.ConnectionCallbacks{
+			OnConnected:       fs.OnConnected,
 			OnMessage:         fs.OnMessage,
 			OnConnectionClose: fs.OnConnectionClose,
 		},
 	}
 }
 
-func (flattenedSettings) OnConnected(context.Context, serverTypes.Connection) {}
+func (fs flattenedSettings) OnConnected(_ context.Context, conn serverTypes.Connection) {
+	if fs.onConnected != nil {
+		fs.onConnected(conn)
+	}
+}
 
 func (fs flattenedSettings) OnMessage(_ context.Context, conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 	if fs.onMessage != nil {

--- a/cmd/opampsupervisor/supervisor/server_test.go
+++ b/cmd/opampsupervisor/supervisor/server_test.go
@@ -4,6 +4,7 @@
 package supervisor
 
 import (
+	"net"
 	"net/http"
 	"testing"
 
@@ -20,7 +21,38 @@ func Test_flattenedSettings_toServerSettings(t *testing.T) {
 	serverSettings := fs.toServerSettings()
 
 	require.Equal(t, "localhost", serverSettings.ListenEndpoint)
+	require.Nil(t, serverSettings.Listener)
 	require.NotNil(t, serverSettings.Callbacks)
+}
+
+func Test_flattenedSettings_toServerSettings_listener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	fs := flattenedSettings{
+		// endpoint is ignored when a listener is provided.
+		endpoint: "localhost:1234",
+		listener: ln,
+	}
+
+	serverSettings := fs.toServerSettings()
+
+	require.Same(t, ln, serverSettings.Listener)
+	require.Empty(t, serverSettings.ListenEndpoint)
+}
+
+func Test_flattenedSettings_OnConnected(t *testing.T) {
+	onConnectedFuncCalled := false
+	fs := flattenedSettings{
+		onConnected: func(serverTypes.Connection) {
+			onConnectedFuncCalled = true
+		},
+	}
+
+	fs.OnConnected(t.Context(), &mockConn{})
+
+	require.True(t, onConnectedFuncCalled)
 }
 
 func Test_flattenedSettings_OnConnecting(t *testing.T) {

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -190,6 +190,17 @@ type Supervisor struct {
 	// The OpAMP server to communicate with the Collector's OpAMP extension
 	opampServer     server.OpAMPServer
 	opampServerPort int
+	// opampServerListener is the Unix domain socket listener backing the local
+	// OpAMP server when agent::opamp_server_unix_socket is configured. It is nil
+	// in the default TCP mode. The supervisor owns its lifecycle and closes it on
+	// shutdown, which unlinks the socket file.
+	opampServerListener net.Listener
+	// agentPID is the PID of the managed collector process, updated whenever it
+	// is (re)started. It is read by the Unix domain socket peer-credential check
+	// from the OpAMP server goroutine, so it is stored atomically rather than
+	// reading s.commander (which is mutated on the agent goroutine). 0 means the
+	// collector is not running, in which case connections are rejected.
+	agentPID atomic.Int64
 
 	// The HTTP server for health check endpoint
 	healthCheckServer   *http.Server
@@ -495,10 +506,14 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 	_, span := s.getTracer().Start(s.runCtx, "GetBootstrapInfo")
 	defer span.End()
 
-	s.opampServerPort, err = s.getSupervisorOpAMPServerPort()
-	if err != nil {
-		span.SetStatus(codes.Error, fmt.Sprintf("Could not get supervisor opamp service port: %v", err))
-		return err
+	// In Unix domain socket mode no TCP port is used; the socket path comes from
+	// config and is read by composeOpAMPExtensionConfig.
+	if !s.usingUnixSocket() {
+		s.opampServerPort, err = s.getSupervisorOpAMPServerPort()
+		if err != nil {
+			span.SetStatus(codes.Error, fmt.Sprintf("Could not get supervisor opamp service port: %v", err))
+			return err
+		}
 	}
 
 	bootstrapConfig, err := s.composeNoopConfig()
@@ -518,14 +533,23 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 	done := make(chan error, 1)
 	var connected atomic.Bool
 	var doneReported atomic.Bool
+	// bootstrapAgentPID holds the PID of the short-lived bootstrap collector once
+	// started, for peer authentication over the Unix domain socket. It is 0 until
+	// the collector is started, and connections are rejected while it is 0.
+	var bootstrapAgentPID atomic.Int64
 
 	// Start a one-shot server to get the Collector's agent description
 	// and available components using the Collector's OpAMP extension.
-	err = srv.Start(flattenedSettings{
-		endpoint: fmt.Sprintf("localhost:%d", s.opampServerPort),
+	bootstrapSettings := flattenedSettings{
 		onConnecting: func(*http.Request) (bool, int) {
 			connected.Store(true)
 			return true, http.StatusOK
+		},
+		onConnectionClose: func(serverTypes.Connection) {
+			// Keep the flag accurate if a peer is rejected by peer-credential
+			// authentication (disconnected during onConnected) so a subsequent
+			// bootstrap timeout reports the right reason.
+			connected.Store(false)
 		},
 		onMessage: func(_ serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			response := &protobufs.ServerToAgent{}
@@ -578,7 +602,28 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 
 			return response
 		},
-	}.toServerSettings())
+	}
+
+	if s.usingUnixSocket() {
+		ln, lerr := s.createOpAMPServerListener()
+		if lerr != nil {
+			span.SetStatus(codes.Error, fmt.Sprintf("Could not create OpAMP server listener: %v", lerr))
+			return lerr
+		}
+		// The bootstrap server is short-lived; close (and unlink) the socket when
+		// done so the long-lived server can bind the same path.
+		defer func() { _ = ln.Close() }()
+		bootstrapSettings.listener = ln
+		expectedPID := func() int { return int(bootstrapAgentPID.Load()) }
+		bootstrapSettings.onConnected = s.authenticateAgentPeer(expectedPID)
+		// Also gate message handling: the plain-HTTP OpAMP transport is served on
+		// the same listener and is not stopped by a Disconnect in OnConnected.
+		bootstrapSettings.onMessage = s.requirePeerAuth(expectedPID, bootstrapSettings.onMessage)
+	} else {
+		bootstrapSettings.endpoint = fmt.Sprintf("localhost:%d", s.opampServerPort)
+	}
+
+	err = srv.Start(bootstrapSettings.toServerSettings())
 	if err != nil {
 		span.SetStatus(codes.Error, fmt.Sprintf("Could not start OpAMP server: %v", err))
 		return err
@@ -612,6 +657,9 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 		span.SetStatus(codes.Error, fmt.Sprintf("Could not start Agent: %v", err))
 		return err
 	}
+	// Record the bootstrap collector PID so the peer-credential check can validate
+	// the connecting peer when serving over a Unix domain socket.
+	bootstrapAgentPID.Store(int64(cmd.Pid()))
 
 	defer func() {
 		if stopErr := cmd.Stop(s.runCtx); stopErr != nil {
@@ -848,18 +896,14 @@ func (nopHost) GetExtensions() map[component.ID]component.Component {
 func (s *Supervisor) startOpAMPServer() error {
 	s.opampServer = server.New(newLoggerFromZap(s.telemetrySettings.Logger, "opamp-server"))
 
-	var err error
-	s.opampServerPort, err = s.getSupervisorOpAMPServerPort()
-	if err != nil {
-		return err
-	}
-
 	s.telemetrySettings.Logger.Debug("Starting OpAMP server...")
 
+	// serverStarted gates the deferred Unix-socket cleanup below: the listener is
+	// only retained if the server actually starts.
+	var serverStarted bool
 	connected := &atomic.Bool{}
 
-	err = s.opampServer.Start(flattenedSettings{
-		endpoint: fmt.Sprintf("localhost:%d", s.opampServerPort),
+	fs := flattenedSettings{
 		onConnecting: func(*http.Request) (bool, int) {
 			// Only allow one agent to be connected the this server at a time.
 			alreadyConnected := connected.Swap(true)
@@ -869,14 +913,53 @@ func (s *Supervisor) startOpAMPServer() error {
 		onConnectionClose: func(serverTypes.Connection) {
 			connected.Store(false)
 		},
-	}.toServerSettings())
-	if err != nil {
+	}
+
+	if s.usingUnixSocket() {
+		ln, err := s.createOpAMPServerListener()
+		if err != nil {
+			return err
+		}
+		s.opampServerListener = ln
+		fs.listener = ln
+		// Authenticate the connecting collector against the process we spawned.
+		fs.onConnected = s.authenticateAgentPeer(s.expectedAgentPID)
+		// Also gate message handling: the plain-HTTP OpAMP transport is served on
+		// the same listener and is not stopped by a Disconnect in OnConnected.
+		fs.onMessage = s.requirePeerAuth(s.expectedAgentPID, fs.onMessage)
+		// If the server fails to start, close (and unlink) the socket we just
+		// created so it does not leak; Shutdown is not called when Start fails.
+		defer func() {
+			if !serverStarted && s.opampServerListener != nil {
+				_ = s.opampServerListener.Close()
+				s.opampServerListener = nil
+			}
+		}()
+	} else {
+		port, err := s.getSupervisorOpAMPServerPort()
+		if err != nil {
+			return err
+		}
+		s.opampServerPort = port
+		fs.endpoint = fmt.Sprintf("localhost:%d", s.opampServerPort)
+	}
+
+	if err := s.opampServer.Start(fs.toServerSettings()); err != nil {
 		return err
 	}
+	serverStarted = true
 
 	s.telemetrySettings.Logger.Debug("OpAMP server started.")
 
 	return nil
+}
+
+// expectedAgentPID returns the PID of the managed collector process, or 0 if it
+// is not currently running. It reads an atomic snapshot updated at each agent
+// (re)start so the peer-credential check (which runs on the OpAMP server
+// goroutine) never races with s.commander mutations on the agent goroutine.
+func (s *Supervisor) expectedAgentPID() int {
+	return int(s.agentPID.Load())
 }
 
 func (s *Supervisor) handleAgentOpAMPMessage(conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
@@ -1342,6 +1425,7 @@ func (s *Supervisor) composeOpAMPExtensionConfig() []byte {
 	tplVars := map[string]any{
 		"InstanceUid":                s.persistentState.InstanceID.String(),
 		"SupervisorPort":             s.opampServerPort,
+		"UnixSocket":                 s.config.Agent.OpAMPServerUnixSocket,
 		"PID":                        s.pidProvider.PID(),
 		"PPIDPollInterval":           orphanPollInterval,
 		"ReportsAvailableComponents": s.config.Capabilities.ReportsAvailableComponents,
@@ -1933,6 +2017,10 @@ func (s *Supervisor) handleRestartCommand() error {
 	}
 	if err != nil {
 		s.telemetrySettings.Logger.Error("Could not restart agent process", zap.Error(err))
+	} else {
+		// Pid() is safe to read here (same goroutine as Restart); publish it for
+		// the Unix domain socket peer-credential check.
+		s.agentPID.Store(int64(s.commander.Pid()))
 	}
 	s.resetAgentReady()
 	return err
@@ -1960,6 +2048,9 @@ func (s *Supervisor) startAgent() (agentStartStatus, error) {
 		}
 		return "", startErr
 	}
+	// Pid() is safe to read here (same goroutine as Start); publish it for the
+	// Unix domain socket peer-credential check.
+	s.agentPID.Store(int64(s.commander.Pid()))
 
 	return agentStarting, nil
 }
@@ -2123,6 +2214,9 @@ func (s *Supervisor) runAgentProcess() {
 			if err != nil {
 				s.telemetrySettings.Logger.Error("Could not stop agent process", zap.Error(err))
 			}
+			// The collector is gone; clear the expected PID so the Unix domain
+			// socket peer check cannot match a recycled PID.
+			s.agentPID.Store(0)
 			return
 		}
 	}
@@ -2283,6 +2377,9 @@ func (s *Supervisor) stopAgentApplyConfig() {
 	if err != nil {
 		s.telemetrySettings.Logger.Error("Could not stop agent process", zap.Error(err))
 	}
+	// The collector is stopped; clear the expected PID so the Unix domain socket
+	// peer check cannot match a recycled PID.
+	s.agentPID.Store(0)
 
 	if err := s.writeAgentConfig(); err != nil {
 		s.telemetrySettings.Logger.Error("Failed to write agent config", zap.Error(err))
@@ -2311,6 +2408,17 @@ func (s *Supervisor) Shutdown() {
 		} else {
 			s.telemetrySettings.Logger.Debug("OpAMP server stopped.")
 		}
+	}
+
+	// Close the Unix domain socket listener (if any) after the server has stopped
+	// using it. Closing the listener unlinks the socket file from the filesystem.
+	// opampServer.Stop above may already have closed it (http.Server.Shutdown
+	// closes the listeners it serves on), so tolerate net.ErrClosed.
+	if s.opampServerListener != nil {
+		if err := s.opampServerListener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			s.telemetrySettings.Logger.Error("Could not close the OpAMP server unix socket listener", zap.Error(err))
+		}
+		s.opampServerListener = nil
 	}
 
 	if s.healthCheckServer != nil {
@@ -2658,6 +2766,70 @@ func (s *Supervisor) getSupervisorOpAMPServerPort() (int, error) {
 		return s.config.Agent.OpAMPServerPort, nil
 	}
 	return s.findRandomPort()
+}
+
+// usingUnixSocket reports whether the local OpAMP server should be served over a
+// Unix domain socket instead of a loopback TCP port.
+func (s *Supervisor) usingUnixSocket() bool {
+	return s.config.Agent.OpAMPServerUnixSocket != ""
+}
+
+// createOpAMPServerListener opens the Unix domain socket listener for the local
+// OpAMP server. It removes any stale socket left by a previous run and sets the
+// socket file to the configured permission mode (default 0600, owner-only). The
+// returned listener unlinks the socket file when closed.
+func (s *Supervisor) createOpAMPServerListener() (net.Listener, error) {
+	socketPath := s.config.Agent.OpAMPServerUnixSocket
+
+	// Ensure the parent directory exists and is private to the owning user, so
+	// the socket is created in a location only this user can reach (defense in
+	// depth alongside the peer-credential check). This also turns an otherwise
+	// cryptic "no such file or directory" from net.Listen into a clear error.
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create parent directory for opamp socket %q: %w", socketPath, err)
+	}
+
+	// net.Listen fails if the path already exists, so remove a stale socket left
+	// by a previous run. This is the most common Unix domain socket footgun.
+	if err := removeStaleUnixSocket(socketPath); err != nil {
+		return nil, fmt.Errorf("remove stale opamp socket %q: %w", socketPath, err)
+	}
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen on opamp unix socket %q: %w", socketPath, err)
+	}
+
+	// Set the socket to the configured mode (default 0600, owner-only) so the
+	// filesystem limits who can connect, as defense in depth alongside the
+	// peer-credential check performed on each connection.
+	if err := os.Chmod(socketPath, s.config.Agent.UnixSocketFileMode()); err != nil {
+		_ = ln.Close()
+		return nil, fmt.Errorf("chmod opamp unix socket %q: %w", socketPath, err)
+	}
+
+	return ln, nil
+}
+
+// removeStaleUnixSocket removes path if it exists and is a socket. It refuses to
+// remove a symlink or a non-socket file so a misconfigured (or maliciously
+// pre-created) path cannot delete or be redirected to arbitrary data. os.Lstat
+// is used so a symlink is detected rather than followed.
+func removeStaleUnixSocket(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to remove %q: is a symlink", path)
+	}
+	if info.Mode().Type()&os.ModeSocket == 0 {
+		return fmt.Errorf("refusing to remove %q: not a socket", path)
+	}
+	return os.Remove(path)
 }
 
 func (s *Supervisor) getFeatureGateFlag() []string {

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -2792,6 +2792,10 @@ func (mockOpAMPClient) RequestConnectionSettings(*protobufs.ConnectionSettingsRe
 	return nil
 }
 
+func (mockOpAMPClient) SetConnectionSettingsStatus(*protobufs.ConnectionSettingsStatus) error {
+	return nil
+}
+
 func (m mockOpAMPClient) SetCustomCapabilities(customCapabilities *protobufs.CustomCapabilities) error {
 	if m.setCustomCapabilitiesFunc != nil {
 		return m.setCustomCapabilitiesFunc(customCapabilities)

--- a/cmd/opampsupervisor/supervisor/templates/opampextension.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/opampextension.yaml
@@ -3,7 +3,12 @@ extensions:
     instance_uid: "{{.InstanceUid}}"
     server:
       ws:
+{{- if .UnixSocket }}
+        endpoint: "ws://localhost/v1/opamp"
+        unix_socket: "{{.UnixSocket}}"
+{{- else }}
         endpoint: "ws://127.0.0.1:{{.SupervisorPort}}/v1/opamp"
+{{- end }}
         tls:
           insecure: true
     ppid: {{.PID}}

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_unix_socket.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_unix_socket.yaml
@@ -1,0 +1,20 @@
+server:
+  endpoint: ws://{{.url}}/v1/opamp
+
+capabilities:
+  reports_effective_config: true
+  reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
+  reports_health: true
+  accepts_remote_config: true
+  reports_remote_config: true
+  accepts_restart_command: true
+
+storage:
+  directory: '{{.storage_dir}}'
+
+agent:
+  executable: ../../bin/otelcontribcol_{{.goos}}_{{.goarch}}{{.extension}}
+  bootstrap_timeout: 10s
+  opamp_server_unix_socket: '{{.unix_socket}}'

--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -291,3 +291,7 @@ providers:
 # file before passing it to OCB, to ensure that local versions are used for all
 # Contrib modules.
 replaces:
+  # TODO(opamp-uds): temporary replace pointing at the local opamp-go fork that
+  # adds the Unix domain socket transport hooks (client DialContext and server
+  # Listener). Remove and bump to the tagged opamp-go release before merge.
+  - github.com/open-telemetry/opamp-go => ../../../../../opamp-go/dpaasman00/main

--- a/extension/opampextension/README.md
+++ b/extension/opampextension/README.md
@@ -28,6 +28,12 @@ The following settings are optional for the websocket client:
     - `tls`: TLS settings.
     - `headers`: HTTP headers to set.
     - `auth`: The ID of an auth extension to use for authentication.
+    - `unix_socket`: A filesystem path to a Unix domain socket. When set, the
+      extension dials this socket instead of a TCP connection, and `endpoint`
+      only supplies the URL scheme, request path, and `Host` header (its host
+      and port are ignored). Only supported with the websocket transport. This
+      is typically set by the Supervisor for the local supervisor-to-collector
+      link and not configured manually.
 
 The following settings are optional for the HTTP client:
 

--- a/extension/opampextension/config.go
+++ b/extension/opampextension/config.go
@@ -96,6 +96,12 @@ type commonFields struct {
 	TLS      configtls.ClientConfig         `mapstructure:"tls,omitempty"`
 	Headers  map[string]configopaque.String `mapstructure:"headers,omitempty"`
 	Auth     component.ID                   `mapstructure:"auth,omitempty"`
+	// UnixSocket, when set, makes the client dial the OpAMP server over a
+	// filesystem-path Unix domain socket instead of TCP. It is only supported
+	// with the WebSocket transport (see OpAMPServer.WS); the Endpoint then only
+	// supplies the URL scheme, request path, and Host header, and the host:port
+	// in the Endpoint is otherwise ignored.
+	UnixSocket string `mapstructure:"unix_socket,omitempty"`
 }
 
 func (c *commonFields) Scheme() string {
@@ -122,6 +128,10 @@ type httpFields struct {
 func (h *httpFields) Validate() error {
 	if err := h.commonFields.Validate(); err != nil {
 		return err
+	}
+
+	if h.UnixSocket != "" {
+		return errors.New("unix_socket is only supported with the websocket transport")
 	}
 
 	if h.PollingInterval < 0 {
@@ -184,6 +194,17 @@ func (s OpAMPServer) GetEndpoint() string {
 		return s.WS.Endpoint
 	} else if s.HTTP != nil {
 		return s.HTTP.Endpoint
+	}
+	return ""
+}
+
+// GetUnixSocket returns the configured Unix domain socket path for the WebSocket
+// transport, or "" if not configured. Only the WebSocket transport supports
+// dialing the OpAMP server over a Unix domain socket; for the HTTP transport
+// this always returns "".
+func (s OpAMPServer) GetUnixSocket() string {
+	if s.WS != nil {
+		return s.WS.UnixSocket
 	}
 	return ""
 }

--- a/extension/opampextension/config.schema.yaml
+++ b/extension/opampextension/config.schema.yaml
@@ -47,6 +47,9 @@ $defs:
             format: duration
           tls:
             $ref: go.opentelemetry.io/collector/config/configtls.client_config
+          unix_socket:
+            description: UnixSocket, when set, makes the client dial the OpAMP server over a filesystem-path Unix domain socket instead of TCP. It is only supported with the WebSocket transport (see OpAMPServer.WS); the Endpoint then only supplies the URL scheme, request path, and Host header, and the host:port in the Endpoint is otherwise ignored.
+            type: string
       ws:
         x-pointer: true
         type: object
@@ -62,6 +65,9 @@ $defs:
               $ref: go.opentelemetry.io/collector/config/configopaque.string
           tls:
             $ref: go.opentelemetry.io/collector/config/configtls.client_config
+          unix_socket:
+            description: UnixSocket, when set, makes the client dial the OpAMP server over a filesystem-path Unix domain socket instead of TCP. It is only supported with the WebSocket transport (see OpAMPServer.WS); the Endpoint then only supplies the URL scheme, request path, and Host header, and the host:port in the Endpoint is otherwise ignored.
+            type: string
 description: Config contains the configuration for the opamp extension. Trying to mirror the OpAMP supervisor config for some consistency.
 type: object
 properties:

--- a/extension/opampextension/config_test.go
+++ b/extension/opampextension/config_test.go
@@ -340,6 +340,36 @@ func TestConfig_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "WS with unix_socket is valid",
+			fields: fields{
+				Server: &OpAMPServer{
+					WS: &commonFields{
+						Endpoint:   "ws://localhost/v1/opamp",
+						UnixSocket: "/run/otelcol/opamp.sock",
+					},
+				},
+				InstanceUID: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "HTTP with unix_socket is rejected",
+			fields: fields{
+				Server: &OpAMPServer{
+					HTTP: &httpFields{
+						commonFields: commonFields{
+							Endpoint:   "http://localhost/v1/opamp",
+							UnixSocket: "/run/otelcol/opamp.sock",
+						},
+					},
+				},
+				InstanceUID: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			},
+			wantErr: func(t assert.TestingT, err error, _ ...any) bool {
+				return assert.Equal(t, "unix_socket is only supported with the websocket transport", err.Error())
+			},
+		},
+		{
 			name: "accepts_restart_command capability without feature gate",
 			fields: fields{
 				Capabilities: Capabilities{

--- a/extension/opampextension/go.mod
+++ b/extension/opampextension/go.mod
@@ -33,13 +33,13 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/elastic/proxy-connect-dialer-go v0.1.1 // indirect
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20251226215517-609e4778396f // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/michel-laterman/proxy-connect-dialer-go v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -130,3 +130,8 @@ require (
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages => ../opampcustommessages
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status => ../../pkg/status
+
+// TODO(opamp-uds): temporary replace pointing at the local opamp-go fork that adds
+// StartSettings.DialContext (Unix domain socket dialing). Remove and bump to the
+// tagged opamp-go release before this PR is merged.
+replace github.com/open-telemetry/opamp-go => github.com/dpaasman00/opamp-go v0.0.0-20260708172145-13df0330339d

--- a/extension/opampextension/go.sum
+++ b/extension/opampextension/go.sum
@@ -12,8 +12,12 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dpaasman00/opamp-go v0.0.0-20260708172145-13df0330339d h1:gKtX5DMAB4OB0ncvrQI0c6GvgiQcMJBbucEOjRGP7NM=
+github.com/dpaasman00/opamp-go v0.0.0-20260708172145-13df0330339d/go.mod h1:cwdYF4QJ7nqJzDNRX+g8qGGZ+PZYZ3GIuG9f3gkoT5c=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/elastic/proxy-connect-dialer-go v0.1.1 h1:kmSFbqC+j6yVlxwPixI/7aTpdp+FH16Oaau1bcClpjI=
+github.com/elastic/proxy-connect-dialer-go v0.1.1/go.mod h1:YYlk9leuhkB2h7STwiNOGa1UkZWalY70jnIF8Ec3Sks=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/foxboron/go-tpm-keyfiles v0.0.0-20251226215517-609e4778396f h1:RJ+BDPLSHQO7cSjKBqjPJSbi1qfk9WcsjQDtZiw3dZw=
@@ -68,8 +72,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIiZhtifTV5OUqqiP82UAl0h87xj/l9k=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
-github.com/michel-laterman/proxy-connect-dialer-go v0.1.0 h1:Q8asukpmyrEheocd+R+6YEI4jcm62sHHalgTMG+LoLw=
-github.com/michel-laterman/proxy-connect-dialer-go v0.1.0/go.mod h1:HTlVkRAqzTRPYbWxgAiwMT9HRZMOqP3Mx7+toa3yJjc=
+github.com/madflojo/testcerts v1.5.0 h1:GhQllyAiGzXVZU+i8O/cQkPTHzN59RxMGtm3uETgXnU=
+github.com/madflojo/testcerts v1.5.0/go.mod h1:MW8sh39gLnkKh4K0Nc55AyHEDl9l/FBLDUsQhpmkuo0=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -84,8 +88,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/oklog/ulid/v2 v2.1.2 h1:IEclFb9JNvzYA6MW2SCxbLzcHTVsfqm3PrqGQJH5zec=
 github.com/oklog/ulid/v2 v2.1.2/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/open-telemetry/opamp-go v0.23.0 h1:k7h7w/muprut9/DAhUC4anX4v7hIdgO02gIsSjV4uq0=
-github.com/open-telemetry/opamp-go v0.23.0/go.mod h1:DIIVdkLefdqPW5L+4I2twmAicVrTB0Bp5XJAfedZzAM=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pierrec/lz4/v4 v4.1.29 h1:CDQY6qZOLI4DW0Nx6R1vRrifrCeQHnNXkMb0hZWXFjg=
 github.com/pierrec/lz4/v4 v4.1.29/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -151,6 +152,18 @@ func (o *opampAgent) Start(ctx context.Context, host component.Host) error {
 			OnMessage: o.onMessage,
 			OnCommand: o.onCommand,
 		},
+	}
+
+	// When configured with a Unix domain socket, dial it instead of TCP. Only
+	// the WebSocket transport honors DialContext (the HTTP transport ignores it),
+	// and config validation enforces that unix_socket is set only under ws. The
+	// OpAMPServerURL endpoint then only supplies the URL scheme, request path, and
+	// Host header; its host:port is ignored.
+	if socketPath := o.cfg.Server.GetUnixSocket(); socketPath != "" {
+		settings.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", socketPath)
+		}
 	}
 
 	if err := o.createAgentDescription(); err != nil {

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -6,11 +6,14 @@ package opampextension
 import (
 	"context"
 	"errors"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -18,6 +21,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/open-telemetry/opamp-go/server"
+	servertypes "github.com/open-telemetry/opamp-go/server/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -65,6 +70,76 @@ func TestNewOpampAgentAttributes(t *testing.T) {
 	assert.Equal(t, "distro.0", o.serviceVersion)
 	assert.Equal(t, "f8999bc1-4c9b-4619-9bae-7f009d2411ec", o.serviceInstanceID)
 	assert.NoError(t, o.Shutdown(t.Context()))
+}
+
+// TestOpampAgentConnectsOverUnixSocket exercises the full WebSocket OpAMP
+// handshake from the extension's client to a server listening on a filesystem
+// Unix domain socket. The endpoint host is cosmetic; the configured unix_socket
+// drives the dial. The server-side connection must be a *net.UnixConn so a
+// consumer (e.g. the supervisor) can authenticate the peer via SO_PEERCRED.
+func TestOpampAgentConnectsOverUnixSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix domain socket peer authentication is not supported on Windows")
+	}
+
+	// macOS limits the socket path to ~104 bytes, which t.TempDir() can exceed,
+	// so bind under a short base directory.
+	dir, err := os.MkdirTemp("/tmp", "opampuds")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socketPath := filepath.Join(dir, "opamp.sock")
+
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	var gotUnixConn atomic.Bool
+	connected := make(chan struct{})
+	var once sync.Once
+
+	callbacks := servertypes.Callbacks{
+		OnConnecting: func(_ *http.Request) servertypes.ConnectionResponse {
+			return servertypes.ConnectionResponse{
+				Accept: true,
+				ConnectionCallbacks: servertypes.ConnectionCallbacks{
+					OnConnected: func(_ context.Context, conn servertypes.Connection) {
+						_, ok := conn.Connection().(*net.UnixConn)
+						gotUnixConn.Store(ok)
+						once.Do(func() { close(connected) })
+					},
+				},
+			}
+		},
+	}
+
+	srv := server.New(nil)
+	require.NoError(t, srv.Start(server.StartSettings{
+		Settings:   server.Settings{Callbacks: callbacks},
+		Listener:   ln,
+		ListenPath: "/v1/opamp",
+	}))
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+	require.Equal(t, "unix", srv.Addr().Network())
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Server = &OpAMPServer{
+		WS: &commonFields{
+			// Host is cosmetic; DialContext dials the socket regardless.
+			Endpoint:   "ws://localhost/v1/opamp",
+			UnixSocket: socketPath,
+		},
+	}
+	set := extensiontest.NewNopSettings(extensiontest.NopType)
+	o, err := newOpampAgent(cfg, set)
+	require.NoError(t, err)
+	require.NoError(t, o.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { _ = o.Shutdown(context.Background()) })
+
+	select {
+	case <-connected:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the opamp client to connect over the unix socket")
+	}
+	assert.True(t, gotUnixConn.Load(), "server-side connection should be a *net.UnixConn")
 }
 
 func TestCreateAgentDescription(t *testing.T) {
@@ -1047,6 +1122,10 @@ func (mockOpAMPClient) SetPackageStatuses(*protobufs.PackageStatuses) error {
 }
 
 func (mockOpAMPClient) RequestConnectionSettings(*protobufs.ConnectionSettingsRequest) error {
+	return nil
+}
+
+func (mockOpAMPClient) SetConnectionSettingsStatus(*protobufs.ConnectionSettingsStatus) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Implements UDS transport support for OpAMP between the Supervisor and Collector. Dependent on this [PR](https://github.com/open-telemetry/opamp-go/pull/642) in OpAMP-Go.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Closes #50603 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests for each component, e2e test in the supervisor.

<!--Describe the documentation added.-->
#### Documentation
Documentation in the supervisor and extension have been added.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
