### PR TITLE
[ci] Add solaris/amd64 to cross-compile build matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -601,6 +601,9 @@ jobs:
           - os: aix
             arch: ppc64
             runner: ubuntu-24.04
+          - os: solaris
+            arch: amd64
+            runner: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
#### Description

Adds solaris/amd64 target to the cross-compile matrix job in build-and-test.yml. This satisfies Tier 3 platform requirements for open-telemetry/opentelemetry-collector#15782 and open-telemetry/opentelemetry-collector#15853.

#### Link to tracking issue

Fixes open-telemetry/opentelemetry-collector#15782

#### Testing

Validated build-and-test.yml with actionlint. Verified GOOS=solaris GOARCH=amd64 compilation of otelcontribcol binary.

#### Documentation

Updated cross-compile build matrix configuration.

#### Authorship

- [ ] I, a human, wrote this pull request description myself.