### PR TITLE
[cmd/opampsupervisor] Disable the bootstrap Collector's internal metrics

### DIFF
--- a/.chloggen/50608-opampsupervisor-bootstrap-disable-internal-metrics.yaml
+++ b/.chloggen/50608-opampsupervisor-bootstrap-disable-internal-metrics.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Supervisor startup failing with `could not get bootstrap info from the Collector` when another process is already using `localhost:8888`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50608]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Collector started during bootstrap is only used to report its AgentDescription and is
+  stopped immediately afterwards, but it applied the default internal telemetry configuration
+  and bound a Prometheus reader on `localhost:8888`. When that port was already in use the
+  Collector exited before connecting back to the Supervisor, and startup failed with
+  `could not get bootstrap info from the Collector`. The bootstrap Collector's internal
+  metrics are never collected, so they are now disabled for that invocation only.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1698,6 +1698,48 @@ func TestSupervisorBootstrapsCollector(t *testing.T) {
 	}
 }
 
+func TestSupervisorBootstrapsCollectorWithInternalTelemetryPortInUse(t *testing.T) {
+	// The Collector's default internal telemetry configuration is a Prometheus
+	// reader on localhost:8888. The bootstrap Collector must not bind it: before
+	// its internal metrics were disabled it failed to create a meter provider,
+	// exited before connecting back, and Start returned "could not get bootstrap
+	// info from the Collector".
+	listener, err := net.Listen("tcp", "localhost:8888")
+	if err != nil {
+		t.Skipf("could not claim the Collector's default internal telemetry port: %v", err)
+	}
+	defer listener.Close()
+
+	agentDescription := atomic.Value{}
+
+	server := newOpAMPServer(
+		t,
+		defaultConnectingHandler,
+		types.ConnectionCallbacks{
+			OnMessage: func(_ context.Context, _ types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				if message.AgentDescription != nil {
+					agentDescription.Store(message.AgentDescription)
+				}
+
+				return &protobufs.ServerToAgent{}
+			},
+		},
+	)
+
+	s, _ := newSupervisor(t, "nocap", map[string]string{"url": server.addr})
+
+	require.NoError(t, s.Start(t.Context()))
+	defer s.Shutdown()
+
+	waitForSupervisorConnection(server.supervisorConnected, true)
+
+	require.Eventually(t, func() bool {
+		_, ok := agentDescription.Load().(*protobufs.AgentDescription)
+		return ok
+	}, 5*time.Second, 250*time.Millisecond,
+		"Supervisor did not bootstrap the Collector while localhost:8888 was in use")
+}
+
 func TestSupervisorBootstrapsCollectorAvailableComponents(t *testing.T) {
 	agentDescription := atomic.Value{}
 	availableComponents := atomic.Value{}

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -69,6 +69,9 @@ var (
 	//go:embed templates/owntelemetry.yaml
 	ownTelemetryTpl string
 
+	//go:embed templates/nooptelemetry.yaml
+	noopTelemetry string
+
 	lastRecvRemoteConfigFile       = "last_recv_remote_config.dat"
 	lastWorkingRemoteConfigFile    = "last_working_remote_config.dat"
 	lastRecvOwnTelemetryConfigFile = "last_recv_own_telemetry_config.dat"
@@ -1244,6 +1247,13 @@ func (s *Supervisor) composeNoopConfig() ([]byte, error) {
 		return nil, err
 	}
 	if err := config.MergeConfFromYAML(conf, s.composeOpAMPExtensionConfig()); err != nil {
+		return nil, err
+	}
+	// The bootstrap Collector is stopped as soon as it has reported its
+	// AgentDescription, so its internal metrics are never collected. Disabling
+	// them keeps the Collector's default reader from binding localhost:8888,
+	// which fails the bootstrap when that port is already in use.
+	if err := config.MergeConfFromYAML(conf, []byte(noopTelemetry)); err != nil {
 		return nil, err
 	}
 

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
@@ -3415,6 +3416,8 @@ service:
             receivers:
                 - nop
     telemetry:
+        metrics:
+            level: none
         resource:
             attributes:
                 - name: service.instance.id
@@ -3463,6 +3466,8 @@ service:
             receivers:
                 - nop
     telemetry:
+        metrics:
+            level: none
         resource:
             attributes:
                 - name: service.instance.id
@@ -3518,6 +3523,8 @@ service:
             receivers:
                 - nop
     telemetry:
+        metrics:
+            level: none
         resource:
             attributes:
                 - name: service.instance.id
@@ -3643,6 +3650,38 @@ telemetry:
 	})
 
 	supervisor.Shutdown()
+}
+
+func TestSupervisor_composeNoopConfigDisablesInternalMetrics(t *testing.T) {
+	// The bootstrap Collector's internal metrics must stay disabled, otherwise its
+	// default reader binds localhost:8888 and the bootstrap fails when that port
+	// is already in use.
+	s := Supervisor{
+		persistentState: &persistentState{
+			InstanceID: uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb"),
+		},
+		pidProvider: staticPIDProvider(1234),
+	}
+
+	require.NoError(t, s.createTemplates())
+
+	noopConfigBytes, err := s.composeNoopConfig()
+	require.NoError(t, err)
+
+	conf, err := config.NewConfFromYAML(noopConfigBytes)
+	require.NoError(t, err)
+
+	telemetryConf, err := conf.Sub("service::telemetry")
+	require.NoError(t, err)
+
+	telemetryCfg, ok := otelconftelemetry.NewFactory().CreateDefaultConfig().(*otelconftelemetry.Config)
+	require.True(t, ok)
+	require.NoError(t, telemetryConf.Unmarshal(telemetryCfg))
+
+	// Metrics must be disabled with `level: none` rather than an empty readers
+	// list: validation rejects an empty list while the level is not none.
+	require.NoError(t, telemetryCfg.Validate())
+	require.Equal(t, configtelemetry.LevelNone, telemetryCfg.Metrics.Level)
 }
 
 func TestSupervisor_addSpecialConfigFiles(t *testing.T) {

--- a/cmd/opampsupervisor/supervisor/templates/nooptelemetry.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/nooptelemetry.yaml
@@ -1,0 +1,15 @@
+# Internal telemetry for the bootstrap Collector.
+#
+# The bootstrap Collector is started only so that it reports its AgentDescription
+# and is stopped immediately afterwards, so its internal metrics are never
+# collected. Without this the Collector falls back to its default internal
+# telemetry configuration, a Prometheus reader on localhost:8888, and fails to
+# create its meter provider when that port is already in use.
+#
+# Metrics are disabled with `level: none` rather than an empty readers list
+# because configuration validation rejects an empty list while the level is not
+# none.
+service:
+  telemetry:
+    metrics:
+      level: none


### PR DESCRIPTION
#### Description

The Supervisor starts a Collector during bootstrap only to read its AgentDescription, and stops it right after. This bootstrap config does not set service::telemetry::metrics, so the Collector uses its default internal telemetry: a Prometheus reader on localhost:8888. If another process already uses that port, the Collector cannot create its meter provider and exits before connecting back, so Supervisor.Start fails with could not get bootstrap info from the Collector. The error does not mention the port, so the cause is hard to find.

The bootstrap Collector runs for a few seconds and nothing scrapes it, so its internal metrics are never collected. This PR disables them for the bootstrap invocation only. The steady-state configuration path is not changed.

level: none is used instead of an empty readers list because configuration validation rejects an empty list while the level is not none.

#### Link to tracking issue
Fixes #50608

#### Testing

Added a unit test TestSupervisor_composeNoopConfigDisablesInternalMetrics, and an e2e test TestSupervisorBootstrapsCollectorWithInternalTelemetryPortInUse that binds localhost:8888 before starting the Supervisor and checks that the Collector still bootstraps. Three existing golden tests were updated for the new bootstrap config.

I also checked that the new e2e test fails without the fix, reporting could not get bootstrap info from the Collector: collector's OpAMP client never connected to the Supervisor. With the fix applied, the full e2e suite passes (go test -race --tags=e2e, 86 tests) and the unit tests pass (270 tests). golangci-lint and make chlog-validate are clean.


#### Authorship

- [x] I, a human, wrote this pull request description myself.
