### PR TITLE
[receiver/azureeventhub] Do not emit 0-valued series for aggregates missing from source records

### DIFF
--- a/.chloggen/50485-azureencoding-missing-aggregates.yaml
+++ b/.chloggen/50485-azureencoding-missing-aggregates.yaml
@@ -1,0 +1,14 @@
+change_type: bug_fix
+
+component: extension/encoding/azureencoding
+
+note: Do not emit 0-valued timeseries for aggregates (total, count, minimum, maximum, average) that are missing from the source Azure record
+
+issues: [50485]
+
+subtext: |
+  Diagnostic settings only export the aggregates a resource supports. A configured
+  aggregation whose aggregate is absent from the record is now skipped instead of
+  being coerced to 0.
+
+change_logs: [user]

--- a/.chloggen/50485-azureencoding-missing-aggregates.yaml
+++ b/.chloggen/50485-azureencoding-missing-aggregates.yaml
@@ -1,6 +1,6 @@
 change_type: bug_fix
 
-component: extension/encoding/azureencoding
+component: extension/azure_encoding
 
 note: Do not emit 0-valued timeseries for aggregates (total, count, minimum, maximum, average) that are missing from the source Azure record
 

--- a/.chloggen/50485-azureeventhub-missing-aggregates.yaml
+++ b/.chloggen/50485-azureeventhub-missing-aggregates.yaml
@@ -1,0 +1,14 @@
+change_type: bug_fix
+
+component: receiver/azureeventhub
+
+note: Do not emit 0-valued timeseries for aggregates (total, count, minimum, maximum, average) that are missing from the source Azure record
+
+issues: [50485]
+
+subtext: |
+  Diagnostic settings only export the aggregates a resource supports, e.g. a Standard
+  Load Balancer exports total and count but no minimum/maximum. Missing aggregates are
+  now skipped instead of being coerced to 0.
+
+change_logs: [user]

--- a/.chloggen/50485-azureeventhub-missing-aggregates.yaml
+++ b/.chloggen/50485-azureeventhub-missing-aggregates.yaml
@@ -1,6 +1,6 @@
 change_type: bug_fix
 
-component: receiver/azureeventhub
+component: receiver/azure_event_hub
 
 note: Do not emit 0-valued timeseries for aggregates (total, count, minimum, maximum, average) that are missing from the source Azure record
 

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler.go
@@ -178,10 +178,6 @@ func (r ResourceMetricsUnmarshaler) unmarshalRecord(allResourceScopeMetrics map[
 
 	metrics := scopeMetrics.Metrics()
 	for _, agg := range r.aggregations {
-		// Aggregates are pointers so an aggregate absent from the source record can be
-		// distinguished from a genuine 0 value; diagnostic settings only export the
-		// aggregates a resource supports, and coercing missing ones to 0 fabricated
-		// 0-valued timeseries downstream.
 		var value *float64
 		switch agg {
 		case AggregationTotal:

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler.go
@@ -37,15 +37,15 @@ var timeGrains = map[string]int64{
 // azureMetricRecord represents a single Azure Metric following
 // the common schema does not exist (yet):
 type azureMetricRecord struct {
-	Time       string  `json:"time"`
-	ResourceID string  `json:"resourceId"`
-	MetricName string  `json:"metricName"`
-	TimeGrain  string  `json:"timeGrain"`
-	Total      float64 `json:"total"`
-	Count      float64 `json:"count"`
-	Minimum    float64 `json:"minimum"`
-	Maximum    float64 `json:"maximum"`
-	Average    float64 `json:"average"`
+	Time       string   `json:"time"`
+	ResourceID string   `json:"resourceId"`
+	MetricName string   `json:"metricName"`
+	TimeGrain  string   `json:"timeGrain"`
+	Total      *float64 `json:"total"`
+	Count      *float64 `json:"count"`
+	Minimum    *float64 `json:"minimum"`
+	Maximum    *float64 `json:"maximum"`
+	Average    *float64 `json:"average"`
 	// Fields below are available only via DCR, not via Diagnostic Settings
 	Unit       string         `json:"unit"`
 	Dimensions map[string]any `json:"dimension"`
@@ -178,23 +178,38 @@ func (r ResourceMetricsUnmarshaler) unmarshalRecord(allResourceScopeMetrics map[
 
 	metrics := scopeMetrics.Metrics()
 	for _, agg := range r.aggregations {
+		// Aggregates are pointers so an aggregate absent from the source record can be
+		// distinguished from a genuine 0 value; diagnostic settings only export the
+		// aggregates a resource supports, and coercing missing ones to 0 fabricated
+		// 0-valued timeseries downstream.
+		var value *float64
+		switch agg {
+		case AggregationTotal:
+			value = azureMetric.Total
+		case AggregationCount:
+			value = azureMetric.Count
+		case AggregationMinimum:
+			value = azureMetric.Minimum
+		case AggregationMaximum:
+			value = azureMetric.Maximum
+		case AggregationAverage:
+			value = azureMetric.Average
+		}
+		if value == nil {
+			r.logger.Debug(
+				"Azure Metric record is missing the requested aggregation",
+				zap.String("metricName", azureMetric.MetricName),
+				zap.String("aggregation", string(agg)),
+			)
+			continue
+		}
+
 		m := metrics.AppendEmpty()
 		m.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(azureMetric.MetricName, " ", "_"), agg)))
 		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
 		dp.SetStartTimestamp(startTimestamp)
 		dp.SetTimestamp(timestamp)
-		switch agg {
-		case AggregationTotal:
-			dp.SetDoubleValue(azureMetric.Total)
-		case AggregationCount:
-			dp.SetDoubleValue(azureMetric.Count)
-		case AggregationMinimum:
-			dp.SetDoubleValue(azureMetric.Minimum)
-		case AggregationMaximum:
-			dp.SetDoubleValue(azureMetric.Maximum)
-		case AggregationAverage:
-			dp.SetDoubleValue(azureMetric.Average)
-		}
+		dp.SetDoubleValue(*value)
 		// Only for records exported via DCRs
 		if azureMetric.Unit != "" {
 			m.SetUnit(azureMetric.Unit)

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler.go
@@ -196,11 +196,6 @@ func (r ResourceMetricsUnmarshaler) unmarshalRecord(allResourceScopeMetrics map[
 			value = azureMetric.Average
 		}
 		if value == nil {
-			r.logger.Debug(
-				"Azure Metric record is missing the requested aggregation",
-				zap.String("metricName", azureMetric.MetricName),
-				zap.String("aggregation", string(agg)),
-			)
 			continue
 		}
 

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler_test.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/metrics/unmarshaler_test.go
@@ -206,3 +206,61 @@ func TestResourceMetricsUnmarshaler_UnmarshalMetrics(t *testing.T) {
 		require.Equal(t, 1, metrics.ResourceMetrics().Len())
 	})
 }
+
+func TestResourceMetricsUnmarshaler_MissingAggregates(t *testing.T) {
+	t.Parallel()
+
+	unmarshaler := NewAzureResourceMetricsUnmarshaler(
+		component.BuildInfo{Version: "test-version"},
+		zap.NewNop(),
+		MetricsConfig{},
+	)
+
+	// Standard Load Balancer diagnostic settings export total and count but no
+	// minimum/maximum aggregates; the unmarshaler must not fabricate 0-valued
+	// series for them, while an aggregate explicitly present as 0 is kept.
+	data := []byte(`{"records":[
+	{
+	  "count":23,
+	  "total":12292.1382,
+	  "resourceId":"/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/RG/PROVIDERS/MICROSOFT.NETWORK/LOADBALANCERS/LB",
+	  "time":"2025-07-14T12:45:00.0000000Z",
+	  "metricName":"bytecount",
+	  "timeGrain":"PT1M"
+	},
+	{
+	  "count":2,
+	  "total":10,
+	  "minimum":0,
+	  "maximum":8,
+	  "average":5,
+	  "resourceId":"/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/RG/PROVIDERS/MICROSOFT.NETWORK/LOADBALANCERS/LB",
+	  "time":"2025-07-14T12:45:00.0000000Z",
+	  "metricName":"withzeros",
+	  "timeGrain":"PT1M"
+	}
+	]}`)
+
+	metrics, err := unmarshaler.UnmarshalMetrics(data)
+	require.NoError(t, err)
+	require.Equal(t, 7, metrics.MetricCount())
+
+	names := map[string]bool{}
+	values := map[string]float64{}
+	ms := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	for i := 0; i < ms.Len(); i++ {
+		names[ms.At(i).Name()] = true
+		values[ms.At(i).Name()] = ms.At(i).Gauge().DataPoints().At(0).DoubleValue()
+	}
+
+	require.Equal(t, map[string]bool{
+		"bytecount_total":   true,
+		"bytecount_count":   true,
+		"withzeros_total":   true,
+		"withzeros_count":   true,
+		"withzeros_minimum": true,
+		"withzeros_maximum": true,
+		"withzeros_average": true,
+	}, names)
+	require.Equal(t, 0.0, values["withzeros_minimum"])
+}

--- a/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
+++ b/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
@@ -85,11 +85,15 @@ type azureResourceMetricRecord struct {
 	MetricName string `json:"metricName"`
 	TimeGrain  string `json:"timeGrain"`
 
-	Total   float64 `json:"total"`
-	Count   float64 `json:"count"`
-	Minimum float64 `json:"minimum"`
-	Maximum float64 `json:"maximum"`
-	Average float64 `json:"average"`
+	// Aggregates are pointers so an aggregate absent from the source record can
+	// be distinguished from a genuine 0 value: diagnostic settings only export
+	// the aggregates a resource supports, and coercing missing ones to 0
+	// fabricated 0-valued timeseries downstream.
+	Total   *float64 `json:"total"`
+	Count   *float64 `json:"count"`
+	Minimum *float64 `json:"minimum"`
+	Maximum *float64 `json:"maximum"`
+	Average *float64 `json:"average"`
 }
 
 func (r *azureResourceMetricRecord) AppendMetrics(c azureResourceMetricsConfiger, md *pmetric.Metrics) error {
@@ -126,53 +130,68 @@ func (r *azureResourceMetricRecord) AppendMetrics(c azureResourceMetricsConfiger
 	startTimestamp = pcommon.NewTimestampFromTime(nanos.AsTime().Add(-time.Minute))
 
 	if c.GetAggregation() == "average" {
+		if r.Total == nil || r.Count == nil {
+			c.GetLogger().Warn("Metric record is missing total or count; skipping average",
+				zap.String("metricName", r.MetricName))
+			return nil
+		}
 		metrics.EnsureCapacity(1)
 		metricAverage := metrics.AppendEmpty()
 		metricAverage.SetName(strings.ToLower(strings.ReplaceAll(r.MetricName, " ", "_")))
 		dpAverage := metricAverage.SetEmptyGauge().DataPoints().AppendEmpty()
 		dpAverage.SetStartTimestamp(startTimestamp)
 		dpAverage.SetTimestamp(nanos)
-		dpAverage.SetDoubleValue(r.Total / r.Count)
+		dpAverage.SetDoubleValue(*r.Total / *r.Count)
 
 		return nil
 	}
 
 	metrics.EnsureCapacity(5)
 
-	metricTotal := metrics.AppendEmpty()
-	metricTotal.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Total")))
-	dpTotal := metricTotal.SetEmptyGauge().DataPoints().AppendEmpty()
-	dpTotal.SetStartTimestamp(startTimestamp)
-	dpTotal.SetTimestamp(nanos)
-	dpTotal.SetDoubleValue(r.Total)
+	if r.Total != nil {
+		metricTotal := metrics.AppendEmpty()
+		metricTotal.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Total")))
+		dpTotal := metricTotal.SetEmptyGauge().DataPoints().AppendEmpty()
+		dpTotal.SetStartTimestamp(startTimestamp)
+		dpTotal.SetTimestamp(nanos)
+		dpTotal.SetDoubleValue(*r.Total)
+	}
 
-	metricCount := metrics.AppendEmpty()
-	metricCount.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Count")))
-	dpCount := metricCount.SetEmptyGauge().DataPoints().AppendEmpty()
-	dpCount.SetStartTimestamp(startTimestamp)
-	dpCount.SetTimestamp(nanos)
-	dpCount.SetDoubleValue(r.Count)
+	if r.Count != nil {
+		metricCount := metrics.AppendEmpty()
+		metricCount.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Count")))
+		dpCount := metricCount.SetEmptyGauge().DataPoints().AppendEmpty()
+		dpCount.SetStartTimestamp(startTimestamp)
+		dpCount.SetTimestamp(nanos)
+		dpCount.SetDoubleValue(*r.Count)
+	}
 
-	metricMin := metrics.AppendEmpty()
-	metricMin.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Minimum")))
-	dpMin := metricMin.SetEmptyGauge().DataPoints().AppendEmpty()
-	dpMin.SetStartTimestamp(startTimestamp)
-	dpMin.SetTimestamp(nanos)
-	dpMin.SetDoubleValue(r.Minimum)
+	if r.Minimum != nil {
+		metricMin := metrics.AppendEmpty()
+		metricMin.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Minimum")))
+		dpMin := metricMin.SetEmptyGauge().DataPoints().AppendEmpty()
+		dpMin.SetStartTimestamp(startTimestamp)
+		dpMin.SetTimestamp(nanos)
+		dpMin.SetDoubleValue(*r.Minimum)
+	}
 
-	metricMax := metrics.AppendEmpty()
-	metricMax.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Maximum")))
-	dpMax := metricMax.SetEmptyGauge().DataPoints().AppendEmpty()
-	dpMax.SetStartTimestamp(startTimestamp)
-	dpMax.SetTimestamp(nanos)
-	dpMax.SetDoubleValue(r.Maximum)
+	if r.Maximum != nil {
+		metricMax := metrics.AppendEmpty()
+		metricMax.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Maximum")))
+		dpMax := metricMax.SetEmptyGauge().DataPoints().AppendEmpty()
+		dpMax.SetStartTimestamp(startTimestamp)
+		dpMax.SetTimestamp(nanos)
+		dpMax.SetDoubleValue(*r.Maximum)
+	}
 
-	metricAverage := metrics.AppendEmpty()
-	metricAverage.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Average")))
-	dpAverage := metricAverage.SetEmptyGauge().DataPoints().AppendEmpty()
-	dpAverage.SetStartTimestamp(startTimestamp)
-	dpAverage.SetTimestamp(nanos)
-	dpAverage.SetDoubleValue(r.Average)
+	if r.Average != nil {
+		metricAverage := metrics.AppendEmpty()
+		metricAverage.SetName(strings.ToLower(fmt.Sprintf("%s_%s", strings.ReplaceAll(r.MetricName, " ", "_"), "Average")))
+		dpAverage := metricAverage.SetEmptyGauge().DataPoints().AppendEmpty()
+		dpAverage.SetStartTimestamp(startTimestamp)
+		dpAverage.SetTimestamp(nanos)
+		dpAverage.SetDoubleValue(*r.Average)
+	}
 
 	return nil
 }

--- a/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
+++ b/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
@@ -85,7 +85,6 @@ type azureResourceMetricRecord struct {
 	MetricName string `json:"metricName"`
 	TimeGrain  string `json:"timeGrain"`
 
-	// nil means the aggregate was omitted from the source record.
 	Total   *float64 `json:"total"`
 	Count   *float64 `json:"count"`
 	Minimum *float64 `json:"minimum"`

--- a/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
+++ b/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
@@ -85,10 +85,7 @@ type azureResourceMetricRecord struct {
 	MetricName string `json:"metricName"`
 	TimeGrain  string `json:"timeGrain"`
 
-	// Aggregates are pointers so an aggregate absent from the source record can
-	// be distinguished from a genuine 0 value: diagnostic settings only export
-	// the aggregates a resource supports, and coercing missing ones to 0
-	// fabricated 0-valued timeseries downstream.
+	// nil means the aggregate was omitted from the source record.
 	Total   *float64 `json:"total"`
 	Count   *float64 `json:"count"`
 	Minimum *float64 `json:"minimum"`

--- a/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler_test.go
+++ b/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler_test.go
@@ -147,10 +147,17 @@ func TestAzureResourceMetricsUnmarshaler_UnmarshalAggregatedAppMetrics(t *testin
 }
 
 func TestAzureResourceMetricsUnmarshaler_SkipsMissingAggregates(t *testing.T) {
-	// Standard Load Balancer diagnostic settings export total and count but no
-	// minimum/maximum aggregates; the unmarshaler must not fabricate 0-valued
-	// series for them, while an aggregate explicitly present as 0 is kept.
-	eventPayload := `{"records":[
+	tests := []struct {
+		name              string
+		metricAggregation string
+		eventPayload      string
+		wantMetricCount   int
+		wantMetricNames   map[string]bool
+		wantValues        map[string]float64
+	}{
+		{
+			name: "does not fabricate absent aggregates",
+			eventPayload: `{"records":[
 	{
 	  "count":23,
 	  "total":12292.1382,
@@ -170,47 +177,25 @@ func TestAzureResourceMetricsUnmarshaler_SkipsMissingAggregates(t *testing.T) {
 	  "metricName":"withzeros",
 	  "timeGrain":"PT1M"
 	}
-	]}`
-	event := azureEvent{AzEventData: &azeventhubs.ReceivedEventData{EventData: azeventhubs.EventData{Body: []byte(eventPayload)}}}
-	unmarshaler := newAzureResourceMetricsUnmarshaler(
-		component.BuildInfo{
-			Command:     "Test",
-			Description: "Test",
-			Version:     "Test",
+	]}`,
+			wantMetricCount: 7,
+			wantMetricNames: map[string]bool{
+				"bytecount_total":   true,
+				"bytecount_count":   true,
+				"withzeros_total":   true,
+				"withzeros_count":   true,
+				"withzeros_minimum": true,
+				"withzeros_maximum": true,
+				"withzeros_average": true,
+			},
+			wantValues: map[string]float64{
+				"withzeros_minimum": 0,
+			},
 		},
-		zap.NewNop(),
-		&Config{},
-	)
-	metrics, err := unmarshaler.UnmarshalMetrics(&event)
-
-	assert.NoError(t, err)
-	require.Equal(t, 7, metrics.MetricCount())
-
-	// Each Event Hub record becomes its own ResourceMetrics entry.
-	names := map[string]bool{}
-	values := map[string]float64{}
-	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
-		ms := metrics.ResourceMetrics().At(i).ScopeMetrics().At(0).Metrics()
-		for j := 0; j < ms.Len(); j++ {
-			names[ms.At(j).Name()] = true
-			values[ms.At(j).Name()] = ms.At(j).Gauge().DataPoints().At(0).DoubleValue()
-		}
-	}
-
-	assert.Equal(t, map[string]bool{
-		"bytecount_total":   true,
-		"bytecount_count":   true,
-		"withzeros_total":   true,
-		"withzeros_count":   true,
-		"withzeros_minimum": true,
-		"withzeros_maximum": true,
-		"withzeros_average": true,
-	}, names)
-	assert.Equal(t, 0.0, values["withzeros_minimum"])
-}
-
-func TestAzureResourceMetricsUnmarshaler_AverageAggregationSkipsRecordWithoutTotalOrCount(t *testing.T) {
-	eventPayload := `{"records":[
+		{
+			name:              "skips average without total or count",
+			metricAggregation: "average",
+			eventPayload: `{"records":[
 	{
 	  "average":5,
 	  "resourceId":"/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/RG/PROVIDERS/MICROSOFT.NETWORK/LOADBALANCERS/LB",
@@ -218,21 +203,47 @@ func TestAzureResourceMetricsUnmarshaler_AverageAggregationSkipsRecordWithoutTot
 	  "metricName":"bytecount",
 	  "timeGrain":"PT1M"
 	}
-	]}`
-	event := azureEvent{AzEventData: &azeventhubs.ReceivedEventData{EventData: azeventhubs.EventData{Body: []byte(eventPayload)}}}
-	unmarshaler := newAzureResourceMetricsUnmarshaler(
-		component.BuildInfo{
-			Command:     "Test",
-			Description: "Test",
-			Version:     "Test",
+	]}`,
 		},
-		zap.NewNop(),
-		&Config{
-			MetricAggregation: "average",
-		},
-	)
-	metrics, err := unmarshaler.UnmarshalMetrics(&event)
+	}
 
-	assert.NoError(t, err)
-	assert.Equal(t, 0, metrics.MetricCount())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := azureEvent{AzEventData: &azeventhubs.ReceivedEventData{EventData: azeventhubs.EventData{Body: []byte(tt.eventPayload)}}}
+			unmarshaler := newAzureResourceMetricsUnmarshaler(
+				component.BuildInfo{
+					Command:     "Test",
+					Description: "Test",
+					Version:     "Test",
+				},
+				zap.NewNop(),
+				&Config{MetricAggregation: tt.metricAggregation},
+			)
+			metrics, err := unmarshaler.UnmarshalMetrics(&event)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantMetricCount, metrics.MetricCount())
+
+			if tt.wantMetricNames == nil {
+				return
+			}
+
+			// Each Event Hub record becomes its own ResourceMetrics entry.
+			names := map[string]bool{}
+			values := map[string]float64{}
+			for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+				ms := metrics.ResourceMetrics().At(i).ScopeMetrics().At(0).Metrics()
+				for j := 0; j < ms.Len(); j++ {
+					names[ms.At(j).Name()] = true
+					values[ms.At(j).Name()] = ms.At(j).Gauge().DataPoints().At(0).DoubleValue()
+				}
+			}
+
+			assert.Equal(t, tt.wantMetricNames, names)
+			for name, want := range tt.wantValues {
+				assert.Equal(t, want, values[name])
+			}
+		},
+		)
+	}
 }

--- a/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler_test.go
+++ b/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 )
@@ -143,4 +144,95 @@ func TestAzureResourceMetricsUnmarshaler_UnmarshalAggregatedAppMetrics(t *testin
 	appMetric := metrics.ResourceMetrics().At(1).ScopeMetrics().At(0).Metrics().At(0)
 	assert.Equal(t, "metric.name", appMetric.Name())
 	assert.Equal(t, 8.0, appMetric.Gauge().DataPoints().At(0).DoubleValue())
+}
+
+func TestAzureResourceMetricsUnmarshaler_SkipsMissingAggregates(t *testing.T) {
+	// Standard Load Balancer diagnostic settings export total and count but no
+	// minimum/maximum aggregates; the unmarshaler must not fabricate 0-valued
+	// series for them, while an aggregate explicitly present as 0 is kept.
+	eventPayload := `{"records":[
+	{
+	  "count":23,
+	  "total":12292.1382,
+	  "resourceId":"/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/RG/PROVIDERS/MICROSOFT.NETWORK/LOADBALANCERS/LB",
+	  "time":"2025-07-14T12:45:00.0000000Z",
+	  "metricName":"bytecount",
+	  "timeGrain":"PT1M"
+	},
+	{
+	  "count":2,
+	  "total":10,
+	  "minimum":0,
+	  "maximum":8,
+	  "average":5,
+	  "resourceId":"/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/RG/PROVIDERS/MICROSOFT.NETWORK/LOADBALANCERS/LB",
+	  "time":"2025-07-14T12:45:00.0000000Z",
+	  "metricName":"withzeros",
+	  "timeGrain":"PT1M"
+	}
+	]}`
+	event := azureEvent{AzEventData: &azeventhubs.ReceivedEventData{EventData: azeventhubs.EventData{Body: []byte(eventPayload)}}}
+	unmarshaler := newAzureResourceMetricsUnmarshaler(
+		component.BuildInfo{
+			Command:     "Test",
+			Description: "Test",
+			Version:     "Test",
+		},
+		zap.NewNop(),
+		&Config{},
+	)
+	metrics, err := unmarshaler.UnmarshalMetrics(&event)
+
+	assert.NoError(t, err)
+	require.Equal(t, 7, metrics.MetricCount())
+
+	// Each Event Hub record becomes its own ResourceMetrics entry.
+	names := map[string]bool{}
+	values := map[string]float64{}
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		ms := metrics.ResourceMetrics().At(i).ScopeMetrics().At(0).Metrics()
+		for j := 0; j < ms.Len(); j++ {
+			names[ms.At(j).Name()] = true
+			values[ms.At(j).Name()] = ms.At(j).Gauge().DataPoints().At(0).DoubleValue()
+		}
+	}
+
+	assert.Equal(t, map[string]bool{
+		"bytecount_total":   true,
+		"bytecount_count":   true,
+		"withzeros_total":   true,
+		"withzeros_count":   true,
+		"withzeros_minimum": true,
+		"withzeros_maximum": true,
+		"withzeros_average": true,
+	}, names)
+	assert.Equal(t, 0.0, values["withzeros_minimum"])
+}
+
+func TestAzureResourceMetricsUnmarshaler_AverageAggregationSkipsRecordWithoutTotalOrCount(t *testing.T) {
+	eventPayload := `{"records":[
+	{
+	  "average":5,
+	  "resourceId":"/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/RG/PROVIDERS/MICROSOFT.NETWORK/LOADBALANCERS/LB",
+	  "time":"2025-07-14T12:45:00.0000000Z",
+	  "metricName":"bytecount",
+	  "timeGrain":"PT1M"
+	}
+	]}`
+	event := azureEvent{AzEventData: &azeventhubs.ReceivedEventData{EventData: azeventhubs.EventData{Body: []byte(eventPayload)}}}
+	unmarshaler := newAzureResourceMetricsUnmarshaler(
+		component.BuildInfo{
+			Command:     "Test",
+			Description: "Test",
+			Version:     "Test",
+		},
+		zap.NewNop(),
+		&Config{
+			MetricAggregation: "average",
+		},
+	)
+	metrics, err := unmarshaler.UnmarshalMetrics(&event)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, metrics.MetricCount())
 }


### PR DESCRIPTION
#### Description

Azure diagnostic settings only export the aggregates a resource supports: a Standard Load Balancer, for example, exports `total` and `count` but no `minimum`/`maximum`. The azureeventhub receiver parsed the aggregates into `float64` value fields, so an aggregate missing from the source record was coerced to `0` and fabricated `0`-valued `_minimum`/`_maximum` (etc.) timeseries downstream, instead of being excluded.

This change parses the aggregates as pointers in both the azureeventhub receiver and the azureencoding extension (which shared the same behavior, as noted in the issue) and emits only the series whose aggregate is actually present in the record. An aggregate explicitly present as `0` is still emitted as a genuine `0` value.

Behavior notes:

- Full-aggregation mode: series are emitted only for the aggregates present in the record.
- `average` aggregation (receiver): a record missing `total` or `count` can no longer produce a value at all, so the record is skipped with a warning instead of emitting a NaN datapoint.
- The azureencoding extension skips a configured aggregation whose aggregate is absent, with a debug log.

#### Link to tracking issue
Fixes #50485

#### Testing

- `receiver/azureeventhubreceiver`: added `TestAzureResourceMetricsUnmarshaler_SkipsMissingAggregates` (a record with only `total`/`count` yields no `minimum`/`maximum` series, while a record with `minimum: 0` still emits a `0`-valued series) and `TestAzureResourceMetricsUnmarshaler_AverageAggregationSkipsRecordWithoutTotalOrCount`. `go test .` passes.
- `extension/encoding/azureencodingextension`: added `TestResourceMetricsUnmarshaler_MissingAggregates` with the same coverage. `go test ./...` passes.

#### Documentation

Added `.chloggen` entries for both components describing the corrected behavior.
