### PR TITLE
[exporter/otelarrow] Simplify stream.read error handling

### DIFF
--- a/.chloggen/otelarrow-simplify-stream-read-error.yaml
+++ b/.chloggen/otelarrow-simplify-stream-read-error.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/otelarrow
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Simplify `stream.read` error handling and remove redundant non-nil check flagging staticcheck SA4023.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50420]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/otelarrowexporter/internal/arrow/stream.go
+++ b/exporter/otelarrowexporter/internal/arrow/stream.go
@@ -196,33 +196,28 @@ func (s *Stream) run(ctx context.Context, dc doneCancel, streamClient StreamClie
 
 	// the result from read() is processed after cancel and wait,
 	// so we can set s.client = nil in case of a delayed Unimplemented.
-	// TODO: SA4023(related information): the lhs of the comparison is the 1st return value of this function call
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50420
-	err = s.read(ctx) //nolint:staticcheck
+	err = s.read(ctx)
 
 	// Wait for the writer to ensure that all waiters are known.
 	dc.cancel()
 	ww.Wait()
 
-	// TODO: SA4023: this comparison is always true
-	if err != nil { //nolint:staticcheck
-		// This branch is reached with an unimplemented status
-		// with or without the WaitForReady flag.
-		if status, ok := status.FromError(err); ok && status.Code() == codes.Unimplemented {
-			// This (client == nil) signals the controller to
-			// downgrade when all streams have returned in that
-			// status.
-			//
-			// This is a special case because we reset s.client,
-			// which sets up a downgrade after the streams return.
-			s.client = nil
-			s.telemetry.Logger.Info("arrow is not supported",
-				zap.String("message", status.Message()),
-			)
-		} else {
-			// All other cases, use the standard log handler.
-			s.logStreamError("reader", err)
-		}
+	// This branch is reached with an unimplemented status
+	// with or without the WaitForReady flag.
+	if status, ok := status.FromError(err); ok && status.Code() == codes.Unimplemented {
+		// This (client == nil) signals the controller to
+		// downgrade when all streams have returned in that
+		// status.
+		//
+		// This is a special case because we reset s.client,
+		// which sets up a downgrade after the streams return.
+		s.client = nil
+		s.telemetry.Logger.Info("arrow is not supported",
+			zap.String("message", status.Message()),
+		)
+	} else {
+		// All other cases, use the standard log handler.
+		s.logStreamError("reader", err)
 	}
 	if writeErr != nil {
 		s.logStreamError("writer", writeErr)


### PR DESCRIPTION
#### Description
Stream.read() loop only exits on a non-nil error from Recv() or processBatchStatus(). As flagged by staticcheck (SA4023), the subsequent `if err != nil` check in run() was redundant and tautological.

This PR removes the redundant check and resolves the SA4023 warning cleanly.

#### Link to tracking issue
Fixes #50420

#### Testing
- Ran unit tests in `exporter/otelarrowexporter/internal/arrow/...`.

#### Documentation
- Added `.chloggen/otelarrow-simplify-stream-read-error.yaml`.

#### Authorship

- [x] I, a human, wrote this pull request description myself.