### PR TITLE
[processor/tailsampling] reuse the decision threshold for late-arriving spans

### DIFF
--- a/.chloggen/tailsampling-late-span-threshold.yaml
+++ b/.chloggen/tailsampling-late-span-threshold.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reuse the original decision's threshold when rewriting tracestate for late-arriving spans of an already-sampled trace.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50623]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/tailsamplingprocessor/cache/types.go
+++ b/processor/tailsamplingprocessor/cache/types.go
@@ -24,10 +24,8 @@ type Cache interface {
 type DecisionMetadata struct {
 	PolicyName string
 	// Threshold is the effective sampling threshold that was used for the
-	// trace's decision, if any policy reported one. Its zero value is
-	// sampling.AlwaysSampleThreshold, which is also what non-probabilistic
-	// (filter-style) policies report for a Sampled decision, so an absent
-	// value is indistinguishable from -- and treated the same as -- an
-	// explicit always-sample report.
+	// trace's decision. The zero value is sampling.AlwaysSampleThreshold,
+	// which is what non-probabilistic (filter-style) policies report for a
+	// Sampled decision.
 	Threshold sampling.Threshold
 }

--- a/processor/tailsamplingprocessor/cache/types.go
+++ b/processor/tailsamplingprocessor/cache/types.go
@@ -5,6 +5,8 @@ package cache // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
 )
 
 // Cache is a cache implementation for the tailsamplingprocessor's decision cache.
@@ -21,4 +23,11 @@ type Cache interface {
 
 type DecisionMetadata struct {
 	PolicyName string
+	// Threshold is the effective sampling threshold that was used for the
+	// trace's decision, if any policy reported one. Its zero value is
+	// sampling.AlwaysSampleThreshold, which is also what non-probabilistic
+	// (filter-style) policies report for a Sampled decision, so an absent
+	// value is indistinguishable from -- and treated the same as -- an
+	// explicit always-sample report.
+	Threshold sampling.Threshold
 }

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -55,6 +55,11 @@ type TraceData struct {
 	samplingpolicy.TraceData
 	FinalDecision samplingpolicy.Decision
 	PolicyName    string
+	// EffectiveThreshold is the sampling threshold associated with a Sampled
+	// decision, kept so that late-arriving spans for this trace can have the
+	// same threshold written into their tracestate as the spans evaluated at
+	// decision time.
+	EffectiveThreshold pkgsampling.Threshold
 
 	arrivalTime   time.Time
 	decisionTime  time.Time
@@ -613,6 +618,9 @@ func (tsp *tailSamplingSpanProcessor) processCachedTrace(traceID pcommon.TraceID
 			}
 			sampling.SetBoolAttrOnScopeSpans(traceTd, "tailsampling.cached_decision", true)
 		}
+		if tsp.useTracestate {
+			sampling.WriteEffectiveThreshold(tsp.ctx, traceTd, metadata.Threshold, tsp.telemetry.ProcessorTailSamplingCountSpansWithUnparseableTracestate)
+		}
 		tsp.forwardSpans(tsp.ctx, traceTd)
 		tsp.telemetry.ProcessorTailSamplingEarlyReleasesFromCacheDecision.
 			Add(tsp.ctx, spanCount, attrSampledTrue)
@@ -820,13 +828,14 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() bool {
 
 	for _, c := range notDropped {
 		c.trace.decisionTime = time.Now()
-		decision, policyName := tsp.makeDecision(ctx, numDropPolicies, c.id, c.data, metrics)
+		decision, policyName, threshold := tsp.makeDecision(ctx, numDropPolicies, c.id, c.data, metrics)
 		globalTracesSampledByDecision[decision]++
 		// Keep release paths working with tail storage by attaching the
 		// retrieved batches back to trace state for this decision.
 		c.trace.ReceivedBatches = c.data.ReceivedBatches
 		c.trace.FinalDecision = decision
 		c.trace.PolicyName = policyName
+		c.trace.EffectiveThreshold = threshold
 
 		if decision == samplingpolicy.Sampled {
 			tsp.releaseSampledTrace(ctx, c.id, c.trace)
@@ -876,7 +885,7 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() bool {
 
 // makeDecision evaluates tsp.policies[numDropPolicies:], skipping a
 // drop-policy prefix the caller already ruled out via evaluateDropPolicies.
-func (tsp *tailSamplingSpanProcessor) makeDecision(ctx context.Context, numDropPolicies int, id pcommon.TraceID, traceData *samplingpolicy.TraceData, metrics *policyEvaluationMetrics) (samplingpolicy.Decision, string) {
+func (tsp *tailSamplingSpanProcessor) makeDecision(ctx context.Context, numDropPolicies int, id pcommon.TraceID, traceData *samplingpolicy.TraceData, metrics *policyEvaluationMetrics) (samplingpolicy.Decision, string, pkgsampling.Threshold) {
 	finalDecision := samplingpolicy.NotSampled
 	samplingDecisions := map[samplingpolicy.Decision]*policy{
 		samplingpolicy.Error:      nil,
@@ -967,12 +976,21 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(ctx context.Context, numDropP
 		metrics.decisionDropped++
 	}
 
-	return finalDecision, getPolicyName(sampledPolicy)
+	if !haveThreshold {
+		// No policy reported a threshold for this decision (e.g. a Sampled
+		// decision reached only through the deprecated invert-match
+		// combinators). Report the same AlwaysSampleThreshold that a
+		// non-probabilistic (filter-style) policy would, rather than
+		// leaking effectiveThreshold's internal "nothing accumulated yet"
+		// value.
+		effectiveThreshold = pkgsampling.AlwaysSampleThreshold
+	}
+	return finalDecision, getPolicyName(sampledPolicy), effectiveThreshold
 }
 
 // makeDecisionOnSpanIngest is used by span-ingest mode. It only returns
 // terminal decisions at ingest time. All other outcomes remain pending.
-func (tsp *tailSamplingSpanProcessor) makeDecisionOnSpanIngest(id pcommon.TraceID, trace *samplingpolicy.TraceData, metrics *policyEvaluationMetrics) (samplingpolicy.Decision, string) {
+func (tsp *tailSamplingSpanProcessor) makeDecisionOnSpanIngest(id pcommon.TraceID, trace *samplingpolicy.TraceData, metrics *policyEvaluationMetrics) (samplingpolicy.Decision, string, pkgsampling.Threshold) {
 	ctx := context.Background()
 	// Track whether a drop policy didn't match this batch. A drop policy
 	// returning NotSampled means it didn't match these spans but could still
@@ -1000,7 +1018,7 @@ func (tsp *tailSamplingSpanProcessor) makeDecisionOnSpanIngest(id pcommon.TraceI
 
 		if decision == samplingpolicy.Dropped {
 			metrics.decisionDropped++
-			return samplingpolicy.Dropped, p.name
+			return samplingpolicy.Dropped, p.name, pkgsampling.AlwaysSampleThreshold
 		}
 
 		if p.isDrop {
@@ -1018,10 +1036,10 @@ func (tsp *tailSamplingSpanProcessor) makeDecisionOnSpanIngest(id pcommon.TraceI
 			if tsp.useTracestate {
 				sampling.WriteEffectiveThreshold(ctx, trace.ReceivedBatches, th, tsp.telemetry.ProcessorTailSamplingCountSpansWithUnparseableTracestate)
 			}
-			return samplingpolicy.Sampled, p.name
+			return samplingpolicy.Sampled, p.name, th
 		}
 	}
-	return samplingpolicy.Pending, ""
+	return samplingpolicy.Pending, "", pkgsampling.AlwaysSampleThreshold
 }
 
 func groupSpansByTraceKey(resourceSpans ptrace.ResourceSpans) map[pcommon.TraceID][]spanAndScope {
@@ -1108,7 +1126,7 @@ func (tsp *tailSamplingSpanProcessor) processTrace(id pcommon.TraceID, rss ptrac
 				ReceivedBatches: ptrace.NewTraces(),
 			}
 			appendToTraces(spanIngestTraceData.ReceivedBatches, rss)
-			decision, policyName := tsp.makeDecisionOnSpanIngest(id, &spanIngestTraceData, metrics)
+			decision, policyName, threshold := tsp.makeDecisionOnSpanIngest(id, &spanIngestTraceData, metrics)
 			tsp.recordImmediateDecisionMetrics(decision, metrics, time.Since(evaluationStart))
 
 			if decision == samplingpolicy.Sampled || decision == samplingpolicy.Dropped {
@@ -1128,6 +1146,7 @@ func (tsp *tailSamplingSpanProcessor) processTrace(id pcommon.TraceID, rss ptrac
 				actualData.FinalDecision = decision
 				actualData.PolicyName = policyName
 				if decision == samplingpolicy.Sampled {
+					actualData.EffectiveThreshold = threshold
 					tsp.releaseSampledTrace(tsp.ctx, id, actualData)
 				} else {
 					tsp.releaseNotSampledTrace(id, actualData)
@@ -1155,6 +1174,9 @@ func (tsp *tailSamplingSpanProcessor) processTrace(id pcommon.TraceID, rss ptrac
 	case samplingpolicy.Sampled:
 		traceTd := ptrace.NewTraces()
 		appendToTraces(traceTd, rss)
+		if tsp.useTracestate {
+			sampling.WriteEffectiveThreshold(tsp.ctx, traceTd, actualData.EffectiveThreshold, tsp.telemetry.ProcessorTailSamplingCountSpansWithUnparseableTracestate)
+		}
 		tsp.forwardSpans(tsp.ctx, traceTd)
 	case samplingpolicy.NotSampled:
 		// TODO: I don't think this is correct? If it isn't sampled shouldn't we just do nothing?
@@ -1250,7 +1272,10 @@ func (tsp *tailSamplingSpanProcessor) releaseSampledTrace(ctx context.Context, i
 	for _, hook := range tsp.sampledHooks {
 		hook(ctx, id, td)
 	}
-	tsp.sampledIDCache.Put(id, cache.DecisionMetadata{PolicyName: td.PolicyName})
+	tsp.sampledIDCache.Put(id, cache.DecisionMetadata{
+		PolicyName: td.PolicyName,
+		Threshold:  td.EffectiveThreshold,
+	})
 	tsp.forwardSpans(ctx, td.ReceivedBatches)
 	_, ok := tsp.sampledIDCache.Get(id)
 	if ok {

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -53,13 +53,9 @@ type policy struct {
 // needed by any sampler implementations.
 type TraceData struct {
 	samplingpolicy.TraceData
-	FinalDecision samplingpolicy.Decision
-	PolicyName    string
-	// EffectiveThreshold is the sampling threshold associated with a Sampled
-	// decision, kept so that late-arriving spans for this trace can have the
-	// same threshold written into their tracestate as the spans evaluated at
-	// decision time.
-	EffectiveThreshold pkgsampling.Threshold
+	FinalDecision  samplingpolicy.Decision
+	FinalThreshold pkgsampling.Threshold
+	PolicyName     string
 
 	arrivalTime   time.Time
 	decisionTime  time.Time
@@ -834,8 +830,8 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() bool {
 		// retrieved batches back to trace state for this decision.
 		c.trace.ReceivedBatches = c.data.ReceivedBatches
 		c.trace.FinalDecision = decision
+		c.trace.FinalThreshold = threshold
 		c.trace.PolicyName = policyName
-		c.trace.EffectiveThreshold = threshold
 
 		if decision == samplingpolicy.Sampled {
 			tsp.releaseSampledTrace(ctx, c.id, c.trace)
@@ -898,7 +894,7 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(ctx context.Context, numDropP
 		samplingpolicy.Dropped:          nil,
 	}
 
-	effectiveThreshold := pkgsampling.NeverSampleThreshold
+	threshold := pkgsampling.Threshold{}
 	haveThreshold := false
 
 	for i := numDropPolicies; i < len(tsp.policies); i++ {
@@ -918,15 +914,18 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(ctx context.Context, numDropP
 
 		metrics.addDecision(i, decision, traceData.SpanCount, int64(traceData.SizeBytes))
 
-		// We associate the first policy with the sampling decision to understand what policy sampled a span
+		// Keep track of which policy was used so that we can understand which
+		// policy sampled/dropped a span.
 		if samplingDecisions[decision] == nil {
 			samplingDecisions[decision] = p
 		}
 
 		if decision == samplingpolicy.Sampled {
-			if !haveThreshold || pkgsampling.ThresholdLessThan(th, effectiveThreshold) {
-				effectiveThreshold = th
+			if !haveThreshold || pkgsampling.ThresholdLessThan(th, threshold) {
+				threshold = th
 				haveThreshold = true
+				// Ensure we record the policy that will match the span's threshold.
+				samplingDecisions[samplingpolicy.Sampled] = p
 			}
 		}
 
@@ -963,8 +962,8 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(ctx context.Context, numDropP
 		sampling.SetAttrOnScopeSpans(traceData.ReceivedBatches, "tailsampling.policy", sampledPolicy.name)
 	}
 
-	if finalDecision == samplingpolicy.Sampled && haveThreshold && tsp.useTracestate {
-		sampling.WriteEffectiveThreshold(ctx, traceData.ReceivedBatches, effectiveThreshold, tsp.telemetry.ProcessorTailSamplingCountSpansWithUnparseableTracestate)
+	if finalDecision == samplingpolicy.Sampled && tsp.useTracestate {
+		sampling.WriteEffectiveThreshold(ctx, traceData.ReceivedBatches, threshold, tsp.telemetry.ProcessorTailSamplingCountSpansWithUnparseableTracestate)
 	}
 
 	switch finalDecision {
@@ -976,16 +975,7 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(ctx context.Context, numDropP
 		metrics.decisionDropped++
 	}
 
-	if !haveThreshold {
-		// No policy reported a threshold for this decision (e.g. a Sampled
-		// decision reached only through the deprecated invert-match
-		// combinators). Report the same AlwaysSampleThreshold that a
-		// non-probabilistic (filter-style) policy would, rather than
-		// leaking effectiveThreshold's internal "nothing accumulated yet"
-		// value.
-		effectiveThreshold = pkgsampling.AlwaysSampleThreshold
-	}
-	return finalDecision, getPolicyName(sampledPolicy), effectiveThreshold
+	return finalDecision, getPolicyName(sampledPolicy), threshold
 }
 
 // makeDecisionOnSpanIngest is used by span-ingest mode. It only returns
@@ -1146,7 +1136,7 @@ func (tsp *tailSamplingSpanProcessor) processTrace(id pcommon.TraceID, rss ptrac
 				actualData.FinalDecision = decision
 				actualData.PolicyName = policyName
 				if decision == samplingpolicy.Sampled {
-					actualData.EffectiveThreshold = threshold
+					actualData.FinalThreshold = threshold
 					tsp.releaseSampledTrace(tsp.ctx, id, actualData)
 				} else {
 					tsp.releaseNotSampledTrace(id, actualData)
@@ -1175,7 +1165,7 @@ func (tsp *tailSamplingSpanProcessor) processTrace(id pcommon.TraceID, rss ptrac
 		traceTd := ptrace.NewTraces()
 		appendToTraces(traceTd, rss)
 		if tsp.useTracestate {
-			sampling.WriteEffectiveThreshold(tsp.ctx, traceTd, actualData.EffectiveThreshold, tsp.telemetry.ProcessorTailSamplingCountSpansWithUnparseableTracestate)
+			sampling.WriteEffectiveThreshold(tsp.ctx, traceTd, actualData.FinalThreshold, tsp.telemetry.ProcessorTailSamplingCountSpansWithUnparseableTracestate)
 		}
 		tsp.forwardSpans(tsp.ctx, traceTd)
 	case samplingpolicy.NotSampled:
@@ -1274,7 +1264,7 @@ func (tsp *tailSamplingSpanProcessor) releaseSampledTrace(ctx context.Context, i
 	}
 	tsp.sampledIDCache.Put(id, cache.DecisionMetadata{
 		PolicyName: td.PolicyName,
-		Threshold:  td.EffectiveThreshold,
+		Threshold:  td.FinalThreshold,
 	})
 	tsp.forwardSpans(ctx, td.ReceivedBatches)
 	_, ok := tsp.sampledIDCache.Get(id)

--- a/processor/tailsamplingprocessor/processor_benchmarks_test.go
+++ b/processor/tailsamplingprocessor/processor_benchmarks_test.go
@@ -48,7 +48,7 @@ func BenchmarkSampling(b *testing.B) {
 	ctx := b.Context()
 	for b.Loop() {
 		for i, id := range traceIDs {
-			_, _ = tsp.makeDecision(ctx, 0, id, sampleBatches[i], metrics)
+			_, _, _ = tsp.makeDecision(ctx, 0, id, sampleBatches[i], metrics)
 		}
 	}
 }

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
@@ -263,6 +264,76 @@ func TestSamplingMultiplePolicies_WithRecordPolicy(t *testing.T) {
 		assert.FailNow(t, "Did not find expected attribute")
 	}
 	require.Equal(t, "mock-policy-1", policy.AsString())
+}
+
+// TestSamplingMultiplePoliciesWithDifferentThresholds_WithRecordPolicy verifies
+// that when multiple policies vote Sampled at different rates, the recorded
+// tailsampling.policy attribute names the policy whose threshold is actually
+// reported (the least-strict one), not simply whichever policy was evaluated
+// first.
+func TestSamplingMultiplePoliciesWithDifferentThresholds_WithRecordPolicy(t *testing.T) {
+	gate := metadata.ProcessorTailsamplingprocessorUsetracestateFeatureGate
+	prev := gate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), true))
+	t.Cleanup(func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), prev))
+	})
+
+	controller := newTestTSPController()
+	nextConsumer := new(consumertest.TracesSink)
+
+	mpe1 := &mockPolicyEvaluator{}
+	mpe2 := &mockPolicyEvaluator{}
+
+	policies := []*policy{
+		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
+	}
+
+	cfg := Config{
+		SamplingStrategy: samplingStrategyTraceComplete,
+		DecisionWait:     defaultTestDecisionWait,
+		NumTraces:        defaultNumTraces,
+		Options:          []Option{withTestController(controller), withPolicies(policies), withRecordPolicy(), withUseTracestate()},
+	}
+
+	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	// mock-policy-1 is evaluated first but samples at a stricter rate (25%);
+	// mock-policy-2 samples at a less strict rate (50%). The effective
+	// threshold is the least-strict of the two, so mock-policy-2 -- not the
+	// first-evaluated mock-policy-1 -- should be the one attributed.
+	thc, err := pkgsampling.TValueToThreshold("c")
+	require.NoError(t, err)
+	th8, err := pkgsampling.TValueToThreshold("8")
+	require.NoError(t, err)
+	mpe1.SetDecision(samplingpolicy.Sampled)
+	mpe1.SetThreshold(thc)
+	mpe2.SetDecision(samplingpolicy.Sampled)
+	mpe2.SetThreshold(th8)
+
+	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+
+	controller.waitForTick()
+	controller.waitForTick()
+
+	require.Equal(t, 1, nextConsumer.SpanCount())
+
+	span := nextConsumer.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+	scope := nextConsumer.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Scope()
+
+	policyAttr, ok := scope.Attributes().Get("tailsampling.policy")
+	if !ok {
+		assert.FailNow(t, "Did not find expected attribute")
+	}
+	require.Equal(t, "mock-policy-2", policyAttr.AsString(), "attribution should follow the threshold-owning policy, not evaluation order")
+	require.Contains(t, span.TraceState().AsRaw(), "th:8", "tracestate should carry mock-policy-2's less-strict threshold")
 }
 
 func TestSamplingPolicyDecisionNotSampled(t *testing.T) {

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -623,6 +623,166 @@ func TestLateArrivingSpanUsesDecisionCache(t *testing.T) {
 	require.True(t, cacheAttr.Bool())
 }
 
+// TestLateArrivingSpanUsesDecisionCacheThreshold verifies that a late-arriving
+// span, resolved via the sampled decision cache, gets the same effective
+// tracestate threshold written as the spans that were present when the
+// original decision was made, rather than no threshold at all.
+func TestLateArrivingSpanUsesDecisionCacheThreshold(t *testing.T) {
+	nextConsumer := new(consumertest.TracesSink)
+	controller := newTestTSPController()
+
+	mpe := &mockPolicyEvaluator{}
+	policies := []*policy{
+		{name: "mock-policy-1", evaluator: mpe, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+	}
+
+	// Use this instead of the default no-op cache
+	c, err := cache.NewLRUDecisionCache(200)
+	require.NoError(t, err)
+
+	cfg := Config{
+		SamplingStrategy: samplingStrategyTraceComplete,
+		DecisionWait:     defaultTestDecisionWait * 10,
+		NumTraces:        defaultNumTraces,
+		Options: []Option{
+			withTestController(controller),
+			withPolicies(policies),
+			WithSampledDecisionCache(c),
+			withUseTracestate(),
+		},
+	}
+	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func(p processor.Traces) {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}(p)
+
+	traceID := uInt64ToTraceID(1)
+
+	// th:8 encodes a 50% sampling threshold.
+	th8, err := pkgsampling.TValueToThreshold("8")
+	require.NoError(t, err)
+	mpe.SetDecision(samplingpolicy.Sampled)
+	mpe.SetThreshold(th8)
+
+	spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
+		traces := ptrace.NewTraces()
+		span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(traceID)
+		span.SetSpanID(uInt64ToSpanID(spanIndex))
+		return traces
+	}
+
+	// Generate and deliver first span; this drives the original decision.
+	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(1)))
+	controller.waitForTick()
+	controller.waitForTick()
+	require.Equal(t, 1, mpe.EvaluationCount())
+	require.Equal(t, 1, nextConsumer.SpanCount())
+
+	firstTracestate := nextConsumer.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceState().AsRaw()
+	require.Contains(t, firstTracestate, "th:8", "original decision should carry the 50%% threshold")
+
+	// New processor instance sharing the same decision cache, simulating a
+	// restart or a different shard picking up a late span for the trace.
+	p, err = newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+	require.NoError(t, err)
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func(p processor.Traces) {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}(p)
+
+	// Change what the policy would report, proving the cached decision (and
+	// its threshold) is reused rather than the policy being re-evaluated.
+	mpe.SetDecision(samplingpolicy.NotSampled)
+	mpe.SetThreshold(pkgsampling.NeverSampleThreshold)
+
+	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(2)))
+	controller.waitForTick()
+
+	require.Equal(t, 1, mpe.EvaluationCount(), "policy should not be re-evaluated for the cached trace")
+	require.Equal(t, 2, nextConsumer.SpanCount())
+
+	lateTracestate := nextConsumer.AllTraces()[1].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceState().AsRaw()
+	require.Contains(t, lateTracestate, "th:8", "late-arriving span should carry the same threshold as the original decision")
+}
+
+// TestLateArrivingSpanBeforeEvictionUsesEffectiveThreshold verifies that a
+// late-arriving span for a trace that already has a Sampled decision, but is
+// still resident in the processor's in-memory trace map (e.g. because no
+// decision cache is configured), gets the same effective tracestate
+// threshold written as the spans present at decision time.
+func TestLateArrivingSpanBeforeEvictionUsesEffectiveThreshold(t *testing.T) {
+	nextConsumer := new(consumertest.TracesSink)
+	controller := newTestTSPController()
+
+	mpe := &mockPolicyEvaluator{}
+	policies := []*policy{
+		{name: "mock-policy-1", evaluator: mpe, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+	}
+
+	cfg := Config{
+		SamplingStrategy: samplingStrategyTraceComplete,
+		DecisionWait:     defaultTestDecisionWait * 10,
+		NumTraces:        defaultNumTraces,
+		// No decision cache configured: the default no-op cache is used, so
+		// the trace stays in the in-memory map after its decision is made.
+		Options: []Option{
+			withTestController(controller),
+			withPolicies(policies),
+			withUseTracestate(),
+		},
+	}
+	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+	require.NoError(t, err)
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func(p processor.Traces) {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}(p)
+
+	traceID := uInt64ToTraceID(1)
+
+	// th:8 encodes a 50% sampling threshold.
+	th8, err := pkgsampling.TValueToThreshold("8")
+	require.NoError(t, err)
+	mpe.SetDecision(samplingpolicy.Sampled)
+	mpe.SetThreshold(th8)
+
+	spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
+		traces := ptrace.NewTraces()
+		span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(traceID)
+		span.SetSpanID(uInt64ToSpanID(spanIndex))
+		return traces
+	}
+
+	// Generate and deliver first span; this drives the original decision.
+	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(1)))
+	controller.waitForTick()
+	controller.waitForTick()
+	require.Equal(t, 1, mpe.EvaluationCount())
+	require.Equal(t, 1, nextConsumer.SpanCount())
+
+	firstTracestate := nextConsumer.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceState().AsRaw()
+	require.Contains(t, firstTracestate, "th:8", "original decision should carry the 50%% threshold")
+
+	// A second span for the same trace arrives before the trace is evicted
+	// from the in-memory map (there is no decision cache to short-circuit
+	// via processCachedTrace, so this exercises processTrace's late-span
+	// forwarding path directly).
+	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(2)))
+	controller.waitForTick()
+
+	require.Equal(t, 1, mpe.EvaluationCount(), "policy should not be re-evaluated for the already-decided trace")
+	require.Equal(t, 2, nextConsumer.SpanCount())
+
+	lateTracestate := nextConsumer.AllTraces()[1].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceState().AsRaw()
+	require.Contains(t, lateTracestate, "th:8", "late-arriving span should carry the same threshold as the original decision")
+}
+
 func TestLateArrivingSpanUsesDecisionCacheWhenDropped(t *testing.T) {
 	nextConsumer := new(consumertest.TracesSink)
 	controller := newTestTSPController()

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -1113,6 +1113,7 @@ type mockPolicyEvaluator struct {
 	mu sync.Mutex
 
 	nextDecision    samplingpolicy.Decision
+	nextThreshold   pkgsampling.Threshold
 	nextError       error
 	evaluationCount int
 }
@@ -1132,7 +1133,10 @@ func (m *mockPolicyEvaluator) Evaluate(context.Context, pcommon.TraceID, *sampli
 
 func (m *mockPolicyEvaluator) EvaluateWithThreshold(ctx context.Context, traceID pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, pkgsampling.Threshold, error) {
 	d, err := m.Evaluate(ctx, traceID, trace)
-	return d, pkgsampling.AlwaysSampleThreshold, err
+	m.mu.Lock()
+	th := m.nextThreshold
+	m.mu.Unlock()
+	return d, th, err
 }
 
 func (*mockPolicyEvaluator) IsStateful() bool {
@@ -1143,6 +1147,12 @@ func (m *mockPolicyEvaluator) SetDecision(decision samplingpolicy.Decision) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.nextDecision = decision
+}
+
+func (m *mockPolicyEvaluator) SetThreshold(threshold pkgsampling.Threshold) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextThreshold = threshold
 }
 
 func (m *mockPolicyEvaluator) SetError(nextError error) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This fixes a bug where late arriving spans would not have their threshold set appropriately to match the rest of the trace. In addition, the policy name we record in the cache/attribute will also now be the same policy name that we take the threshold value from. Otherwise it is confusing to diagnose why a span has a certain threshold.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

New tests added to ensure the behavior.

<!--Describe the documentation added.-->
#### Documentation

No new documentation is needed

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
