### PR TITLE
[chore] [receiver/yanggrpcreceiver] Fix flaky telemetry validation tests

### DIFF
--- a/receiver/yanggrpcreceiver/detailed_validation_test.go
+++ b/receiver/yanggrpcreceiver/detailed_validation_test.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver/internal/metadata"
@@ -67,7 +66,8 @@ func TestDetailedTelemetryValidation(t *testing.T) {
 	// Create receiver configuration
 	config := createDefaultConfig().(*Config)
 
-	config.ServerConfig.NetAddr.Endpoint = "localhost:57403"
+	endpoint := getFreeEndpoint(t)
+	config.ServerConfig.NetAddr.Endpoint = endpoint
 	config.ServerConfig.NetAddr.Transport = "tcp"
 
 	settings := receiver.Settings{
@@ -87,7 +87,13 @@ func TestDetailedTelemetryValidation(t *testing.T) {
 		assert.NoError(t, rcvr.Shutdown(ctx))
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	// Wait until the gRPC server is ready to accept streams instead of using a
+	// fixed sleep, which is unreliable on slow or loaded CI machines. Reusing a
+	// single ready connection for all sends avoids per-send connection setup
+	// racing the send deadline, which previously surfaced as
+	// "failed to create stream: context deadline exceeded".
+	conn := newReadyClientConn(t, endpoint)
+	defer conn.Close()
 
 	// Send realistic telemetry data with multiple interfaces
 	testCases := []struct {
@@ -125,7 +131,7 @@ func TestDetailedTelemetryValidation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := sendDetailedTelemetryData("localhost:57403", "CISCO-TEST-SWITCH", tc.interfaceName, tc.rxPkts, tc.txPkts, tc.rxBytes, tc.txBytes)
+		err := sendDetailedTelemetryData(conn, "CISCO-TEST-SWITCH", tc.interfaceName, tc.rxPkts, tc.txPkts, tc.rxBytes, tc.txBytes)
 		assert.NoError(t, err, "Failed to send telemetry for %s: %v", tc.name, err)
 	}
 
@@ -293,18 +299,12 @@ func TestDetailedTelemetryValidation(t *testing.T) {
 }
 
 // sendDetailedTelemetryData sends telemetry data for a specific interface with detailed metrics
-func sendDetailedTelemetryData(endpoint, nodeID, interfaceName string, rxPkts, txPkts, rxBytes, txBytes uint64) error {
-	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return fmt.Errorf("failed to connect to receiver: %w", err)
-	}
-	defer conn.Close()
-
+func sendDetailedTelemetryData(conn *grpc.ClientConn, nodeID, interfaceName string, rxPkts, txPkts, rxBytes, txBytes uint64) error {
 	client := pb.NewGRPCMdtDialoutClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stream, err := client.MdtDialout(ctx)
+	stream, err := client.MdtDialout(ctx, grpc.WaitForReady(true))
 	if err != nil {
 		return fmt.Errorf("failed to create stream: %w", err)
 	}

--- a/receiver/yanggrpcreceiver/sample_telemetry_test.go
+++ b/receiver/yanggrpcreceiver/sample_telemetry_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 
@@ -50,7 +51,8 @@ func TestSampleTelemetryData(t *testing.T) {
 
 	// Create receiver configuration
 	config := createDefaultConfig().(*Config)
-	config.ServerConfig.NetAddr.Endpoint = "localhost:57404"
+	endpoint := getFreeEndpoint(t)
+	config.ServerConfig.NetAddr.Endpoint = endpoint
 	config.ServerConfig.NetAddr.Transport = "tcp"
 
 	settings := receiver.Settings{
@@ -70,23 +72,19 @@ func TestSampleTelemetryData(t *testing.T) {
 		assert.NoError(t, rcvr.Shutdown(ctx))
 	}()
 
-	// Wait until the gRPC server is ready to accept connections instead of using
-	// a fixed sleep, which is unreliable on slow or loaded CI machines.
-	require.Eventually(t, func() bool {
-		conn, err := net.DialTimeout(string(config.ServerConfig.NetAddr.Transport), config.ServerConfig.NetAddr.Endpoint, 100*time.Millisecond)
-		if err != nil {
-			return false
-		}
-		conn.Close()
-		return true
-	}, 5*time.Second, 10*time.Millisecond, "receiver did not start accepting connections in time")
+	// Wait until the gRPC server is ready to accept streams. A raw TCP dial is not
+	// sufficient because the listener accepts connections before the gRPC server
+	// starts serving; establishing a real gRPC connection and reusing it for all
+	// sends avoids the "failed to create stream: context deadline exceeded" flake.
+	conn := newReadyClientConn(t, endpoint)
+	defer conn.Close()
 
 	// Load sample data (either from file or use built-in sample)
 	sampleData := getSampleTelemetryData(t)
 
 	// Send each interface's telemetry data
 	for _, interfaceData := range sampleData.Interfaces {
-		err := sendInterfaceTelemetryData("localhost:57404", sampleData.NodeID, sampleData.Subscription, sampleData.EncodingPath, interfaceData)
+		err := sendInterfaceTelemetryData(conn, sampleData.NodeID, sampleData.Subscription, sampleData.EncodingPath, interfaceData)
 		if err != nil {
 			t.Fatalf("Failed to send telemetry for interface %s: %v", interfaceData.Name, err)
 		}
@@ -207,18 +205,12 @@ func loadSampleFromFile(filename string) (SampleTelemetryData, error) {
 }
 
 // sendInterfaceTelemetryData sends telemetry data for a specific interface
-func sendInterfaceTelemetryData(endpoint, nodeID, subscription, encodingPath string, interfaceData InterfaceTelemetry) error {
-	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return fmt.Errorf("failed to connect to receiver: %w", err)
-	}
-	defer conn.Close()
-
+func sendInterfaceTelemetryData(conn *grpc.ClientConn, nodeID, subscription, encodingPath string, interfaceData InterfaceTelemetry) error {
 	client := pb.NewGRPCMdtDialoutClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stream, err := client.MdtDialout(ctx)
+	stream, err := client.MdtDialout(ctx, grpc.WaitForReady(true))
 	if err != nil {
 		return fmt.Errorf("failed to create stream: %w", err)
 	}
@@ -414,6 +406,44 @@ func analyzeResults(t *testing.T, consumer *metricsCapture, sampleData SampleTel
 		} else {
 			t.Errorf("   FAIL %s: Missing telemetry data", expectedInterface.Name)
 		}
+	}
+}
+
+// getFreeEndpoint returns a currently-unused local TCP endpoint. Using a
+// dynamically allocated port instead of a hard-coded one prevents flaky failures
+// caused by the port already being in use.
+func getFreeEndpoint(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	return listener.Addr().String()
+}
+
+// newReadyClientConn dials the receiver and blocks until the gRPC connection is
+// actually ready to serve requests. Waiting for the READY state (rather than a
+// raw TCP dial or a fixed sleep) ensures the gRPC server has finished starting,
+// and reusing the returned connection for every send avoids per-send connection
+// setup racing the send deadline. Both previously surfaced as
+// "failed to create stream: context deadline exceeded" flakes on loaded CI.
+func newReadyClientConn(t *testing.T, endpoint string) *grpc.ClientConn {
+	t.Helper()
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return conn
+		}
+		if state == connectivity.Idle {
+			conn.Connect()
+		}
+		require.True(t, conn.WaitForStateChange(ctx, state),
+			"gRPC server did not become ready in time (last state: %s)", state)
 	}
 }
 


### PR DESCRIPTION
#### Description
This PR fixes intermittent CI failures in `TestDetailedTelemetryValidation` and `TestSampleTelemetryData` ("failed to create stream: context deadline exceeded").

There were two causes. Both tests opened a fresh gRPC connection for every send, so connection setup raced the 5s send deadline on loaded runners. Readiness was also checked with a fixed sleep or a raw TCP dial, but the listener accepts TCP connections before the gRPC server starts serving, so neither guaranteed the server was ready.

The tests now wait for the connection to reach `connectivity.Ready` and reuse that single ready connection for all sends. They also allocate a dynamic port instead of a hard-coded one to avoid port-in-use conflicts.

#### Link to tracking issue
Fixes #48175


#### Testing
Tuned.

#### Documentation
N/A

#### Authorship

- [x] I, a human, wrote this pull request description myself.