### PR TITLE
[receiver/mongodb] Fix replica set secondary connections never being established

### DIFF
--- a/.chloggen/mongodb-secondary-host-discovery.yaml
+++ b/.chloggen/mongodb-secondary-host-discovery.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mongodb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix replica set secondary connections never being established
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50622]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Replica set members were type-asserted to bson.M, which the driver never produces for an embedded
+  document, so no secondary was ever discovered. Secondary connections now also apply the configured
+  TLS and an operation timeout, matching the primary connection.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/mongodbreceiver/config.go
+++ b/receiver/mongodbreceiver/config.go
@@ -127,6 +127,11 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 
 		if c.Timeout > 0 {
 			clientOptions.SetConnectTimeout(c.Timeout)
+			// A secondary that connects but stops responding would otherwise stall a scrape
+			// indefinitely, because the scrape context carries no deadline unless one is
+			// configured. The driver honors an operation's own deadline over this value, so
+			// a configured scrape timeout still wins.
+			clientOptions.SetTimeout(c.Timeout)
 		}
 
 		// Set up authentication if username/password are provided or if an auth mechanism is specified
@@ -134,6 +139,12 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 		if c.Username != "" && c.Password != "" || c.AuthMechanism != "" {
 			credential := c.buildCredential()
 			clientOptions.SetAuth(credential)
+		}
+
+		// Secondaries are members of the same deployment as the primary, so they need the
+		// same transport security.
+		if tlsConfig, err := c.ClientConfig.LoadTLSConfig(context.Background()); err == nil && tlsConfig != nil {
+			clientOptions.SetTLSConfig(tlsConfig)
 		}
 
 		return clientOptions

--- a/receiver/mongodbreceiver/config_test.go
+++ b/receiver/mongodbreceiver/config_test.go
@@ -340,6 +340,28 @@ func TestOptionsTLS(t *testing.T) {
 	}
 	opts := cfg.ClientOptions(false)
 	require.NotNil(t, opts.TLSConfig)
+
+	// Secondaries belong to the same deployment, so they need the same transport security.
+	secondaryOpts := cfg.ClientOptions(true)
+	require.NotNil(t, secondaryOpts.TLSConfig)
+}
+
+func TestOptionsSecondaryOperationTimeout(t *testing.T) {
+	cfg := &Config{
+		Hosts: []confignet.TCPAddrConfig{
+			{
+				Endpoint: defaultEndpoint,
+			},
+		},
+		Timeout: createDefaultConfig().(*Config).Timeout,
+	}
+
+	// A secondary that connects but stops responding must not hold a collection open.
+	opts := cfg.ClientOptions(true)
+	require.NotNil(t, opts.Timeout)
+	require.Equal(t, cfg.Timeout, *opts.Timeout)
+	require.NotNil(t, opts.ConnectTimeout)
+	require.Equal(t, cfg.Timeout, *opts.ConnectTimeout)
 }
 
 func TestLoadConfig(t *testing.T) {

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -806,23 +806,16 @@ func (s *mongodbScraper) findSecondaryHosts(ctx context.Context) ([]string, erro
 
 	members, ok := result["members"].(bson.A)
 	if !ok {
-		return nil, fmt.Errorf("invalid members format: expected type primitive.A but got %T, value: %v", result["members"], result["members"])
+		return nil, fmt.Errorf("invalid members format: expected type bson.A but got %T, value: %v", result["members"], result["members"])
 	}
 
 	var hosts []string
 	for _, member := range members {
-		m, ok := member.(bson.M)
-		if !ok {
-			continue
-		}
-
-		state, ok := m["stateStr"].(string)
-		if !ok {
-			continue
-		}
-
-		name, ok := m["name"].(string)
-		if !ok {
+		// A member arrives as a bson.D, which is how the driver decodes an embedded document
+		// held in a bson.M, so read it through lookup rather than asserting a concrete type.
+		state := getValue[string](member, "stateStr")
+		name := getValue[string](member, "name")
+		if name == "" {
 			continue
 		}
 

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -1032,6 +1032,79 @@ func TestScrapeLogsWithSecondaries(t *testing.T) {
 	}
 }
 
+func TestFindSecondaryHosts(t *testing.T) {
+	// The driver decodes an embedded document held in a bson.M as a bson.D, so this is the
+	// shape replSetGetStatus members actually arrive in.
+	bsonDMembers := bson.A{
+		bson.D{bson.E{Key: "name", Value: "mongo-0:27017"}, bson.E{Key: "stateStr", Value: "PRIMARY"}},
+		bson.D{bson.E{Key: "name", Value: "mongo-1:27017"}, bson.E{Key: "stateStr", Value: "SECONDARY"}},
+		bson.D{bson.E{Key: "name", Value: "mongo-2:27017"}, bson.E{Key: "stateStr", Value: "ARBITER"}},
+		bson.D{bson.E{Key: "name", Value: "mongo-3:27017"}, bson.E{Key: "stateStr", Value: "SECONDARY"}},
+	}
+
+	testCases := []struct {
+		desc          string
+		result        bson.M
+		resultErr     error
+		expectedHosts []string
+		expectedErr   string
+	}{
+		{
+			desc:          "members decoded as bson.D",
+			result:        bson.M{"members": bsonDMembers},
+			expectedHosts: []string{"mongo-1:27017", "mongo-3:27017"},
+		},
+		{
+			desc: "members decoded as bson.M",
+			result: bson.M{"members": bson.A{
+				bson.M{"name": "mongo-0:27017", "stateStr": "PRIMARY"},
+				bson.M{"name": "mongo-1:27017", "stateStr": "SECONDARY"},
+			}},
+			expectedHosts: []string{"mongo-1:27017"},
+		},
+		{
+			desc: "member without a name",
+			result: bson.M{"members": bson.A{
+				bson.D{bson.E{Key: "stateStr", Value: "SECONDARY"}},
+			}},
+			expectedHosts: nil,
+		},
+		{
+			desc:        "members missing",
+			result:      bson.M{"set": "rs0"},
+			expectedErr: "invalid members format",
+		},
+		{
+			desc:        "command failed",
+			resultErr:   errors.New("not authorized"),
+			expectedErr: "failed to get replica set status",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			fc := &fakeClient{}
+			if tc.resultErr != nil {
+				fc.On("RunCommand", mock.Anything, "admin", bson.M{"replSetGetStatus": 1}).Return(nil, tc.resultErr)
+			} else {
+				fc.On("RunCommand", mock.Anything, "admin", bson.M{"replSetGetStatus": 1}).Return(tc.result, nil)
+			}
+
+			scraper := newMongodbScraper(receivertest.NewNopSettings(metadata.Type), createDefaultConfig().(*Config))
+			scraper.client = fc
+
+			hosts, err := scraper.findSecondaryHosts(t.Context())
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				require.Nil(t, hosts)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedHosts, hosts)
+		})
+	}
+}
+
 func TestShouldIncludeOperation(t *testing.T) {
 	// Internal databases, handshake commands, and missing/empty namespace
 	// records are pruned server-side by the $currentOp pipeline (see


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The MongoDB receiver never uses a replica set secondary. Two call sites type-assert a nested BSON
document to `bson.M`, which the Go driver does not produce.

The driver's default registry maps a BSON embedded document to `bson.D`
(`RegisterTypeMapEntry(TypeEmbeddedDocument, tD)`). `RunCommand` decodes only the **top level** into
`bson.M`; every document nested inside it decodes as `bson.D`. Both assertions therefore always
fail, and both fail silently.

**1. `findSecondaryHosts` (`scraper.go`) discovers no secondaries.**

```go
for _, member := range members {
	m, ok := member.(bson.M)
	if !ok {
		continue    // always taken
	}
	...
}
```

The loop `continue`s on every member and the function returns `(nil, nil)`, so nothing is logged and
`start()` reads the empty result as "this deployment has no secondaries". `secondaryClients` stays
empty for the receiver's lifetime, and `scrapeLogs` collects `db.server.query_sample` events from
the scraped instance only.

**A second instance of the same mistake is deliberately left alone.** `recordOperationsRepl`
(`metrics.go`) does `status["opcountersRepl"].(bson.M)` for the same reason and fails the same way.
It stays dead after this change, so `mongodb.operation.repl.count` continues to read the scraped
instance exactly as it does today. It is not repaired here because repairing it correctly is a
redesign, not a bug fix — see the follow-ups below. The accepted cost is that `recordOperationsRepl`
now issues one `serverStatus` per secondary per scrape whose result is discarded.

Both sites were introduced by the same commit, `2605e8cb885` (#37517) — one mistaken model of the
driver's decode shape, two call sites. A scan of every nested-BSON type assertion in the receiver's
non-test code finds no third instance: the rest target `bson.A` on arrays, which is correct, or check
both container types (`dig` / `digBsonD`).

**The fix.** Site 1 reads the member fields through the receiver's existing `getValue[T]` helper,
which resolves `bson.M`, `bson.D`, and `map[string]any` — the same helper the `$currentOp` handling
already uses. Behaviour is otherwise unchanged: only members in state `SECONDARY` are returned, and a
member without a name is still skipped.

**Hardening the path this makes live.** Populating `secondaryClients` for the first time also makes
`Config.ClientOptions(secondary=true)` reachable, and it returned before two settings the primary
path applies:

- **TLS.** Secondary clients would have connected in plaintext, so on a TLS-required deployment the
  fix would have been silently inert.
- **An operation timeout.** The secondary branch set only `SetConnectTimeout`. A secondary that
  connects but stops responding would stall the scrape indefinitely, because `scraperhelper`'s
  `Timeout` defaults to `0` — the scrape context carries no deadline. `SetTimeout` bounds a single
  operation and, per the driver's contract, defers to an operation context deadline when one exists,
  so a configured scrape timeout still wins.

The members-format error a few lines above site 1 reports `expected type primitive.A`. `primitive.A`
is a v1 driver type that no longer exists after the v2 migration, so the message is corrected here.

No configuration change is required, and no metric or attribute is added, removed, or renamed.

**Known follow-ups, deliberately out of scope.** Making discovery work surfaces pre-existing limits
in the discovery feature itself. None is a regression from this change, and each is better reviewed on
its own:

- `recordOperationsRepl`'s furthest-ahead-secondary selection has the same `bson.M` assertion and has
  never executed. Simply repairing the assertion would emit incorrect telemetry: the data point is
  emitted under the *scraped instance's* resource, so another member's counters would carry the wrong
  `server.address`; and `mongodb.operation.repl.count` is `sum` / `cumulative` / `monotonic: true`
  over a per-process counter, so a source host that changes between scrapes would make the series
  decrease. Doing it properly means emitting per-secondary series under each secondary's own resource,
  the way `scrapeLogsFromClient` already emits query samples. That is a design change and needs its
  own issue.
- Secondaries are discovered once in `start()` and never refreshed, so a failover or membership change
  is not picked up until the collector restarts.
- All three scraper instances (metrics, query-sample logs, top-query) run discovery, but only the
  query-sample scraper reads `secondaryClients`.
- The primary client sets `SetConnectTimeout` but not `SetTimeout`, so the stall bounded here for
  secondaries is still possible on the primary. Unchanged from `main`, but asymmetric.
- On `mongodb+srv` with `tls.insecure`, the secondary branch may not preserve the scheme's implied TLS.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #50622

<!--Describe what testing was performed and which tests were added.-->
#### Testing

`findSecondaryHosts` had no test coverage — the existing tests assign `scraper.secondaryClients`
directly and never call it. That is why this went unnoticed. Three tests are added or extended, and
**each fails on `main`** without its corresponding change:

`TestFindSecondaryHosts`, a table test over a mocked client:

- **members decoded as `bson.D`** — the shape a real server produces. Asserts both secondaries are
  discovered and the primary and arbiter are not. Fails on `main` (returns `nil`).
- **members decoded as `bson.M`** — asserts the previously-supported shape still works, so the change
  widens what is accepted rather than swapping one narrow assertion for another.
- **member without a name** — asserts such a member is skipped rather than yielding an empty host.
- **members missing** — asserts the format error is returned.
- **command failed** — asserts the `replSetGetStatus` error is wrapped and returned.

`TestOptionsTLS` gains an assertion that `ClientOptions(true)` carries a TLS config. Fails on `main`
with `Expected value not to be nil`.

`TestOptionsSecondaryOperationTimeout` asserts the secondary branch sets an operation timeout, using
the receiver's own default `Timeout` rather than a hand-picked value, so the test exercises the
shipped configuration. Fails on `main`.

`go build ./...`, `go vet ./...`, `go test ./...`, and `gofmt -l .` are clean; the full receiver
suite passes unchanged.

<!--Describe the documentation added.-->
#### Documentation

None required. No user-facing configuration, metric, or attribute changes — the receiver now does
what its existing documentation already describes.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
