### PR TITLE
[processor/resourcedetection] Parse machine type from GCE host.type

### DIFF
--- a/.chloggen/resourcedetection-gce-host-type.yaml
+++ b/.chloggen/resourcedetection-gce-host-type.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resourcedetection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Strip URI prefix from GCE `host.type` to conform with semantic conventions machine type format.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50604]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Extracts the machine type (e.g. `e2-medium`) from the GCE metadata string `projects/PROJECT_NUM/machineTypes/MACHINE_TYPE`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -6,6 +6,7 @@ package gcp // import "github.com/open-telemetry/opentelemetry-collector-contrib
 import (
 	"context"
 	"regexp"
+	"strings"
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
@@ -160,7 +161,16 @@ func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		d.rb.SetCloudPlatform(conventions.CloudPlatformGCPComputeEngine.Value.AsString())
 		errs = multierr.Combine(errs,
 			d.rb.SetZoneAndRegion(d.detector.GCEAvailabilityZoneAndRegion),
-			d.rb.SetFromCallable(d.rb.SetHostType, d.detector.GCEHostType),
+			d.rb.SetFromCallable(d.rb.SetHostType, func() (string, error) {
+				hostType, err := d.detector.GCEHostType()
+				if err != nil {
+					return "", err
+				}
+				if idx := strings.LastIndex(hostType, "/"); idx != -1 {
+					hostType = hostType[idx+1:]
+				}
+				return hostType, nil
+			}),
 			d.rb.SetFromCallable(d.rb.SetHostID, d.detector.GCEHostID),
 			d.rb.SetFromCallable(d.rb.SetHostName, d.detector.GCEHostName),
 			d.rb.SetFromCallable(d.rb.SetGcpGceInstanceHostname, d.detector.GCEInstanceHostname),

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
@@ -201,7 +201,7 @@ func TestDetect(t *testing.T) {
 				cloudPlatform:          gcp.GCE,
 				gceHostID:              "1472385723456792345",
 				gceHostName:            "my-gke-node-1234",
-				gceHostType:            "n1-standard1",
+				gceHostType:            "projects/123456789/machineTypes/n1-standard1",
 				gceAvailabilityZone:    "us-central1-c",
 				gceRegion:              "us-central1",
 				gcpGceInstanceHostname: "custom.dns.example.com",


### PR DESCRIPTION
#### Description
The GCE metadata server returns the instance machine type in the format `projects/PROJECT_NUM/machineTypes/MACHINE_TYPE`. However, the OpenTelemetry Semantic Conventions for host.type specify that for Cloud environments, this should be only the machine type itself (e.g. `e2-medium` or `n1-standard-1`).

This PR strips the URI prefix from `GCEHostType()` and retains just the machine type.

#### Link to tracking issue
Fixes #50604

#### Testing
- Updated unit test in `processor/resourcedetectionprocessor/internal/gcp/gcp_test.go` verifying that `projects/123456789/machineTypes/n1-standard1` is formatted as `n1-standard1`.

#### Documentation
- Added `.chloggen/resourcedetection-gce-host-type.yaml`.

#### Authorship

- [x] I, a human, wrote this pull request description myself.