### PR TITLE
[processor/geoip] Remove shared provider factory registry to fix data race

### DIFF
--- a/.chloggen/fix_geoip-provider-factories-data-race.yaml
+++ b/.chloggen/fix_geoip-provider-factories-data-race.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/geoip
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a data race on the provider factory registry observed when geoip processor tests run in parallel.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46853]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/geoipprocessor/config.go
+++ b/processor/geoipprocessor/config.go
@@ -57,6 +57,13 @@ type Config struct {
 	//   - `propagate`: errors are logged and returned, halting processing.
 	// The default value is `propagate` to preserve existing behavior.
 	ErrorMode ottl.ErrorMode `mapstructure:"error_mode"`
+
+	// providerFactories is the snapshot of GeoIPProviderFactory instances that this Config
+	// resolves provider keys against during Unmarshal and processor creation. It is populated
+	// by createDefaultConfig from defaultProviderFactories. Keeping the registry on the Config
+	// (rather than as mutable package state) lets tests inject mock providers without racing
+	// with concurrent reads.
+	providerFactories map[string]provider.GeoIPProviderFactory `mapstructure:"-"`
 }
 
 var (
@@ -89,6 +96,13 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 		return nil
 	}
 
+	// Fall back to the built-in factories for Configs constructed directly (i.e. without going
+	// through createDefaultConfig). The normal collector pipeline always calls
+	// createDefaultConfig first, so this branch is reserved for ad-hoc callers.
+	if cfg.providerFactories == nil {
+		cfg.providerFactories = defaultProviderFactories
+	}
+
 	// load the non-dynamic config normally
 	err := componentParser.Unmarshal(cfg, confmap.WithIgnoreUnused())
 	if err != nil {
@@ -106,7 +120,7 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 
 	// loop through all defined providers and load their configuration
 	for key := range providersSection.ToStringMap() {
-		factory, ok := getProviderFactory(key)
+		factory, ok := cfg.providerFactories[key]
 		if !ok {
 			return fmt.Errorf("invalid provider key: %s", key)
 		}

--- a/processor/geoipprocessor/config_test.go
+++ b/processor/geoipprocessor/config_test.go
@@ -42,8 +42,9 @@ func TestLoadConfig(t *testing.T) {
 				Providers: map[string]provider.Config{
 					"maxmind": &maxmind.Config{DatabasePath: "/tmp/db"},
 				},
-				Attributes: defaultAttributes,
-				ErrorMode:  ottl.PropagateError,
+				Attributes:        defaultAttributes,
+				ErrorMode:         ottl.PropagateError,
+				providerFactories: defaultProviderFactories,
 			},
 		},
 		{
@@ -53,8 +54,9 @@ func TestLoadConfig(t *testing.T) {
 				Providers: map[string]provider.Config{
 					"maxmind": &maxmind.Config{DatabasePath: "/tmp/db"},
 				},
-				Attributes: defaultAttributes,
-				ErrorMode:  ottl.PropagateError,
+				Attributes:        defaultAttributes,
+				ErrorMode:         ottl.PropagateError,
+				providerFactories: defaultProviderFactories,
 			},
 		},
 		{
@@ -76,8 +78,9 @@ func TestLoadConfig(t *testing.T) {
 				Providers: map[string]provider.Config{
 					"maxmind": &maxmind.Config{DatabasePath: "/tmp/db"},
 				},
-				Attributes: []attribute.Key{"client.address", "source.address", "custom.address"},
-				ErrorMode:  ottl.PropagateError,
+				Attributes:        []attribute.Key{"client.address", "source.address", "custom.address"},
+				ErrorMode:         ottl.PropagateError,
+				providerFactories: defaultProviderFactories,
 			},
 		},
 		{
@@ -87,8 +90,9 @@ func TestLoadConfig(t *testing.T) {
 				Providers: map[string]provider.Config{
 					"maxmind": &maxmind.Config{DatabasePath: "/tmp/db"},
 				},
-				Attributes: defaultAttributes,
-				ErrorMode:  ottl.IgnoreError,
+				Attributes:        defaultAttributes,
+				ErrorMode:         ottl.IgnoreError,
+				providerFactories: defaultProviderFactories,
 			},
 		},
 		{
@@ -144,13 +148,11 @@ func TestLoadConfig_ValidProviderKey(t *testing.T) {
 	baseMockFactory.CreateDefaultConfigF = func() provider.Config {
 		return &dbMockConfig{providerConfigMock: providerConfigMock{func() error { return nil }}}
 	}
-	providerFactories["mock"] = &baseMockFactory
 
 	factories, err := otelcoltest.NopFactories()
 	require.NoError(t, err)
 
-	factory := NewFactory()
-	factories.Processors[metadata.Type] = factory
+	factories.Processors[metadata.Type] = newFactoryWithMocks(map[string]provider.GeoIPProviderFactory{"mock": &baseMockFactory})
 	collectorConfig, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-mockProvider.yaml"), factories)
 
 	require.NoError(t, err)
@@ -161,9 +163,8 @@ func TestLoadConfig_ValidProviderKey(t *testing.T) {
 	baseMockFactory.CreateDefaultConfigF = func() provider.Config {
 		return &providerConfigMock{func() error { return nil }}
 	}
-	providerFactories["mock"] = &baseMockFactory
 
-	factories.Processors[metadata.Type] = factory
+	factories.Processors[metadata.Type] = newFactoryWithMocks(map[string]provider.GeoIPProviderFactory{"mock": &baseMockFactory})
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-mockProvider.yaml"), factories)
 
 	require.ErrorContains(t, err, "'geoipprocessor.providerConfigMock' has invalid keys: database")
@@ -180,13 +181,11 @@ func TestLoadConfig_ProviderValidateError(t *testing.T) {
 		}
 		return &sampleConfig
 	}
-	providerFactories["mock"] = &baseMockFactory
 
 	factories, err := otelcoltest.NopFactories()
 	require.NoError(t, err)
 
-	factory := NewFactory()
-	factories.Processors[metadata.Type] = factory
+	factories.Processors[metadata.Type] = newFactoryWithMocks(map[string]provider.GeoIPProviderFactory{"mock": &baseMockFactory})
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-mockProvider.yaml"), factories)
 
 	require.ErrorContains(t, err, "error validating provider mock")

--- a/processor/geoipprocessor/factory.go
+++ b/processor/geoipprocessor/factory.go
@@ -32,8 +32,11 @@ var (
 	}
 )
 
-// providerFactories is a map that stores GeoIPProviderFactory instances, keyed by the provider type.
-var providerFactories = map[string]provider.GeoIPProviderFactory{
+// defaultProviderFactories is the read-only set of provider factories baked into the geoip
+// processor at build time. Each Config snapshots this map in createDefaultConfig so that
+// runtime overrides (e.g. tests installing a mock provider) live on the Config instance
+// instead of mutating shared package state.
+var defaultProviderFactories = map[string]provider.GeoIPProviderFactory{
 	maxmind.TypeStr: &maxmind.Factory{},
 }
 
@@ -43,37 +46,27 @@ func NewFactory() processor.Factory {
 	return processor.NewFactory(metadata.Type, createDefaultConfig, processor.WithMetrics(createMetricsProcessor, metadata.MetricsStability), processor.WithLogs(createLogsProcessor, metadata.LogsStability), processor.WithTraces(createTracesProcessor, metadata.TracesStability))
 }
 
-// getProviderFactory retrieves the GeoIPProviderFactory for the given key.
-// It returns the factory and a boolean indicating whether the factory was found.
-func getProviderFactory(key string) (provider.GeoIPProviderFactory, bool) {
-	if factory, ok := providerFactories[key]; ok {
-		return factory, true
-	}
-
-	return nil, false
-}
-
 // createDefaultConfig returns a default configuration for the processor.
 func createDefaultConfig() component.Config {
 	return &Config{
-		Context:    resource,
-		Attributes: defaultAttributes,
-		ErrorMode:  ottl.PropagateError,
+		Context:           resource,
+		Attributes:        defaultAttributes,
+		ErrorMode:         ottl.PropagateError,
+		providerFactories: defaultProviderFactories,
 	}
 }
 
-// createGeoIPProviders creates a list of GeoIPProvider instances based on the provided configuration and providers factories.
+// createGeoIPProviders creates a list of GeoIPProvider instances based on the provided configuration.
 func createGeoIPProviders(
 	ctx context.Context,
 	set processor.Settings,
 	config *Config,
-	factories map[string]provider.GeoIPProviderFactory,
 ) ([]provider.GeoIPProvider, error) {
 	providers := make([]provider.GeoIPProvider, 0, len(config.Providers))
 
 	for key, cfg := range config.Providers {
-		factory := factories[key]
-		if factory == nil {
+		factory, ok := config.providerFactories[key]
+		if !ok {
 			return nil, fmt.Errorf("geoIP provider factory not found for key: %q", key)
 		}
 
@@ -90,7 +83,7 @@ func createGeoIPProviders(
 
 func createMetricsProcessor(ctx context.Context, set processor.Settings, cfg component.Config, nextConsumer consumer.Metrics) (processor.Metrics, error) {
 	geoCfg := cfg.(*Config)
-	providers, err := createGeoIPProviders(ctx, set, geoCfg, providerFactories)
+	providers, err := createGeoIPProviders(ctx, set, geoCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +93,7 @@ func createMetricsProcessor(ctx context.Context, set processor.Settings, cfg com
 
 func createTracesProcessor(ctx context.Context, set processor.Settings, cfg component.Config, nextConsumer consumer.Traces) (processor.Traces, error) {
 	geoCfg := cfg.(*Config)
-	providers, err := createGeoIPProviders(ctx, set, geoCfg, providerFactories)
+	providers, err := createGeoIPProviders(ctx, set, geoCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +103,7 @@ func createTracesProcessor(ctx context.Context, set processor.Settings, cfg comp
 
 func createLogsProcessor(ctx context.Context, set processor.Settings, cfg component.Config, nextConsumer consumer.Logs) (processor.Logs, error) {
 	geoCfg := cfg.(*Config)
-	providers, err := createGeoIPProviders(ctx, set, geoCfg, providerFactories)
+	providers, err := createGeoIPProviders(ctx, set, geoCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/geoipprocessor/factory_test.go
+++ b/processor/geoipprocessor/factory_test.go
@@ -74,15 +74,21 @@ func TestCreateProcessor_ProcessorKeyConfigError(t *testing.T) {
 }
 
 func TestCreateProcessor_FailedProvider(t *testing.T) {
-	baseMockFactory.CreateGeoIPProviderF = func(context.Context, processor.Settings, provider.Config) (provider.GeoIPProvider, error) {
-		return nil, errors.New("error creating provider")
+	mockFactory := providerFactoryMock{
+		CreateDefaultConfigF: func() provider.Config {
+			return &providerConfigMock{ValidateF: func() error { return nil }}
+		},
+		CreateGeoIPProviderF: func(context.Context, processor.Settings, provider.Config) (provider.GeoIPProvider, error) {
+			return nil, errors.New("error creating provider")
+		},
 	}
-
 	const providerKey string = "mock"
-	providerFactories[providerKey] = &baseMockFactory
 
 	factory := NewFactory()
-	cfg := &Config{Providers: map[string]provider.Config{providerKey: &providerConfigMock{}}}
+	cfg := &Config{
+		Providers:         map[string]provider.Config{providerKey: &providerConfigMock{}},
+		providerFactories: map[string]provider.GeoIPProviderFactory{providerKey: &mockFactory},
+	}
 
 	_, err := factory.CreateMetrics(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 	assert.EqualError(t, err, fmt.Errorf("failed to create provider for key %q: %w", providerKey, errors.New("error creating provider")).Error())

--- a/processor/geoipprocessor/geoip_processor_test.go
+++ b/processor/geoipprocessor/geoip_processor_test.go
@@ -6,6 +6,7 @@ package geoipprocessor
 import (
 	"context"
 	"errors"
+	"maps"
 	"net/netip"
 	"path/filepath"
 	"testing"
@@ -84,13 +85,26 @@ var baseMockFactory = providerFactoryMock{
 	},
 }
 
-var baseProviderMock = providerMock{
-	LocationF: func(context.Context, netip.Addr) (attribute.Set, error) {
-		return attribute.Set{}, nil
-	},
-	CloseF: func(context.Context) error {
-		return nil
-	},
+// newFactoryWithMocks returns a processor.Factory whose default Config carries the built-in
+// provider factories plus the supplied extras. Tests that route through otelcoltest or
+// otherwise rely on factory.CreateDefaultConfig() to construct the Config use this helper
+// to inject mock providers without mutating package-level state.
+func newFactoryWithMocks(extras map[string]provider.GeoIPProviderFactory) processor.Factory {
+	createCfg := func() component.Config {
+		factories := make(map[string]provider.GeoIPProviderFactory, len(defaultProviderFactories)+len(extras))
+		maps.Copy(factories, defaultProviderFactories)
+		maps.Copy(factories, extras)
+		return &Config{
+			Context:           resource,
+			Attributes:        defaultAttributes,
+			providerFactories: factories,
+		}
+	}
+	return processor.NewFactory(metadata.Type, createCfg,
+		processor.WithMetrics(createMetricsProcessor, metadata.MetricsStability),
+		processor.WithLogs(createLogsProcessor, metadata.LogsStability),
+		processor.WithTraces(createTracesProcessor, metadata.TracesStability),
+	)
 }
 
 var testCases = []struct {
@@ -209,30 +223,36 @@ func compareAllSignals(cfg component.Config, goldenDir string) func(t *testing.T
 func TestProcessor(t *testing.T) {
 	t.Parallel()
 
-	baseMockFactory.CreateGeoIPProviderF = func(context.Context, processor.Settings, provider.Config) (provider.GeoIPProvider, error) {
-		return &baseProviderMock, nil
-	}
-
-	baseProviderMock.LocationF = func(_ context.Context, sourceIP netip.Addr) (attribute.Set, error) {
-		if sourceIP.Compare(netip.AddrFrom4([4]byte{1, 2, 3, 4})) == 0 {
-			return attribute.NewSet([]attribute.KeyValue{
-				attribute.String(conventions.AttributeGeoCityName, "Boxford"),
-				attribute.String(conventions.AttributeGeoContinentCode, "EU"),
-				attribute.String(conventions.AttributeGeoContinentName, "Europe"),
-				attribute.String(conventions.AttributeGeoCountryIsoCode, "GB"),
-				attribute.String(conventions.AttributeGeoCountryName, "United Kingdom"),
-				attribute.String(conventions.AttributeGeoTimezone, "Europe/London"),
-				attribute.String(conventions.AttributeGeoRegionIsoCode, "WBK"),
-				attribute.String(conventions.AttributeGeoRegionName, "West Berkshire"),
-				attribute.String(conventions.AttributeGeoPostalCode, "OX1"),
-				attribute.Float64(conventions.AttributeGeoLocationLat, 1234),
-				attribute.Float64(conventions.AttributeGeoLocationLon, 5678),
-			}...), nil
-		}
-		return attribute.Set{}, provider.ErrNoMetadataFound
+	mockFactory := providerFactoryMock{
+		CreateDefaultConfigF: func() provider.Config {
+			return &providerConfigMock{ValidateF: func() error { return nil }}
+		},
+		CreateGeoIPProviderF: func(context.Context, processor.Settings, provider.Config) (provider.GeoIPProvider, error) {
+			return &providerMock{
+				LocationF: func(_ context.Context, sourceIP netip.Addr) (attribute.Set, error) {
+					if sourceIP.Compare(netip.AddrFrom4([4]byte{1, 2, 3, 4})) == 0 {
+						return attribute.NewSet([]attribute.KeyValue{
+							attribute.String(conventions.AttributeGeoCityName, "Boxford"),
+							attribute.String(conventions.AttributeGeoContinentCode, "EU"),
+							attribute.String(conventions.AttributeGeoContinentName, "Europe"),
+							attribute.String(conventions.AttributeGeoCountryIsoCode, "GB"),
+							attribute.String(conventions.AttributeGeoCountryName, "United Kingdom"),
+							attribute.String(conventions.AttributeGeoTimezone, "Europe/London"),
+							attribute.String(conventions.AttributeGeoRegionIsoCode, "WBK"),
+							attribute.String(conventions.AttributeGeoRegionName, "West Berkshire"),
+							attribute.String(conventions.AttributeGeoPostalCode, "OX1"),
+							attribute.Float64(conventions.AttributeGeoLocationLat, 1234),
+							attribute.Float64(conventions.AttributeGeoLocationLon, 5678),
+						}...), nil
+					}
+					return attribute.Set{}, provider.ErrNoMetadataFound
+				},
+				CloseF: func(context.Context) error { return nil },
+			}, nil
+		},
 	}
 	const providerKey string = "mock"
-	providerFactories[providerKey] = &baseMockFactory
+	factories := map[string]provider.GeoIPProviderFactory{providerKey: &mockFactory}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -240,7 +260,12 @@ func TestProcessor(t *testing.T) {
 			if tt.attributes != nil {
 				attributes = tt.attributes
 			}
-			cfg := &Config{Context: tt.context, Providers: map[string]provider.Config{providerKey: &providerConfigMock{}}, Attributes: attributes}
+			cfg := &Config{
+				Context:           tt.context,
+				Providers:         map[string]provider.Config{providerKey: &providerConfigMock{}},
+				Attributes:        attributes,
+				providerFactories: factories,
+			}
 			compareAllSignals(cfg, tt.goldenDir)(t)
 		})
 	}

--- a/processor/geoipprocessor/integration_test.go
+++ b/processor/geoipprocessor/integration_test.go
@@ -24,7 +24,12 @@ func TestProcessorWithMaxMind(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("maxmind_"+tt.name, func(t *testing.T) {
-			cfg := &Config{Context: tt.context, Providers: map[string]provider.Config{"maxmind": &maxmindConfig}, Attributes: []attribute.Key{"source.address", "client.address", "custom.address"}}
+			cfg := &Config{
+				Context:           tt.context,
+				Providers:         map[string]provider.Config{"maxmind": &maxmindConfig},
+				Attributes:        []attribute.Key{"source.address", "client.address", "custom.address"},
+				providerFactories: defaultProviderFactories,
+			}
 
 			compareAllSignals(cfg, tt.goldenDir)(t)
 		})


### PR DESCRIPTION
#### Description
This PR fixes a data race on the package-level `providerFactories` map. The map was read by `getProviderFactory` during config unmarshal and processor creation, while tests registering a mock provider wrote to it. With `t.Parallel()` on both `TestLoadConfig` and `TestProcessor`, the race detector flagged concurrent map access on CI.

The mutable package-level registry is replaced with a read-only `defaultProviderFactories` map that `createDefaultConfig` snapshots onto an unexported `providerFactories` field on `Config`. Unmarshal and `createGeoIPProviders` now resolve provider keys from that field, so tests inject mock providers per-`Config` (or via the `newFactoryWithMocks` helper) instead of mutating shared state.

#### Link to tracking issue
Fixes #46853


#### Testing
Tuned.

#### Documentation
Tuned.

#### Authorship

- [x] I, a human, wrote this pull request description myself.