### PR TITLE
[chore] [exporter/splunkhecexporter] Fix flaky TestReceiveLogs by recording requests in order

### DIFF
--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -197,6 +197,13 @@ type receivedRequest struct {
 	headers http.Header
 }
 
+// receivedRequestChanBuffer is the capacity given to receivedRequest channels.
+// The ServeHTTP handler records requests synchronously to preserve their order,
+// so the channel must be buffered enough that the send never blocks the exporter
+// before the test's collecting loop starts reading. It comfortably exceeds the
+// number of batches any test in this package produces.
+const receivedRequestChanBuffer = 1024
+
 type capturingData struct {
 	testing          *testing.T
 	receivedRequest  chan receivedRequest
@@ -214,11 +221,14 @@ func (c *capturingData) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		panic(err)
 	}
-	go func() {
-		if c.receivedRequest != nil {
-			c.receivedRequest <- receivedRequest{body, r.Header}
-		}
-	}()
+	// Record the request synchronously so that batches are captured in the exact
+	// order the client sent them. Spawning a goroutine per request here would let
+	// requests race onto the channel and be collected out of order, causing flaky
+	// assertions on per-batch contents. The channel is buffered by the callers so
+	// this send never blocks the exporter.
+	if c.receivedRequest != nil {
+		c.receivedRequest <- receivedRequest{body, r.Header}
+	}
 	w.WriteHeader(c.statusCode)
 }
 
@@ -233,7 +243,7 @@ func runMetricsExport(t *testing.T, cfg *Config, metrics pmetric.Metrics, expect
 	cfg.Token = "1234-1234"
 	cfg.UseMultiMetricFormat = useMultiMetricsFormat
 
-	rr := make(chan receivedRequest)
+	rr := make(chan receivedRequest, receivedRequestChanBuffer)
 	capture := capturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
 	s := &http.Server{
 		Handler:           &capture,
@@ -286,7 +296,7 @@ func runTraceExport(t *testing.T, testConfig *Config, traces ptrace.Traces, expe
 	cfg.MaxContentLengthTraces = testConfig.MaxContentLengthTraces
 	cfg.Token = "1234-1234"
 
-	rr := make(chan receivedRequest)
+	rr := make(chan receivedRequest, receivedRequestChanBuffer)
 	capture := capturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
 	s := &http.Server{
 		Handler:           &capture,
@@ -346,7 +356,7 @@ func runLogExport(t *testing.T, cfg *Config, ld plog.Logs, expectedBatchesNum in
 	cfg.ClientConfig.Endpoint = "http://" + listener.Addr().String() + "/services/collector"
 	cfg.Token = "1234-1234"
 
-	rr := make(chan receivedRequest)
+	rr := make(chan receivedRequest, receivedRequestChanBuffer)
 	capture := capturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
 	s := &http.Server{
 		Handler:           &capture,
@@ -1302,7 +1312,7 @@ func TestReceiveMetricsWithCompression(t *testing.T) {
 }
 
 func TestErrorReceived(t *testing.T) {
-	rr := make(chan receivedRequest)
+	rr := make(chan receivedRequest, receivedRequestChanBuffer)
 	capture := capturingData{receivedRequest: rr, statusCode: 500}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -1354,7 +1364,7 @@ func TestErrorReceived(t *testing.T) {
 }
 
 func TestErrorReceivedForbidden(t *testing.T) {
-	rr := make(chan receivedRequest)
+	rr := make(chan receivedRequest, receivedRequestChanBuffer)
 	capture := capturingData{receivedRequest: rr, statusCode: 403}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -1489,7 +1499,7 @@ func TestHeartbeatStartupFailed(t *testing.T) {
 }
 
 func TestHeartbeatStartupPass_Disabled(t *testing.T) {
-	rr := make(chan receivedRequest)
+	rr := make(chan receivedRequest, receivedRequestChanBuffer)
 	capture := capturingData{receivedRequest: rr, statusCode: 403}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -2550,7 +2560,7 @@ func runBatchedLogExport(t *testing.T, cfg *Config, ld plog.Logs, expectedBatche
 	cfg.ClientConfig.Endpoint = "http://" + listener.Addr().String() + "/services/collector"
 	cfg.Token = "1234-1234"
 
-	// Buffered channel so the async handler goroutines never block.
+	// Buffered channel so the handler's synchronous send never blocks the exporter.
 	rr := make(chan receivedRequest, 64)
 	capture := capturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
 	s := &http.Server{
@@ -2575,7 +2585,7 @@ func runBatchedLogExport(t *testing.T, cfg *Config, ld plog.Logs, expectedBatche
 	require.NoError(t, exp.Shutdown(t.Context()))
 
 	// Collect exactly expectedBatchesNum requests, with a generous timeout to
-	// account for the async handler goroutine scheduling.
+	// account for batcher flush scheduling.
 	var requests []receivedRequest
 	deadline := time.After(10 * time.Second)
 	for len(requests) < expectedBatchesNum {


### PR DESCRIPTION
#### Description
This PR fixes flaky per-batch assertions in `TestReceiveLogs` and related tests. The test HTTP handler recorded each received request in a separate goroutine, so although the exporter sends batches sequentially, the goroutines raced onto the unbuffered channel and were collected out of order.

Requests are now recorded synchronously in `ServeHTTP` to preserve send order, and the `receivedRequest` channels are buffered so the synchronous send never blocks the exporter before the collecting loop starts reading.

#### Link to tracking issue
Fixes #48832 and #48831


#### Testing
Verified with `go test -race -count=20` over the affected tests.

#### Documentation
N/A

#### Authorship

- [x] I, a human, wrote this pull request description myself.