### PR TITLE
[exporter/prometheus] Align permissive label sanitization with remote write exporters

### DIFF
--- a/.chloggen/50429-align-label-namer.yaml
+++ b/.chloggen/50429-align-label-namer.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Align the Prometheus exporter's LabelNamer with the Prometheus remote write exporter by adding the missing UnderscoreLabelSanitization field and fixing the inverted PreserveMultipleUnderscores polarity.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, the Prometheus exporter did not set `UnderscoreLabelSanitization` on its
+  `LabelNamer`, meaning labels starting with `_` were never prefixed with `key_` regardless
+  of the `pkg.translator.prometheus.PermissiveLabelSanitization` feature gate state. It also
+  had `PreserveMultipleUnderscores` wired with inverted polarity compared to the remote write
+  exporter. Both fields now match the remote write exporter's behavior.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -93,9 +93,13 @@ func configureMetricNamer(config *Config) otlptranslator.MetricNamer {
 // configureLabelNamer configures the LabelNamer based on the translation strategy or legacy configuration
 func configureLabelNamer(config *Config) otlptranslator.LabelNamer {
 	_, utf8Allowed := getTranslationConfiguration(config)
+	permissiveSanitization := prometheustranslator.DropSanitizationGate.IsEnabled()
 	return otlptranslator.LabelNamer{
-		UTF8Allowed:                 utf8Allowed,
-		PreserveMultipleUnderscores: !prometheustranslator.DropSanitizationGate.IsEnabled(),
+		UTF8Allowed: utf8Allowed,
+		// TODO: SA1019: (github.com/prometheus/otlptranslator.LabelNamer).UnderscoreLabelSanitization is deprecated: This will be removed in a future version of otlptranslator.
+		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50429
+		UnderscoreLabelSanitization: !permissiveSanitization, //nolint:staticcheck
+		PreserveMultipleUnderscores: permissiveSanitization,
 	}
 }
 


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Aligns the Prometheus exporter's handling of `pkg.translator.prometheus.PermissiveLabelSanitization` with the Prometheus Remote Write exporters.

Previously the feature gate was applied inconsistently between the exporters. The remote write exporters use the gate to control both `UnderscoreLabelSanitization` and `PreserveMultipleUnderscores`, while the Prometheus exporter only applied it to `PreserveMultipleUnderscores` and used the opposite value.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/50584#issuecomment-5465714571


<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
