### PR TITLE
[receiver/jaeger] Bound Thrift HTTP decoder max message size to request body length

### DIFF
--- a/.chloggen/49218-jaeger-thrift-memory-amplification.yaml
+++ b/.chloggen/49218-jaeger-thrift-memory-amplification.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/jaeger
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bound the Thrift decoder's max message size to the HTTP request body length to prevent a memory-amplification DoS.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49218]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  A tiny Thrift-binary payload could declare a spans list with a huge element count, forcing the decoder to
+  pre-allocate a large slice before failing to read the (absent) data. The Thrift `/api/traces` handler now
+  caps the decoder's max message size at the number of bytes actually received, so a container that declares
+  more elements than the payload can hold is rejected instead of being pre-allocated.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"math"
 	"mime"
 	"net/http"
 	"sync"
@@ -290,15 +291,46 @@ func (*jReceiver) decodeThriftHTTPBody(r *http.Request) (*jaeger.Batch, *httpErr
 		}
 	}
 
-	tdes := apacheThrift.NewTDeserializer()
 	batch := &jaeger.Batch{}
-	if err = tdes.Read(r.Context(), batch, bodyBytes); err != nil {
+	if err = deserializeThriftBatch(r.Context(), bodyBytes, batch); err != nil {
 		return nil, &httpError{
 			fmt.Sprintf("Unable to process request body: %v", err),
 			http.StatusBadRequest,
 		}
 	}
 	return batch, nil
+}
+
+// deserializeThriftBatch decodes a Thrift-binary-encoded Jaeger batch from body.
+//
+// It bounds the Thrift decoder's MaxMessageSize to the length of the payload
+// that was actually received. A valid message can never require more wire bytes
+// than the payload provides, so this bound is transparent to legitimate
+// requests. It does, however, reject a malicious payload that declares a
+// container (e.g. a list of spans) whose element count is far larger than the
+// bytes provided. Without it, a tiny request can force the generated Thrift code
+// to pre-allocate a huge slice (CWE-789, memory-amplification DoS), because the
+// decoder's default MaxMessageSize of 100MB is orders of magnitude larger than a
+// typical request body.
+func deserializeThriftBatch(ctx context.Context, body []byte, batch *jaeger.Batch) error {
+	cfg := &apacheThrift.TConfiguration{
+		MaxMessageSize: boundedThriftMessageSize(len(body)),
+	}
+	transport := apacheThrift.NewTMemoryBufferLen(len(body))
+	protocol := apacheThrift.NewTBinaryProtocolConf(transport, cfg)
+	tdes := &apacheThrift.TDeserializer{Transport: transport, Protocol: protocol}
+	return tdes.Read(ctx, batch, body)
+}
+
+// boundedThriftMessageSize clamps a payload length into the int32 range expected
+// by TConfiguration.MaxMessageSize. A non-positive length disables the bound (the
+// decoder then falls back to its default), and a length beyond math.MaxInt32 is
+// capped so the value never overflows.
+func boundedThriftMessageSize(bodyLen int) int32 {
+	if bodyLen > 0 && bodyLen < math.MaxInt32 {
+		return int32(bodyLen)
+	}
+	return math.MaxInt32
 }
 
 // HandleThriftHTTPBatch implements Jaeger HTTP Thrift handler.

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -73,6 +74,46 @@ func TestThriftHTTPBodyDecode(t *testing.T) {
 	gotBatch, hErr := jr.decodeThriftHTTPBody(r)
 	require.Nil(t, hErr, "failed to decode http body")
 	assert.Equal(t, batch, gotBatch)
+}
+
+// TestThriftHTTPBodyDecodeMemoryAmplification reproduces the payload from
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49218:
+// a tiny Thrift payload that declares a Spans list with a huge element count so
+// the decoder would pre-allocate a large slice (CWE-789). The decoder must
+// reject it instead of allocating based on the wire-declared size.
+func TestThriftHTTPBodyDecodeMemoryAmplification(t *testing.T) {
+	// Minimal Batch: Process.serviceName="x", then a Spans list declaring
+	// 33,554,432 struct elements while carrying no element data at all.
+	var payload bytes.Buffer
+	payload.Write([]byte{0x0c, 0x00, 0x01}) // field: STRUCT (12), id 1 (Process)
+	payload.Write([]byte{0x0b, 0x00, 0x01}) // field: STRING (11), id 1 (serviceName)
+	payload.Write(binary.BigEndian.AppendUint32(nil, 1))
+	payload.WriteByte('x')                                        // serviceName value "x"
+	payload.WriteByte(0x00)                                       // Process struct stop
+	payload.Write([]byte{0x0f, 0x00, 0x02})                       // field: LIST (15), id 2 (Spans)
+	payload.WriteByte(0x0c)                                       // list element type: STRUCT (12)
+	payload.Write(binary.BigEndian.AppendUint32(nil, 0x02000000)) // list size: 33,554,432
+
+	r := httptest.NewRequest(http.MethodPost, "/api/traces", bytes.NewReader(payload.Bytes()))
+	r.Header.Add("content-type", "application/x-thrift")
+
+	jr := jReceiver{}
+
+	// The declared list would pre-allocate 33,554,432 *Span pointers (~256MB) if
+	// the wire-declared size were trusted. Measure the bytes allocated across the
+	// decode and assert the decoder never allocated anywhere near that.
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	gotBatch, hErr := jr.decodeThriftHTTPBody(r)
+	runtime.ReadMemStats(&after)
+
+	require.NotNil(t, hErr, "malicious payload must be rejected")
+	assert.Nil(t, gotBatch)
+	assert.Equal(t, http.StatusBadRequest, hErr.statusCode)
+
+	const allocLimit = 10 * 1024 * 1024 // 10MB, far below the ~256MB pre-allocation
+	assert.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(allocLimit),
+		"decoder allocated based on the wire-declared container size")
 }
 
 func TestReception(t *testing.T) {


### PR DESCRIPTION
#### Description

Fixes a memory-amplification DoS (CWE-789) in the Thrift-over-HTTP endpoint `POST /api/traces`.

**How the amplification works.** The generated Thrift code reads a list by calling `ReadListBegin`, which returns the declared element count, and then runs `make([]*T, 0, count)` before reading a single element. For a list of structs that is 8 bytes of pointer per declared element. A ~20-byte payload that declares `Batch.spans` with 33,554,432 elements therefore allocates ~256MB, then fails with EOF on the first element.

**Why Thrift's own check does not catch it.** `ReadListBegin` already runs a pre-allocation check: `count × minElemSize ≤ TConfiguration.MaxMessageSize`, where `minElemSize` is the smallest possible on-wire size of one element (1 byte for a struct, since an empty struct is just a stop byte). The default `MaxMessageSize` is 100MB, so 33.5M × 1 = 33.5MB passes, and the 8-bytes-per-element allocation is 8x what the check assumed. `MaxMessageSize` is not a transport read cap; in this path (`TDeserializer.Read` on a `TMemoryBuffer`) it is used only by this check and by the equivalent check on declared string lengths.

**The fix.** `MaxMessageSize` is set to the length of the received (already decompressed) body. The pre-allocation check then reads as "no container may declare more elements than this payload has bytes". This never rejects a valid message: every element a valid message declares is actually present, and each occupies at least `minElemSize` bytes, so `count × minElemSize` is at most the body length.

**Residual amplification.** The check is per container and is not cumulative, so an attacker can still declare `count = bodyLen` at each nesting level of the currently open chain of containers. Decoding is depth-first and a container can only be moved past by supplying its full declared contents in real bytes, so only one chain is open at a time. In `jaeger.thrift` the deepest list-of-struct chain is `Batch.spans` → `Span.logs` → `Log.fields`, three levels, so the worst case is about 3 × 8 × bodyLen for slice headroom plus two copies of the body, roughly 26x the body size. With the default 20MiB `max_request_body_size` that is ~500MB per request, down from ~800MB for a 20-byte request before this change. The amplification is now linear in what the attacker must send rather than unbounded. Removing it entirely would require Thrift's check to compare against bytes remaining in the buffer, or the generated code to stop pre-sizing slices from the wire count; both are upstream changes.


#### Link to tracking issue
Fixes #49218


#### Testing
`TestThriftHTTPBodyDecodeMemoryAmplification` reproduces the reported payload and asserts that the decode allocates under 10MB, far below the 256MB the pre-allocation would have taken.

#### Documentation
Tuned.

#### Authorship

- [x] I, a human, wrote this pull request description myself.