### PR TITLE
[exporter/awss3] Honor request checksum calculation setting on upload

### DIFF
--- a/.chloggen/50184.yaml
+++ b/.chloggen/50184.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/awss3
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Honor the S3 client's request checksum calculation setting (including the `AWS_REQUEST_CHECKSUM_CALCULATION` environment variable) when uploading objects.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50184]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The transfer manager previously always defaulted to calculating a CRC32 checksum, which is sent as
+  an aws-chunked trailer that some S3-compatible backends reject. It now inherits the setting from the
+  configured S3 client.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/awss3exporter/internal/upload/writer.go
+++ b/exporter/awss3exporter/internal/upload/writer.go
@@ -43,10 +43,15 @@ var _ Manager = (*s3manager)(nil)
 
 func NewS3Manager(logger *zap.Logger, bucket string, builder *PartitionKeyBuilder, service *s3.Client, storageClass s3types.StorageClass, opts ...ManagerOpt) Manager {
 	manager := &s3manager{
-		logger:       logger,
-		bucket:       bucket,
-		builder:      builder,
-		uploader:     transfermanager.New(service),
+		logger:  logger,
+		bucket:  bucket,
+		builder: builder,
+		uploader: transfermanager.New(service, func(o *transfermanager.Options) {
+			// transfermanager.New ignores the S3 client checksum setting and always
+			// adds a CRC32 trailer, which some S3 compatible stores reject. So we
+			// pass the client's own setting here so it is honored.
+			o.RequestChecksumCalculation = service.Options().RequestChecksumCalculation
+		}),
 		storageClass: storageClass,
 	}
 	for _, opt := range opts {

--- a/exporter/awss3exporter/internal/upload/writer_test.go
+++ b/exporter/awss3exporter/internal/upload/writer_test.go
@@ -332,3 +332,62 @@ func TestS3ManagerUpload(t *testing.T) {
 		})
 	}
 }
+
+func TestS3ManagerUploadRequestChecksumCalculation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name                string
+		checksumCalculation aws.RequestChecksumCalculation
+		wantChecksumAlgo    string
+	}{
+		{
+			name:                "when supported sends CRC32 checksum",
+			checksumCalculation: aws.RequestChecksumCalculationWhenSupported,
+			wantChecksumAlgo:    "CRC32",
+		},
+		{
+			name:                "when required omits checksum",
+			checksumCalculation: aws.RequestChecksumCalculationWhenRequired,
+			wantChecksumAlgo:    "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotChecksumAlgo string
+			s := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				gotChecksumAlgo = r.Header.Get("X-Amz-Sdk-Checksum-Algorithm")
+				_, _ = io.Copy(io.Discard, r.Body)
+				_ = r.Body.Close()
+			}))
+			t.Cleanup(s.Close)
+
+			sm := NewS3Manager(
+				zap.NewNop(),
+				"my-bucket",
+				&PartitionKeyBuilder{
+					PartitionPrefix:       "telemetry",
+					PartitionFormat:       "year=%Y",
+					FilePrefix:            "signal-data-",
+					FileFormat:            "metrics",
+					UniqueKeyFunc:         func() string { return "random" },
+					PartitionTimeLocation: time.Local,
+				},
+				s3.New(s3.Options{
+					BaseEndpoint:               aws.String(s.URL),
+					Region:                     "local",
+					RequestChecksumCalculation: tc.checksumCalculation,
+				}),
+				"STANDARD",
+			)
+
+			err := sm.Upload(t.Context(), []byte("hello world"), nil)
+			assert.NoError(t, err)
+			// If the transfer manager did not take the setting from the client,
+			// this header would still come back as CRC32 even when we asked for
+			// "when required".
+			assert.Equal(t, tc.wantChecksumAlgo, gotChecksumAlgo)
+		})
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The change passes the S3 client's own RequestChecksumCalculation that reads `AWS_REQUEST_CHECKSUM_CALCULATION` into the transfer manager, so the configured mode is honored.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes  #50184

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added TestS3ManagerUploadRequestChecksumCalculation in internal/upload/writer_test.go.
<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
