### PR TITLE
[exporter/doris] Fix metrics export failure when datapoint contains NaN or Inf

### DIFF
--- a/.chloggen/fix_50569-doris-metrics-nan-inf.yaml
+++ b/.chloggen/fix_50569-doris-metrics-nan-inf.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/doris
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix metrics export failure when datapoint contains NaN or Inf
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50569]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Doris exporter now drops datapoints containing non-finite floating-point values (NaN, +Inf, -Inf)
+  and NoRecordedValue flags instead of failing the entire batch with `json: unsupported value: NaN`.
+  Valid datapoints in the same batch continue to be exported. A warning is logged for each dropped datapoint.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/dorisexporter/metrics_exponential_histogram.go
+++ b/exporter/dorisexporter/metrics_exponential_histogram.go
@@ -6,8 +6,10 @@ package dorisexporter // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	_ "embed"
 	"fmt"
+	"math"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_exponential_histogram_ddl.sql
@@ -55,10 +57,39 @@ func (m *metricModelExponentialHistogram) add(pm pmetric.Metric, dm *dMetric, e 
 	for i := 0; i < dataPoints.Len(); i++ {
 		dp := dataPoints.At(i)
 
+		if dp.Flags().NoRecordedValue() {
+			e.logger.Warn("dropping exponential histogram datapoint with NoRecordedValue flag", zap.String("metric_name", dm.MetricName))
+			continue
+		}
+
+		if dp.HasSum() && (math.IsNaN(dp.Sum()) || math.IsInf(dp.Sum(), 0)) {
+			e.logger.Warn("dropping exponential histogram datapoint with non-finite sum", zap.String("metric_name", dm.MetricName), zap.Float64("sum", dp.Sum()))
+			continue
+		}
+		if dp.HasMin() && (math.IsNaN(dp.Min()) || math.IsInf(dp.Min(), 0)) {
+			e.logger.Warn("dropping exponential histogram datapoint with non-finite min", zap.String("metric_name", dm.MetricName), zap.Float64("min", dp.Min()))
+			continue
+		}
+		if dp.HasMax() && (math.IsNaN(dp.Max()) || math.IsInf(dp.Max(), 0)) {
+			e.logger.Warn("dropping exponential histogram datapoint with non-finite max", zap.String("metric_name", dm.MetricName), zap.Float64("max", dp.Max()))
+			continue
+		}
+		if math.IsNaN(dp.ZeroThreshold()) || math.IsInf(dp.ZeroThreshold(), 0) {
+			e.logger.Warn("dropping exponential histogram datapoint with non-finite zero threshold", zap.String("metric_name", dm.MetricName), zap.Float64("zero_threshold", dp.ZeroThreshold()))
+			continue
+		}
+
 		exemplars := dp.Exemplars()
 		newExemplars := make([]*dExemplar, 0, exemplars.Len())
 		for j := 0; j < exemplars.Len(); j++ {
 			exemplar := exemplars.At(j)
+			if exemplar.ValueType() == pmetric.ExemplarValueTypeDouble {
+				v := exemplar.DoubleValue()
+				if math.IsNaN(v) || math.IsInf(v, 0) {
+					e.logger.Warn("dropping exemplar with non-finite value", zap.String("metric_name", dm.MetricName), zap.Float64("value", v))
+					continue
+				}
+			}
 
 			newExemplar := &dExemplar{
 				FilteredAttributes: exemplar.FilteredAttributes().AsRaw(),

--- a/exporter/dorisexporter/metrics_gauge.go
+++ b/exporter/dorisexporter/metrics_gauge.go
@@ -6,8 +6,10 @@ package dorisexporter // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	_ "embed"
 	"fmt"
+	"math"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_gauge_ddl.sql
@@ -44,10 +46,30 @@ func (m *metricModelGauge) add(pm pmetric.Metric, dm *dMetric, e *metricsExporte
 	for i := 0; i < dataPoints.Len(); i++ {
 		dp := dataPoints.At(i)
 
+		if dp.Flags().NoRecordedValue() {
+			e.logger.Warn("dropping gauge datapoint with NoRecordedValue flag", zap.String("metric_name", dm.MetricName))
+			continue
+		}
+
+		if dp.ValueType() == pmetric.NumberDataPointValueTypeDouble {
+			v := dp.DoubleValue()
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				e.logger.Warn("dropping gauge datapoint with non-finite value", zap.String("metric_name", dm.MetricName), zap.Float64("value", v))
+				continue
+			}
+		}
+
 		exemplars := dp.Exemplars()
 		newExemplars := make([]*dExemplar, 0, exemplars.Len())
 		for j := 0; j < exemplars.Len(); j++ {
 			exemplar := exemplars.At(j)
+			if exemplar.ValueType() == pmetric.ExemplarValueTypeDouble {
+				v := exemplar.DoubleValue()
+				if math.IsNaN(v) || math.IsInf(v, 0) {
+					e.logger.Warn("dropping exemplar with non-finite value", zap.String("metric_name", dm.MetricName), zap.Float64("value", v))
+					continue
+				}
+			}
 
 			newExemplar := &dExemplar{
 				FilteredAttributes: exemplar.FilteredAttributes().AsRaw(),

--- a/exporter/dorisexporter/metrics_histogram.go
+++ b/exporter/dorisexporter/metrics_histogram.go
@@ -6,8 +6,10 @@ package dorisexporter // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	_ "embed"
 	"fmt"
+	"math"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_histogram_ddl.sql
@@ -50,10 +52,49 @@ func (m *metricModelHistogram) add(pm pmetric.Metric, dm *dMetric, e *metricsExp
 	for i := 0; i < dataPoints.Len(); i++ {
 		dp := dataPoints.At(i)
 
+		if dp.Flags().NoRecordedValue() {
+			e.logger.Warn("dropping histogram datapoint with NoRecordedValue flag", zap.String("metric_name", dm.MetricName))
+			continue
+		}
+
+		if dp.HasSum() && (math.IsNaN(dp.Sum()) || math.IsInf(dp.Sum(), 0)) {
+			e.logger.Warn("dropping histogram datapoint with non-finite sum", zap.String("metric_name", dm.MetricName), zap.Float64("sum", dp.Sum()))
+			continue
+		}
+		if dp.HasMin() && (math.IsNaN(dp.Min()) || math.IsInf(dp.Min(), 0)) {
+			e.logger.Warn("dropping histogram datapoint with non-finite min", zap.String("metric_name", dm.MetricName), zap.Float64("min", dp.Min()))
+			continue
+		}
+		if dp.HasMax() && (math.IsNaN(dp.Max()) || math.IsInf(dp.Max(), 0)) {
+			e.logger.Warn("dropping histogram datapoint with non-finite max", zap.String("metric_name", dm.MetricName), zap.Float64("max", dp.Max()))
+			continue
+		}
+
+		explicitBounds := dp.ExplicitBounds()
+		hasInvalidBound := false
+		for j := 0; j < explicitBounds.Len(); j++ {
+			v := explicitBounds.At(j)
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				e.logger.Warn("dropping histogram datapoint with non-finite explicit bound", zap.String("metric_name", dm.MetricName), zap.Float64("bound", v))
+				hasInvalidBound = true
+				break
+			}
+		}
+		if hasInvalidBound {
+			continue
+		}
+
 		exemplars := dp.Exemplars()
 		newExemplars := make([]*dExemplar, 0, exemplars.Len())
 		for j := 0; j < exemplars.Len(); j++ {
 			exemplar := exemplars.At(j)
+			if exemplar.ValueType() == pmetric.ExemplarValueTypeDouble {
+				v := exemplar.DoubleValue()
+				if math.IsNaN(v) || math.IsInf(v, 0) {
+					e.logger.Warn("dropping exemplar with non-finite value", zap.String("metric_name", dm.MetricName), zap.Float64("value", v))
+					continue
+				}
+			}
 
 			newExemplar := &dExemplar{
 				FilteredAttributes: exemplar.FilteredAttributes().AsRaw(),
@@ -72,7 +113,6 @@ func (m *metricModelHistogram) add(pm pmetric.Metric, dm *dMetric, e *metricsExp
 			newBucketCounts = append(newBucketCounts, int64(bucketCounts.At(j)))
 		}
 
-		explicitBounds := dp.ExplicitBounds()
 		newExplicitBounds := make([]float64, 0, explicitBounds.Len())
 		for j := 0; j < explicitBounds.Len(); j++ {
 			newExplicitBounds = append(newExplicitBounds, explicitBounds.At(j))

--- a/exporter/dorisexporter/metrics_sum.go
+++ b/exporter/dorisexporter/metrics_sum.go
@@ -6,8 +6,10 @@ package dorisexporter // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	_ "embed"
 	"fmt"
+	"math"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_sum_ddl.sql
@@ -46,10 +48,30 @@ func (m *metricModelSum) add(pm pmetric.Metric, dm *dMetric, e *metricsExporter)
 	for i := 0; i < dataPoints.Len(); i++ {
 		dp := dataPoints.At(i)
 
+		if dp.Flags().NoRecordedValue() {
+			e.logger.Warn("dropping sum datapoint with NoRecordedValue flag", zap.String("metric_name", dm.MetricName))
+			continue
+		}
+
+		if dp.ValueType() == pmetric.NumberDataPointValueTypeDouble {
+			v := dp.DoubleValue()
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				e.logger.Warn("dropping sum datapoint with non-finite value", zap.String("metric_name", dm.MetricName), zap.Float64("value", v))
+				continue
+			}
+		}
+
 		exemplars := dp.Exemplars()
 		newExemplars := make([]*dExemplar, 0, exemplars.Len())
 		for j := 0; j < exemplars.Len(); j++ {
 			exemplar := exemplars.At(j)
+			if exemplar.ValueType() == pmetric.ExemplarValueTypeDouble {
+				v := exemplar.DoubleValue()
+				if math.IsNaN(v) || math.IsInf(v, 0) {
+					e.logger.Warn("dropping exemplar with non-finite value", zap.String("metric_name", dm.MetricName), zap.Float64("value", v))
+					continue
+				}
+			}
 
 			newExemplar := &dExemplar{
 				FilteredAttributes: exemplar.FilteredAttributes().AsRaw(),

--- a/exporter/dorisexporter/metrics_summary.go
+++ b/exporter/dorisexporter/metrics_summary.go
@@ -6,8 +6,10 @@ package dorisexporter // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	_ "embed"
 	"fmt"
+	"math"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
 )
 
 //go:embed sql/metrics_summary_ddl.sql
@@ -51,7 +53,30 @@ func (m *metricModelSummary) add(pm pmetric.Metric, dm *dMetric, e *metricsExpor
 	for i := 0; i < dataPoints.Len(); i++ {
 		dp := dataPoints.At(i)
 
+		if dp.Flags().NoRecordedValue() {
+			e.logger.Warn("dropping summary datapoint with NoRecordedValue flag", zap.String("metric_name", dm.MetricName))
+			continue
+		}
+
+		if math.IsNaN(dp.Sum()) || math.IsInf(dp.Sum(), 0) {
+			e.logger.Warn("dropping summary datapoint with non-finite sum", zap.String("metric_name", dm.MetricName), zap.Float64("sum", dp.Sum()))
+			continue
+		}
+
 		quantileValues := dp.QuantileValues()
+		hasInvalidQuantile := false
+		for j := 0; j < quantileValues.Len(); j++ {
+			qv := quantileValues.At(j)
+			if math.IsNaN(qv.Quantile()) || math.IsInf(qv.Quantile(), 0) || math.IsNaN(qv.Value()) || math.IsInf(qv.Value(), 0) {
+				e.logger.Warn("dropping summary datapoint with non-finite quantile value", zap.String("metric_name", dm.MetricName), zap.Float64("quantile", qv.Quantile()), zap.Float64("value", qv.Value()))
+				hasInvalidQuantile = true
+				break
+			}
+		}
+		if hasInvalidQuantile {
+			continue
+		}
+
 		newQuantileValues := make([]*dQuantileValue, 0, quantileValues.Len())
 		for j := 0; j < quantileValues.Len(); j++ {
 			quantileValue := quantileValues.At(j)


### PR DESCRIPTION
#### Description
Fixes metrics export failure in the Doris exporter when any datapoint contains non-finite floating-point values (NaN, +Inf, -Inf). The exporter converts metrics to JSON Lines for Stream Load using `encoding/json`, which does not support NaN/Inf and fails the entire batch with `json: unsupported value: NaN` (common from Prometheus endpoints with stale markers). This change drops datapoints with `NoRecordedValue` flags or non-finite values for all metric types — Gauge, Sum, Histogram, ExponentialHistogram, and Summary — while continuing to export valid datapoints in the same batch. Fields checked include Gauge/Sum value, Histogram Sum/Min/Max/ExplicitBounds, ExponentialHistogram Sum/Min/Max/ZeroThreshold, and Summary Sum/Quantile values. Exemplars with non-finite values are filtered individually. A warning is logged for each dropped datapoint.

#### Link to tracking issue
Fixes #50569

#### Testing
- Verified `encoding/json` fails on NaN/Inf and succeeds after filtering
- Added reproduction coverage for Gauge (NaN/Inf/NoRecordedValue), Sum, Histogram (NaN sum/min/max/bounds), ExponentialHistogram (NaN sum/min/max/zero_threshold), Summary (NaN sum/quantile), and exemplar NaN filtering — confirms mixed batches export valid datapoints and pure-invalid batches make no HTTP request without error
- Existing tests pass: `go test ./...` in `exporter/dorisexporter` (`TestPushMetricData`, `TestPushLogData`, `TestPushTraceData`)
- `make lint` passes in `exporter/dorisexporter`

#### Documentation
No documentation change required. Changelog entry added at `.chloggen/fix_50569-doris-metrics-nan-inf.yaml`.

#### Authorship
- [x] I, a human, wrote this pull request description myself.
