### PR TITLE
[receiver/mongodb] Add replica set topology and oplog metrics

### DIFF
--- a/.chloggen/50654-mongodb-replica-set-oplog.yaml
+++ b/.chloggen/50654-mongodb-replica-set-oplog.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mongodb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add replica set topology and oplog metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50654]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Seven opt-in metrics, disabled by default, emitted only by replica set members.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -303,6 +303,13 @@ The following metrics are version-gated:
 - `mongodb.wt.log.write`, `mongodb.wt.log.operation.count`, `mongodb.wt.log.sync.time`, `mongodb.wt.fsync.count`, and `mongodb.wt.concurrent_transaction.ticket.in_use` — require the WiredTiger storage engine (the default since MongoDB 3.2; MMAPv1, the previous default, was removed in 4.2). No data points are emitted on other storage engines, such as the Enterprise-only inMemory engine.
 - `mongodb.wt.concurrent_transaction.ticket.in_use` is additionally read from `serverStatus.wiredTiger.concurrentTransactions.{read,write}.out` on MongoDB `< 8.0`, and from `serverStatus.queues.execution.{read,write}.out` on MongoDB `8.0+` (the field was renamed in 8.0). The receiver probes both paths and uses whichever is present, so the same metric emits across all supported versions.
 
+The `mongodb.oplog.*`, `mongodb.replica.*`, and `mongodb.replica_set.*` metrics are only emitted by a
+`mongod` that is a member of a replica set. They are skipped on a standalone deployment, on a `mongos` router, and
+wherever the `clusterMonitor` role or read access to the `local` database is unavailable, such as on
+MongoDB Atlas. `mongodb.replica_set.lag` and `mongodb.replica_set.headroom` are additionally only
+emitted when the scraped member is the primary, which is the only member with an up-to-date view of
+every other member's replication progress.
+
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 
 ## Feature gate configurations

--- a/receiver/mongodbreceiver/client.go
+++ b/receiver/mongodbreceiver/client.go
@@ -26,6 +26,8 @@ type client interface {
 	DBStats(ctx context.Context, DBName string) (bson.M, error)
 	TopStats(ctx context.Context) (bson.M, error)
 	IndexStats(ctx context.Context, DBName, collectionName string) ([]bson.M, error)
+	OplogStats(ctx context.Context) (bson.M, error)
+	OplogBounds(ctx context.Context) (bson.Timestamp, bson.Timestamp, error)
 	// RunCommand accepts any BSON-serializable command (bson.M or bson.D).
 	RunCommand(ctx context.Context, db string, command any) (bson.M, error)
 	CurrentOp(ctx context.Context) ([]bson.M, error)
@@ -108,6 +110,63 @@ func (c *mongodbClient) IndexStats(ctx context.Context, database, collectionName
 		return nil, err
 	}
 	return indexStats, nil
+}
+
+const (
+	oplogDatabase   = "local"
+	oplogCollection = "oplog.rs"
+)
+
+// OplogStats returns the storage statistics of the oplog collection
+// more information can be found here: https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/
+func (c *mongodbClient) OplogStats(ctx context.Context) (bson.M, error) {
+	collection := c.Database(oplogDatabase).Collection(oplogCollection)
+	pipeline := mongo.Pipeline{bson.D{bson.E{Key: "$collStats", Value: bson.M{"storageStats": bson.M{}}}}}
+	cursor, err := collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	if !cursor.Next(ctx) {
+		if err := cursor.Err(); err != nil {
+			return nil, err
+		}
+		return nil, mongo.ErrNoDocuments
+	}
+	var document bson.M
+	if err := cursor.Decode(&document); err != nil {
+		return nil, err
+	}
+	return document, nil
+}
+
+// OplogBounds returns the timestamps of the oldest and the newest entry currently retained in
+// the oplog. Both are read in natural order, which is insertion order on a capped collection.
+func (c *mongodbClient) OplogBounds(ctx context.Context) (bson.Timestamp, bson.Timestamp, error) {
+	oldest, err := c.oplogEntryTimestamp(ctx, 1)
+	if err != nil {
+		return bson.Timestamp{}, bson.Timestamp{}, err
+	}
+	newest, err := c.oplogEntryTimestamp(ctx, -1)
+	if err != nil {
+		return bson.Timestamp{}, bson.Timestamp{}, err
+	}
+	return oldest, newest, nil
+}
+
+func (c *mongodbClient) oplogEntryTimestamp(ctx context.Context, order int) (bson.Timestamp, error) {
+	opts := options.FindOne().
+		SetSort(bson.D{bson.E{Key: "$natural", Value: order}}).
+		SetProjection(bson.D{bson.E{Key: "ts", Value: 1}})
+
+	var entry struct {
+		Timestamp bson.Timestamp `bson:"ts"`
+	}
+	if err := c.Database(oplogDatabase).Collection(oplogCollection).FindOne(ctx, bson.D{}, opts).Decode(&entry); err != nil {
+		return bson.Timestamp{}, err
+	}
+	return entry.Timestamp, nil
 }
 
 const currentOpNamespaceFilterRegex = `^(?:admin|local)(?:\.|$)`

--- a/receiver/mongodbreceiver/client_test.go
+++ b/receiver/mongodbreceiver/client_test.go
@@ -71,6 +71,19 @@ func (fc *fakeClient) IndexStats(ctx context.Context, dbName, collectionName str
 	return args.Get(0).([]bson.M), args.Error(1)
 }
 
+func (fc *fakeClient) OplogStats(ctx context.Context) (bson.M, error) {
+	args := fc.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(bson.M), args.Error(1)
+}
+
+func (fc *fakeClient) OplogBounds(ctx context.Context) (bson.Timestamp, bson.Timestamp, error) {
+	args := fc.Called(ctx)
+	return args.Get(0).(bson.Timestamp), args.Get(1).(bson.Timestamp), args.Error(2)
+}
+
 func (fc *fakeClient) RunCommand(ctx context.Context, db string, command any) (bson.M, error) {
 	args := fc.Called(ctx, db, command)
 	if args.Get(0) == nil {

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -446,6 +446,30 @@ The number of replicated operations executed.
 | ---- | ----------- | ------ | ----------------- | ------------------- |
 | operation | The MongoDB operation being counted. | Str: ``insert``, ``query``, ``update``, ``delete``, ``getmore``, ``command`` | Recommended | - |
 
+### mongodb.oplog.limit
+
+The maximum amount of storage the oplog is allowed to use.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | Development |
+
+### mongodb.oplog.usage
+
+The amount of storage the oplog is using.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | Development |
+
+### mongodb.oplog.window
+
+The time span between the oldest and the newest entry retained in the oplog.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Double | Development |
+
 ### mongodb.page_faults
 
 The number of page faults.
@@ -509,6 +533,65 @@ The number of replicated updates executed per second.
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
 | {update}/s | Gauge | Double | Development |
+
+### mongodb.replica.status
+
+The current state of the scraped replica.
+
+A timeseries is produced for every possible state. The value is 1 for the state the instance is currently in, and 0 for all others.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| mongodb.replica.state | The state of a replica within the replica set. | Str: ``startup``, ``primary``, ``secondary``, ``recovering``, ``startup2``, ``unknown``, ``arbiter``, ``down``, ``rollback``, ``removed`` | Recommended | - |
+
+### mongodb.replica_set.headroom
+
+The time margin a replica set member has before it falls off the end of the oplog.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Double | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| mongodb.replica.name | The name of the replica, in host:port form. | Any Str | Recommended | - |
+
+### mongodb.replica_set.lag
+
+The time a replica set member is behind the primary.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Double | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| mongodb.replica.name | The name of the replica, in host:port form. | Any Str | Recommended | - |
+| mongodb.replica_set.lag.type | The replication progress that the lag is measured against. | Str: ``applied``, ``durable`` | Recommended | - |
+
+### mongodb.replica_set.member.count
+
+The number of members in the replica set.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {member} | Sum | Int | Cumulative | false | Development |
+
+#### Attributes
+
+| Name | Description | Values | Requirement Level | Semantic Convention |
+| ---- | ----------- | ------ | ----------------- | ------------------- |
+| mongodb.replica.state | The state of a replica within the replica set. | Str: ``startup``, ``primary``, ``secondary``, ``recovering``, ``startup2``, ``unknown``, ``arbiter``, ``down``, ``rollback``, ``removed`` | Recommended | - |
 
 ### mongodb.updates.rate
 

--- a/receiver/mongodbreceiver/internal/metadata/generated_config.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config.go
@@ -1234,6 +1234,66 @@ func (ms *MongodbOperationTimeMetricConfig) Validate() error {
 	return nil
 }
 
+// MongodbOplogLimitMetricConfig provides config for the mongodb.oplog.limit metric.
+type MongodbOplogLimitMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbOplogLimitMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbOplogUsageMetricConfig provides config for the mongodb.oplog.usage metric.
+type MongodbOplogUsageMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbOplogUsageMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbOplogWindowMetricConfig provides config for the mongodb.oplog.window metric.
+type MongodbOplogWindowMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+}
+
+func (ms *MongodbOplogWindowMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // MongodbPageFaultsMetricConfig provides config for the mongodb.page_faults metric.
 type MongodbPageFaultsMetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
@@ -1391,6 +1451,199 @@ func (ms *MongodbReplUpdatesPerSecMetricConfig) Unmarshal(parser *confmap.Conf) 
 	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+// MongodbReplicaStatusMetricAttributeKey specifies the key of an attribute for the mongodb.replica.status metric.
+type MongodbReplicaStatusMetricAttributeKey string
+
+const (
+	MongodbReplicaStatusMetricAttributeKeyMongodbReplicaState MongodbReplicaStatusMetricAttributeKey = "mongodb.replica.state"
+)
+
+// MongodbReplicaStatusMetricConfig provides config for the mongodb.replica.status metric.
+type MongodbReplicaStatusMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbReplicaStatusMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbReplicaStatusMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbReplicaStatusMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbReplicaStatusMetricAttributeKeyMongodbReplicaState:
+		default:
+			return fmt.Errorf("metric mongodb.replica.status doesn't have an attribute %v, valid attributes: [mongodb.replica.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbReplicaSetHeadroomMetricAttributeKey specifies the key of an attribute for the mongodb.replica_set.headroom metric.
+type MongodbReplicaSetHeadroomMetricAttributeKey string
+
+const (
+	MongodbReplicaSetHeadroomMetricAttributeKeyMongodbReplicaName MongodbReplicaSetHeadroomMetricAttributeKey = "mongodb.replica.name"
+)
+
+// MongodbReplicaSetHeadroomMetricConfig provides config for the mongodb.replica_set.headroom metric.
+type MongodbReplicaSetHeadroomMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                        `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbReplicaSetHeadroomMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbReplicaSetHeadroomMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbReplicaSetHeadroomMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbReplicaSetHeadroomMetricAttributeKeyMongodbReplicaName:
+		default:
+			return fmt.Errorf("metric mongodb.replica_set.headroom doesn't have an attribute %v, valid attributes: [mongodb.replica.name]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbReplicaSetLagMetricAttributeKey specifies the key of an attribute for the mongodb.replica_set.lag metric.
+type MongodbReplicaSetLagMetricAttributeKey string
+
+const (
+	MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaName       MongodbReplicaSetLagMetricAttributeKey = "mongodb.replica.name"
+	MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaSetLagType MongodbReplicaSetLagMetricAttributeKey = "mongodb.replica_set.lag.type"
+)
+
+// MongodbReplicaSetLagMetricConfig provides config for the mongodb.replica_set.lag metric.
+type MongodbReplicaSetLagMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbReplicaSetLagMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbReplicaSetLagMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbReplicaSetLagMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaName, MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaSetLagType:
+		default:
+			return fmt.Errorf("metric mongodb.replica_set.lag doesn't have an attribute %v, valid attributes: [mongodb.replica.name, mongodb.replica_set.lag.type]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
+	return nil
+}
+
+// MongodbReplicaSetMemberCountMetricAttributeKey specifies the key of an attribute for the mongodb.replica_set.member.count metric.
+type MongodbReplicaSetMemberCountMetricAttributeKey string
+
+const (
+	MongodbReplicaSetMemberCountMetricAttributeKeyMongodbReplicaState MongodbReplicaSetMemberCountMetricAttributeKey = "mongodb.replica.state"
+)
+
+// MongodbReplicaSetMemberCountMetricConfig provides config for the mongodb.replica_set.member.count metric.
+type MongodbReplicaSetMemberCountMetricConfig struct {
+	Enabled          bool `mapstructure:"enabled"`
+	enabledSetByUser bool
+
+	AggregationStrategy string                                           `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []MongodbReplicaSetMemberCountMetricAttributeKey `mapstructure:"attributes"`
+}
+
+func (ms *MongodbReplicaSetMemberCountMetricConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+
+	err := parser.Unmarshal(ms)
+	if err != nil {
+		return err
+	}
+
+	ms.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
+func (ms *MongodbReplicaSetMemberCountMetricConfig) Validate() error {
+	for _, val := range ms.EnabledAttributes {
+		switch val {
+		case MongodbReplicaSetMemberCountMetricAttributeKeyMongodbReplicaState:
+		default:
+			return fmt.Errorf("metric mongodb.replica_set.member.count doesn't have an attribute %v, valid attributes: [mongodb.replica.state]", val)
+		}
+	}
+
+	switch ms.AggregationStrategy {
+	case AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax:
+	default:
+		return fmt.Errorf("invalid aggregation strategy %q, valid strategies: [%s, %s, %s, %s]", ms.AggregationStrategy, AggregationStrategySum, AggregationStrategyAvg, AggregationStrategyMin, AggregationStrategyMax)
+	}
+
 	return nil
 }
 
@@ -1714,6 +1967,9 @@ type MetricsConfig struct {
 	MongodbOperationLatencyTime               MongodbOperationLatencyTimeMetricConfig               `mapstructure:"mongodb.operation.latency.time"`
 	MongodbOperationReplCount                 MongodbOperationReplCountMetricConfig                 `mapstructure:"mongodb.operation.repl.count"`
 	MongodbOperationTime                      MongodbOperationTimeMetricConfig                      `mapstructure:"mongodb.operation.time"`
+	MongodbOplogLimit                         MongodbOplogLimitMetricConfig                         `mapstructure:"mongodb.oplog.limit"`
+	MongodbOplogUsage                         MongodbOplogUsageMetricConfig                         `mapstructure:"mongodb.oplog.usage"`
+	MongodbOplogWindow                        MongodbOplogWindowMetricConfig                        `mapstructure:"mongodb.oplog.window"`
 	MongodbPageFaults                         MongodbPageFaultsMetricConfig                         `mapstructure:"mongodb.page_faults"`
 	MongodbQueriesRate                        MongodbQueriesRateMetricConfig                        `mapstructure:"mongodb.queries.rate"`
 	MongodbReplCommandsPerSec                 MongodbReplCommandsPerSecMetricConfig                 `mapstructure:"mongodb.repl_commands_per_sec"`
@@ -1722,6 +1978,10 @@ type MetricsConfig struct {
 	MongodbReplInsertsPerSec                  MongodbReplInsertsPerSecMetricConfig                  `mapstructure:"mongodb.repl_inserts_per_sec"`
 	MongodbReplQueriesPerSec                  MongodbReplQueriesPerSecMetricConfig                  `mapstructure:"mongodb.repl_queries_per_sec"`
 	MongodbReplUpdatesPerSec                  MongodbReplUpdatesPerSecMetricConfig                  `mapstructure:"mongodb.repl_updates_per_sec"`
+	MongodbReplicaStatus                      MongodbReplicaStatusMetricConfig                      `mapstructure:"mongodb.replica.status"`
+	MongodbReplicaSetHeadroom                 MongodbReplicaSetHeadroomMetricConfig                 `mapstructure:"mongodb.replica_set.headroom"`
+	MongodbReplicaSetLag                      MongodbReplicaSetLagMetricConfig                      `mapstructure:"mongodb.replica_set.lag"`
+	MongodbReplicaSetMemberCount              MongodbReplicaSetMemberCountMetricConfig              `mapstructure:"mongodb.replica_set.member.count"`
 	MongodbSessionCount                       MongodbSessionCountMetricConfig                       `mapstructure:"mongodb.session.count"`
 	MongodbStorageSize                        MongodbStorageSizeMetricConfig                        `mapstructure:"mongodb.storage.size"`
 	MongodbUpdatesRate                        MongodbUpdatesRateMetricConfig                        `mapstructure:"mongodb.updates.rate"`
@@ -1876,6 +2136,15 @@ func DefaultMetricsConfig() MetricsConfig {
 			AggregationStrategy: AggregationStrategySum,
 			EnabledAttributes:   []MongodbOperationTimeMetricAttributeKey{MongodbOperationTimeMetricAttributeKeyOperation},
 		},
+		MongodbOplogLimit: MongodbOplogLimitMetricConfig{
+			Enabled: false,
+		},
+		MongodbOplogUsage: MongodbOplogUsageMetricConfig{
+			Enabled: false,
+		},
+		MongodbOplogWindow: MongodbOplogWindowMetricConfig{
+			Enabled: false,
+		},
 		MongodbPageFaults: MongodbPageFaultsMetricConfig{
 			Enabled: false,
 		},
@@ -1899,6 +2168,26 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		MongodbReplUpdatesPerSec: MongodbReplUpdatesPerSecMetricConfig{
 			Enabled: false,
+		},
+		MongodbReplicaStatus: MongodbReplicaStatusMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MongodbReplicaStatusMetricAttributeKey{MongodbReplicaStatusMetricAttributeKeyMongodbReplicaState},
+		},
+		MongodbReplicaSetHeadroom: MongodbReplicaSetHeadroomMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbReplicaSetHeadroomMetricAttributeKey{MongodbReplicaSetHeadroomMetricAttributeKeyMongodbReplicaName},
+		},
+		MongodbReplicaSetLag: MongodbReplicaSetLagMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategyAvg,
+			EnabledAttributes:   []MongodbReplicaSetLagMetricAttributeKey{MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaName, MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaSetLagType},
+		},
+		MongodbReplicaSetMemberCount: MongodbReplicaSetMemberCountMetricConfig{
+			Enabled:             false,
+			AggregationStrategy: AggregationStrategySum,
+			EnabledAttributes:   []MongodbReplicaSetMemberCountMetricAttributeKey{MongodbReplicaSetMemberCountMetricAttributeKeyMongodbReplicaState},
 		},
 		MongodbSessionCount: MongodbSessionCountMetricConfig{
 			Enabled: true,

--- a/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
@@ -167,6 +167,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MongodbOperationTimeMetricAttributeKey{MongodbOperationTimeMetricAttributeKeyOperation},
 					},
+					MongodbOplogLimit: MongodbOplogLimitMetricConfig{
+						Enabled: true,
+					},
+					MongodbOplogUsage: MongodbOplogUsageMetricConfig{
+						Enabled: true,
+					},
+					MongodbOplogWindow: MongodbOplogWindowMetricConfig{
+						Enabled: true,
+					},
 					MongodbPageFaults: MongodbPageFaultsMetricConfig{
 						Enabled: true,
 					},
@@ -190,6 +199,26 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					MongodbReplUpdatesPerSec: MongodbReplUpdatesPerSecMetricConfig{
 						Enabled: true,
+					},
+					MongodbReplicaStatus: MongodbReplicaStatusMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbReplicaStatusMetricAttributeKey{MongodbReplicaStatusMetricAttributeKeyMongodbReplicaState},
+					},
+					MongodbReplicaSetHeadroom: MongodbReplicaSetHeadroomMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbReplicaSetHeadroomMetricAttributeKey{MongodbReplicaSetHeadroomMetricAttributeKeyMongodbReplicaName},
+					},
+					MongodbReplicaSetLag: MongodbReplicaSetLagMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbReplicaSetLagMetricAttributeKey{MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaName, MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaSetLagType},
+					},
+					MongodbReplicaSetMemberCount: MongodbReplicaSetMemberCountMetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbReplicaSetMemberCountMetricAttributeKey{MongodbReplicaSetMemberCountMetricAttributeKeyMongodbReplicaState},
 					},
 					MongodbSessionCount: MongodbSessionCountMetricConfig{
 						Enabled: true,
@@ -382,6 +411,15 @@ func TestMetricsBuilderConfig(t *testing.T) {
 						AggregationStrategy: AggregationStrategySum,
 						EnabledAttributes:   []MongodbOperationTimeMetricAttributeKey{MongodbOperationTimeMetricAttributeKeyOperation},
 					},
+					MongodbOplogLimit: MongodbOplogLimitMetricConfig{
+						Enabled: false,
+					},
+					MongodbOplogUsage: MongodbOplogUsageMetricConfig{
+						Enabled: false,
+					},
+					MongodbOplogWindow: MongodbOplogWindowMetricConfig{
+						Enabled: false,
+					},
 					MongodbPageFaults: MongodbPageFaultsMetricConfig{
 						Enabled: false,
 					},
@@ -405,6 +443,26 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 					MongodbReplUpdatesPerSec: MongodbReplUpdatesPerSecMetricConfig{
 						Enabled: false,
+					},
+					MongodbReplicaStatus: MongodbReplicaStatusMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbReplicaStatusMetricAttributeKey{MongodbReplicaStatusMetricAttributeKeyMongodbReplicaState},
+					},
+					MongodbReplicaSetHeadroom: MongodbReplicaSetHeadroomMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbReplicaSetHeadroomMetricAttributeKey{MongodbReplicaSetHeadroomMetricAttributeKeyMongodbReplicaName},
+					},
+					MongodbReplicaSetLag: MongodbReplicaSetLagMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []MongodbReplicaSetLagMetricAttributeKey{MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaName, MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaSetLagType},
+					},
+					MongodbReplicaSetMemberCount: MongodbReplicaSetMemberCountMetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategySum,
+						EnabledAttributes:   []MongodbReplicaSetMemberCountMetricAttributeKey{MongodbReplicaSetMemberCountMetricAttributeKeyMongodbReplicaState},
 					},
 					MongodbSessionCount: MongodbSessionCountMetricConfig{
 						Enabled: false,
@@ -457,7 +515,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MongodbActiveReadsMetricConfig{}, MongodbActiveWritesMetricConfig{}, MongodbCacheOperationsMetricConfig{}, MongodbCollectionCountMetricConfig{}, MongodbCommandsRateMetricConfig{}, MongodbConnectionCountMetricConfig{}, MongodbCursorCountMetricConfig{}, MongodbCursorTimeoutCountMetricConfig{}, MongodbDataSizeMetricConfig{}, MongodbDatabaseCountMetricConfig{}, MongodbDeletesRateMetricConfig{}, MongodbDocumentOperationCountMetricConfig{}, MongodbExtentCountMetricConfig{}, MongodbFlushesRateMetricConfig{}, MongodbGetmoresRateMetricConfig{}, MongodbGlobalLockTimeMetricConfig{}, MongodbHealthMetricConfig{}, MongodbIndexAccessCountMetricConfig{}, MongodbIndexCountMetricConfig{}, MongodbIndexSizeMetricConfig{}, MongodbInsertsRateMetricConfig{}, MongodbLockAcquireCountMetricConfig{}, MongodbLockAcquireTimeMetricConfig{}, MongodbLockAcquireWaitCountMetricConfig{}, MongodbLockDeadlockCountMetricConfig{}, MongodbMemoryUsageMetricConfig{}, MongodbNetworkIoReceiveMetricConfig{}, MongodbNetworkIoTransmitMetricConfig{}, MongodbNetworkRequestCountMetricConfig{}, MongodbObjectCountMetricConfig{}, MongodbOperationCountMetricConfig{}, MongodbOperationLatencyTimeMetricConfig{}, MongodbOperationReplCountMetricConfig{}, MongodbOperationTimeMetricConfig{}, MongodbPageFaultsMetricConfig{}, MongodbQueriesRateMetricConfig{}, MongodbReplCommandsPerSecMetricConfig{}, MongodbReplDeletesPerSecMetricConfig{}, MongodbReplGetmoresPerSecMetricConfig{}, MongodbReplInsertsPerSecMetricConfig{}, MongodbReplQueriesPerSecMetricConfig{}, MongodbReplUpdatesPerSecMetricConfig{}, MongodbSessionCountMetricConfig{}, MongodbStorageSizeMetricConfig{}, MongodbUpdatesRateMetricConfig{}, MongodbUptimeMetricConfig{}, MongodbWtConcurrentTransactionTicketInUseMetricConfig{}, MongodbWtFsyncCountMetricConfig{}, MongodbWtLogOperationCountMetricConfig{}, MongodbWtLogSyncTimeMetricConfig{}, MongodbWtLogWriteMetricConfig{}, MongodbWtcacheBytesReadMetricConfig{}, DbSystemVersionResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MongodbActiveReadsMetricConfig{}, MongodbActiveWritesMetricConfig{}, MongodbCacheOperationsMetricConfig{}, MongodbCollectionCountMetricConfig{}, MongodbCommandsRateMetricConfig{}, MongodbConnectionCountMetricConfig{}, MongodbCursorCountMetricConfig{}, MongodbCursorTimeoutCountMetricConfig{}, MongodbDataSizeMetricConfig{}, MongodbDatabaseCountMetricConfig{}, MongodbDeletesRateMetricConfig{}, MongodbDocumentOperationCountMetricConfig{}, MongodbExtentCountMetricConfig{}, MongodbFlushesRateMetricConfig{}, MongodbGetmoresRateMetricConfig{}, MongodbGlobalLockTimeMetricConfig{}, MongodbHealthMetricConfig{}, MongodbIndexAccessCountMetricConfig{}, MongodbIndexCountMetricConfig{}, MongodbIndexSizeMetricConfig{}, MongodbInsertsRateMetricConfig{}, MongodbLockAcquireCountMetricConfig{}, MongodbLockAcquireTimeMetricConfig{}, MongodbLockAcquireWaitCountMetricConfig{}, MongodbLockDeadlockCountMetricConfig{}, MongodbMemoryUsageMetricConfig{}, MongodbNetworkIoReceiveMetricConfig{}, MongodbNetworkIoTransmitMetricConfig{}, MongodbNetworkRequestCountMetricConfig{}, MongodbObjectCountMetricConfig{}, MongodbOperationCountMetricConfig{}, MongodbOperationLatencyTimeMetricConfig{}, MongodbOperationReplCountMetricConfig{}, MongodbOperationTimeMetricConfig{}, MongodbOplogLimitMetricConfig{}, MongodbOplogUsageMetricConfig{}, MongodbOplogWindowMetricConfig{}, MongodbPageFaultsMetricConfig{}, MongodbQueriesRateMetricConfig{}, MongodbReplCommandsPerSecMetricConfig{}, MongodbReplDeletesPerSecMetricConfig{}, MongodbReplGetmoresPerSecMetricConfig{}, MongodbReplInsertsPerSecMetricConfig{}, MongodbReplQueriesPerSecMetricConfig{}, MongodbReplUpdatesPerSecMetricConfig{}, MongodbReplicaStatusMetricConfig{}, MongodbReplicaSetHeadroomMetricConfig{}, MongodbReplicaSetLagMetricConfig{}, MongodbReplicaSetMemberCountMetricConfig{}, MongodbSessionCountMetricConfig{}, MongodbStorageSizeMetricConfig{}, MongodbUpdatesRateMetricConfig{}, MongodbUptimeMetricConfig{}, MongodbWtConcurrentTransactionTicketInUseMetricConfig{}, MongodbWtFsyncCountMetricConfig{}, MongodbWtLogOperationCountMetricConfig{}, MongodbWtLogSyncTimeMetricConfig{}, MongodbWtLogWriteMetricConfig{}, MongodbWtcacheBytesReadMetricConfig{}, DbSystemVersionResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -687,6 +745,54 @@ func TestMongodbOperationTimeMetricsConfig_Validate(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric mongodb.operation.time doesn't have an attribute invalid, valid attributes: [operation]")
 
 	cfg = DefaultMetricsConfig().MongodbOperationTime
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestMongodbReplicaStatusMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().MongodbReplicaStatus
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []MongodbReplicaStatusMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric mongodb.replica.status doesn't have an attribute invalid, valid attributes: [mongodb.replica.state]")
+
+	cfg = DefaultMetricsConfig().MongodbReplicaStatus
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestMongodbReplicaSetHeadroomMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().MongodbReplicaSetHeadroom
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []MongodbReplicaSetHeadroomMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric mongodb.replica_set.headroom doesn't have an attribute invalid, valid attributes: [mongodb.replica.name]")
+
+	cfg = DefaultMetricsConfig().MongodbReplicaSetHeadroom
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestMongodbReplicaSetLagMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().MongodbReplicaSetLag
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []MongodbReplicaSetLagMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric mongodb.replica_set.lag doesn't have an attribute invalid, valid attributes: [mongodb.replica.name, mongodb.replica_set.lag.type]")
+
+	cfg = DefaultMetricsConfig().MongodbReplicaSetLag
+	cfg.AggregationStrategy = "invalid"
+	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
+}
+
+func TestMongodbReplicaSetMemberCountMetricsConfig_Validate(t *testing.T) {
+	cfg := DefaultMetricsConfig().MongodbReplicaSetMemberCount
+	require.NoError(t, cfg.Validate())
+
+	cfg.EnabledAttributes = []MongodbReplicaSetMemberCountMetricAttributeKey{"invalid"}
+	require.ErrorContains(t, cfg.Validate(), "metric mongodb.replica_set.member.count doesn't have an attribute invalid, valid attributes: [mongodb.replica.state]")
+
+	cfg = DefaultMetricsConfig().MongodbReplicaSetMemberCount
 	cfg.AggregationStrategy = "invalid"
 	require.ErrorContains(t, cfg.Validate(), "invalid aggregation strategy")
 }

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -208,6 +208,90 @@ var MapAttributeMongodbOperationState = map[string]AttributeMongodbOperationStat
 	"waiting": AttributeMongodbOperationStateWaiting,
 }
 
+// AttributeMongodbReplicaState specifies the value mongodb.replica.state attribute.
+type AttributeMongodbReplicaState int
+
+const (
+	_ AttributeMongodbReplicaState = iota
+	AttributeMongodbReplicaStateStartup
+	AttributeMongodbReplicaStatePrimary
+	AttributeMongodbReplicaStateSecondary
+	AttributeMongodbReplicaStateRecovering
+	AttributeMongodbReplicaStateStartup2
+	AttributeMongodbReplicaStateUnknown
+	AttributeMongodbReplicaStateArbiter
+	AttributeMongodbReplicaStateDown
+	AttributeMongodbReplicaStateRollback
+	AttributeMongodbReplicaStateRemoved
+)
+
+// String returns the string representation of the AttributeMongodbReplicaState.
+func (av AttributeMongodbReplicaState) String() string {
+	switch av {
+	case AttributeMongodbReplicaStateStartup:
+		return "startup"
+	case AttributeMongodbReplicaStatePrimary:
+		return "primary"
+	case AttributeMongodbReplicaStateSecondary:
+		return "secondary"
+	case AttributeMongodbReplicaStateRecovering:
+		return "recovering"
+	case AttributeMongodbReplicaStateStartup2:
+		return "startup2"
+	case AttributeMongodbReplicaStateUnknown:
+		return "unknown"
+	case AttributeMongodbReplicaStateArbiter:
+		return "arbiter"
+	case AttributeMongodbReplicaStateDown:
+		return "down"
+	case AttributeMongodbReplicaStateRollback:
+		return "rollback"
+	case AttributeMongodbReplicaStateRemoved:
+		return "removed"
+	}
+	return ""
+}
+
+// MapAttributeMongodbReplicaState is a helper map of string to AttributeMongodbReplicaState attribute value.
+var MapAttributeMongodbReplicaState = map[string]AttributeMongodbReplicaState{
+	"startup":    AttributeMongodbReplicaStateStartup,
+	"primary":    AttributeMongodbReplicaStatePrimary,
+	"secondary":  AttributeMongodbReplicaStateSecondary,
+	"recovering": AttributeMongodbReplicaStateRecovering,
+	"startup2":   AttributeMongodbReplicaStateStartup2,
+	"unknown":    AttributeMongodbReplicaStateUnknown,
+	"arbiter":    AttributeMongodbReplicaStateArbiter,
+	"down":       AttributeMongodbReplicaStateDown,
+	"rollback":   AttributeMongodbReplicaStateRollback,
+	"removed":    AttributeMongodbReplicaStateRemoved,
+}
+
+// AttributeMongodbReplicaSetLagType specifies the value mongodb.replica_set.lag.type attribute.
+type AttributeMongodbReplicaSetLagType int
+
+const (
+	_ AttributeMongodbReplicaSetLagType = iota
+	AttributeMongodbReplicaSetLagTypeApplied
+	AttributeMongodbReplicaSetLagTypeDurable
+)
+
+// String returns the string representation of the AttributeMongodbReplicaSetLagType.
+func (av AttributeMongodbReplicaSetLagType) String() string {
+	switch av {
+	case AttributeMongodbReplicaSetLagTypeApplied:
+		return "applied"
+	case AttributeMongodbReplicaSetLagTypeDurable:
+		return "durable"
+	}
+	return ""
+}
+
+// MapAttributeMongodbReplicaSetLagType is a helper map of string to AttributeMongodbReplicaSetLagType attribute value.
+var MapAttributeMongodbReplicaSetLagType = map[string]AttributeMongodbReplicaSetLagType{
+	"applied": AttributeMongodbReplicaSetLagTypeApplied,
+	"durable": AttributeMongodbReplicaSetLagTypeDurable,
+}
+
 // AttributeMongodbWtConcurrentTransactionTicketType specifies the value mongodb.wt.concurrent_transaction.ticket.type attribute.
 type AttributeMongodbWtConcurrentTransactionTicketType int
 
@@ -484,6 +568,15 @@ var MetricsInfo = metricsInfo{
 		Name:       "mongodb.operation.time",
 		Attributes: []string{"operation"},
 	},
+	MongodbOplogLimit: metricInfo{
+		Name: "mongodb.oplog.limit",
+	},
+	MongodbOplogUsage: metricInfo{
+		Name: "mongodb.oplog.usage",
+	},
+	MongodbOplogWindow: metricInfo{
+		Name: "mongodb.oplog.window",
+	},
 	MongodbPageFaults: metricInfo{
 		Name: "mongodb.page_faults",
 	},
@@ -507,6 +600,22 @@ var MetricsInfo = metricsInfo{
 	},
 	MongodbReplUpdatesPerSec: metricInfo{
 		Name: "mongodb.repl_updates_per_sec",
+	},
+	MongodbReplicaStatus: metricInfo{
+		Name:       "mongodb.replica.status",
+		Attributes: []string{"mongodb.replica.state"},
+	},
+	MongodbReplicaSetHeadroom: metricInfo{
+		Name:       "mongodb.replica_set.headroom",
+		Attributes: []string{"mongodb.replica.name"},
+	},
+	MongodbReplicaSetLag: metricInfo{
+		Name:       "mongodb.replica_set.lag",
+		Attributes: []string{"mongodb.replica.name", "mongodb.replica_set.lag.type"},
+	},
+	MongodbReplicaSetMemberCount: metricInfo{
+		Name:       "mongodb.replica_set.member.count",
+		Attributes: []string{"mongodb.replica.state"},
 	},
 	MongodbSessionCount: metricInfo{
 		Name: "mongodb.session.count",
@@ -578,6 +687,9 @@ type metricsInfo struct {
 	MongodbOperationLatencyTime               metricInfo
 	MongodbOperationReplCount                 metricInfo
 	MongodbOperationTime                      metricInfo
+	MongodbOplogLimit                         metricInfo
+	MongodbOplogUsage                         metricInfo
+	MongodbOplogWindow                        metricInfo
 	MongodbPageFaults                         metricInfo
 	MongodbQueriesRate                        metricInfo
 	MongodbReplCommandsPerSec                 metricInfo
@@ -586,6 +698,10 @@ type metricsInfo struct {
 	MongodbReplInsertsPerSec                  metricInfo
 	MongodbReplQueriesPerSec                  metricInfo
 	MongodbReplUpdatesPerSec                  metricInfo
+	MongodbReplicaStatus                      metricInfo
+	MongodbReplicaSetHeadroom                 metricInfo
+	MongodbReplicaSetLag                      metricInfo
+	MongodbReplicaSetMemberCount              metricInfo
 	MongodbSessionCount                       metricInfo
 	MongodbStorageSize                        metricInfo
 	MongodbUpdatesRate                        metricInfo
@@ -3134,6 +3250,160 @@ func newMetricMongodbOperationTime(cfg MongodbOperationTimeMetricConfig) metricM
 	return m
 }
 
+type metricMongodbOplogLimit struct {
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   MongodbOplogLimitMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.oplog.limit metric with initial data.
+func (m *metricMongodbOplogLimit) init() {
+	m.data.SetName("mongodb.oplog.limit")
+	m.data.SetDescription("The maximum amount of storage the oplog is allowed to use.")
+	m.data.SetUnit("By")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbOplogLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbOplogLimit) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbOplogLimit) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbOplogLimit(cfg MongodbOplogLimitMetricConfig) metricMongodbOplogLimit {
+	m := metricMongodbOplogLimit{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbOplogUsage struct {
+	data     pmetric.Metric                // data buffer for generated metric.
+	config   MongodbOplogUsageMetricConfig // metric config provided by user.
+	capacity int                           // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.oplog.usage metric with initial data.
+func (m *metricMongodbOplogUsage) init() {
+	m.data.SetName("mongodb.oplog.usage")
+	m.data.SetDescription("The amount of storage the oplog is using.")
+	m.data.SetUnit("By")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricMongodbOplogUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbOplogUsage) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbOplogUsage) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbOplogUsage(cfg MongodbOplogUsageMetricConfig) metricMongodbOplogUsage {
+	m := metricMongodbOplogUsage{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbOplogWindow struct {
+	data     pmetric.Metric                 // data buffer for generated metric.
+	config   MongodbOplogWindowMetricConfig // metric config provided by user.
+	capacity int                            // max observed number of data points added to the metric.
+}
+
+// init fills mongodb.oplog.window metric with initial data.
+func (m *metricMongodbOplogWindow) init() {
+	m.data.SetName("mongodb.oplog.window")
+	m.data.SetDescription("The time span between the oldest and the newest entry retained in the oplog.")
+	m.data.SetUnit("s")
+	m.data.SetEmptyGauge()
+}
+
+func (m *metricMongodbOplogWindow) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbOplogWindow) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbOplogWindow) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbOplogWindow(cfg MongodbOplogWindowMetricConfig) metricMongodbOplogWindow {
+	m := metricMongodbOplogWindow{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricMongodbPageFaults struct {
 	data     pmetric.Metric                // data buffer for generated metric.
 	config   MongodbPageFaultsMetricConfig // metric config provided by user.
@@ -3528,6 +3798,369 @@ func (m *metricMongodbReplUpdatesPerSec) emit(metrics pmetric.MetricSlice) {
 
 func newMetricMongodbReplUpdatesPerSec(cfg MongodbReplUpdatesPerSecMetricConfig) metricMongodbReplUpdatesPerSec {
 	m := metricMongodbReplUpdatesPerSec{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbReplicaStatus struct {
+	data          pmetric.Metric                   // data buffer for generated metric.
+	config        MongodbReplicaStatusMetricConfig // metric config provided by user.
+	capacity      int                              // max observed number of data points added to the metric.
+	aggDataPoints []int64                          // slice containing number of aggregated datapoints at each index
+}
+
+// init fills mongodb.replica.status metric with initial data.
+func (m *metricMongodbReplicaStatus) init() {
+	m.data.SetName("mongodb.replica.status")
+	m.data.SetDescription("The current state of the scraped replica.")
+	m.data.SetUnit("1")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricMongodbReplicaStatus) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, mongodbReplicaStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbReplicaStatusMetricAttributeKeyMongodbReplicaState) {
+		dp.Attributes().PutStr("mongodb.replica.state", mongodbReplicaStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbReplicaStatus) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbReplicaStatus) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbReplicaStatus(cfg MongodbReplicaStatusMetricConfig) metricMongodbReplicaStatus {
+	m := metricMongodbReplicaStatus{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbReplicaSetHeadroom struct {
+	data          pmetric.Metric                        // data buffer for generated metric.
+	config        MongodbReplicaSetHeadroomMetricConfig // metric config provided by user.
+	capacity      int                                   // max observed number of data points added to the metric.
+	aggDataPoints []float64                             // slice containing number of aggregated datapoints at each index
+}
+
+// init fills mongodb.replica_set.headroom metric with initial data.
+func (m *metricMongodbReplicaSetHeadroom) init() {
+	m.data.SetName("mongodb.replica_set.headroom")
+	m.data.SetDescription("The time margin a replica set member has before it falls off the end of the oplog.")
+	m.data.SetUnit("s")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricMongodbReplicaSetHeadroom) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, mongodbReplicaNameAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbReplicaSetHeadroomMetricAttributeKeyMongodbReplicaName) {
+		dp.Attributes().PutStr("mongodb.replica.name", mongodbReplicaNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbReplicaSetHeadroom) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbReplicaSetHeadroom) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbReplicaSetHeadroom(cfg MongodbReplicaSetHeadroomMetricConfig) metricMongodbReplicaSetHeadroom {
+	m := metricMongodbReplicaSetHeadroom{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbReplicaSetLag struct {
+	data          pmetric.Metric                   // data buffer for generated metric.
+	config        MongodbReplicaSetLagMetricConfig // metric config provided by user.
+	capacity      int                              // max observed number of data points added to the metric.
+	aggDataPoints []float64                        // slice containing number of aggregated datapoints at each index
+}
+
+// init fills mongodb.replica_set.lag metric with initial data.
+func (m *metricMongodbReplicaSetLag) init() {
+	m.data.SetName("mongodb.replica_set.lag")
+	m.data.SetDescription("The time a replica set member is behind the primary.")
+	m.data.SetUnit("s")
+	m.data.SetEmptyGauge()
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricMongodbReplicaSetLag) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, mongodbReplicaNameAttributeValue string, mongodbReplicaSetLagTypeAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaName) {
+		dp.Attributes().PutStr("mongodb.replica.name", mongodbReplicaNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, MongodbReplicaSetLagMetricAttributeKeyMongodbReplicaSetLagType) {
+		dp.Attributes().PutStr("mongodb.replica_set.lag.type", mongodbReplicaSetLagTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetDoubleValue(dpi.DoubleValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.DoubleValue() > val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.DoubleValue() < val {
+					dpi.SetDoubleValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetDoubleValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbReplicaSetLag) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbReplicaSetLag) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetDoubleValue(m.data.Gauge().DataPoints().At(i).DoubleValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbReplicaSetLag(cfg MongodbReplicaSetLagMetricConfig) metricMongodbReplicaSetLag {
+	m := metricMongodbReplicaSetLag{config: cfg}
+
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricMongodbReplicaSetMemberCount struct {
+	data          pmetric.Metric                           // data buffer for generated metric.
+	config        MongodbReplicaSetMemberCountMetricConfig // metric config provided by user.
+	capacity      int                                      // max observed number of data points added to the metric.
+	aggDataPoints []int64                                  // slice containing number of aggregated datapoints at each index
+}
+
+// init fills mongodb.replica_set.member.count metric with initial data.
+func (m *metricMongodbReplicaSetMemberCount) init() {
+	m.data.SetName("mongodb.replica_set.member.count")
+	m.data.SetDescription("The number of members in the replica set.")
+	m.data.SetUnit("{member}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
+}
+
+func (m *metricMongodbReplicaSetMemberCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, mongodbReplicaStateAttributeValue string) {
+	if !m.config.Enabled {
+		return
+	}
+
+	dp := pmetric.NewNumberDataPoint()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, MongodbReplicaSetMemberCountMetricAttributeKeyMongodbReplicaState) {
+		dp.Attributes().PutStr("mongodb.replica.state", mongodbReplicaStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Sum().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
+	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricMongodbReplicaSetMemberCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricMongodbReplicaSetMemberCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Sum().DataPoints().At(i).SetIntValue(m.data.Sum().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricMongodbReplicaSetMemberCount(cfg MongodbReplicaSetMemberCountMetricConfig) metricMongodbReplicaSetMemberCount {
+	m := metricMongodbReplicaSetMemberCount{config: cfg}
 
 	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
@@ -4215,6 +4848,9 @@ type MetricsBuilder struct {
 	metricMongodbOperationLatencyTime               metricMongodbOperationLatencyTime
 	metricMongodbOperationReplCount                 metricMongodbOperationReplCount
 	metricMongodbOperationTime                      metricMongodbOperationTime
+	metricMongodbOplogLimit                         metricMongodbOplogLimit
+	metricMongodbOplogUsage                         metricMongodbOplogUsage
+	metricMongodbOplogWindow                        metricMongodbOplogWindow
 	metricMongodbPageFaults                         metricMongodbPageFaults
 	metricMongodbQueriesRate                        metricMongodbQueriesRate
 	metricMongodbReplCommandsPerSec                 metricMongodbReplCommandsPerSec
@@ -4223,6 +4859,10 @@ type MetricsBuilder struct {
 	metricMongodbReplInsertsPerSec                  metricMongodbReplInsertsPerSec
 	metricMongodbReplQueriesPerSec                  metricMongodbReplQueriesPerSec
 	metricMongodbReplUpdatesPerSec                  metricMongodbReplUpdatesPerSec
+	metricMongodbReplicaStatus                      metricMongodbReplicaStatus
+	metricMongodbReplicaSetHeadroom                 metricMongodbReplicaSetHeadroom
+	metricMongodbReplicaSetLag                      metricMongodbReplicaSetLag
+	metricMongodbReplicaSetMemberCount              metricMongodbReplicaSetMemberCount
 	metricMongodbSessionCount                       metricMongodbSessionCount
 	metricMongodbStorageSize                        metricMongodbStorageSize
 	metricMongodbUpdatesRate                        metricMongodbUpdatesRate
@@ -4292,6 +4932,9 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMongodbOperationLatencyTime:               newMetricMongodbOperationLatencyTime(mbc.Metrics.MongodbOperationLatencyTime),
 		metricMongodbOperationReplCount:                 newMetricMongodbOperationReplCount(mbc.Metrics.MongodbOperationReplCount),
 		metricMongodbOperationTime:                      newMetricMongodbOperationTime(mbc.Metrics.MongodbOperationTime),
+		metricMongodbOplogLimit:                         newMetricMongodbOplogLimit(mbc.Metrics.MongodbOplogLimit),
+		metricMongodbOplogUsage:                         newMetricMongodbOplogUsage(mbc.Metrics.MongodbOplogUsage),
+		metricMongodbOplogWindow:                        newMetricMongodbOplogWindow(mbc.Metrics.MongodbOplogWindow),
 		metricMongodbPageFaults:                         newMetricMongodbPageFaults(mbc.Metrics.MongodbPageFaults),
 		metricMongodbQueriesRate:                        newMetricMongodbQueriesRate(mbc.Metrics.MongodbQueriesRate),
 		metricMongodbReplCommandsPerSec:                 newMetricMongodbReplCommandsPerSec(mbc.Metrics.MongodbReplCommandsPerSec),
@@ -4300,6 +4943,10 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMongodbReplInsertsPerSec:                  newMetricMongodbReplInsertsPerSec(mbc.Metrics.MongodbReplInsertsPerSec),
 		metricMongodbReplQueriesPerSec:                  newMetricMongodbReplQueriesPerSec(mbc.Metrics.MongodbReplQueriesPerSec),
 		metricMongodbReplUpdatesPerSec:                  newMetricMongodbReplUpdatesPerSec(mbc.Metrics.MongodbReplUpdatesPerSec),
+		metricMongodbReplicaStatus:                      newMetricMongodbReplicaStatus(mbc.Metrics.MongodbReplicaStatus),
+		metricMongodbReplicaSetHeadroom:                 newMetricMongodbReplicaSetHeadroom(mbc.Metrics.MongodbReplicaSetHeadroom),
+		metricMongodbReplicaSetLag:                      newMetricMongodbReplicaSetLag(mbc.Metrics.MongodbReplicaSetLag),
+		metricMongodbReplicaSetMemberCount:              newMetricMongodbReplicaSetMemberCount(mbc.Metrics.MongodbReplicaSetMemberCount),
 		metricMongodbSessionCount:                       newMetricMongodbSessionCount(mbc.Metrics.MongodbSessionCount),
 		metricMongodbStorageSize:                        newMetricMongodbStorageSize(mbc.Metrics.MongodbStorageSize),
 		metricMongodbUpdatesRate:                        newMetricMongodbUpdatesRate(mbc.Metrics.MongodbUpdatesRate),
@@ -4452,6 +5099,9 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMongodbOperationLatencyTime.emit(ils.Metrics())
 	mb.metricMongodbOperationReplCount.emit(ils.Metrics())
 	mb.metricMongodbOperationTime.emit(ils.Metrics())
+	mb.metricMongodbOplogLimit.emit(ils.Metrics())
+	mb.metricMongodbOplogUsage.emit(ils.Metrics())
+	mb.metricMongodbOplogWindow.emit(ils.Metrics())
 	mb.metricMongodbPageFaults.emit(ils.Metrics())
 	mb.metricMongodbQueriesRate.emit(ils.Metrics())
 	mb.metricMongodbReplCommandsPerSec.emit(ils.Metrics())
@@ -4460,6 +5110,10 @@ func (mb *MetricsBuilder) EmitForResource(options ...ResourceMetricsOption) {
 	mb.metricMongodbReplInsertsPerSec.emit(ils.Metrics())
 	mb.metricMongodbReplQueriesPerSec.emit(ils.Metrics())
 	mb.metricMongodbReplUpdatesPerSec.emit(ils.Metrics())
+	mb.metricMongodbReplicaStatus.emit(ils.Metrics())
+	mb.metricMongodbReplicaSetHeadroom.emit(ils.Metrics())
+	mb.metricMongodbReplicaSetLag.emit(ils.Metrics())
+	mb.metricMongodbReplicaSetMemberCount.emit(ils.Metrics())
 	mb.metricMongodbSessionCount.emit(ils.Metrics())
 	mb.metricMongodbStorageSize.emit(ils.Metrics())
 	mb.metricMongodbUpdatesRate.emit(ils.Metrics())
@@ -4671,6 +5325,21 @@ func (mb *MetricsBuilder) RecordMongodbOperationTimeDataPoint(ts pcommon.Timesta
 	mb.metricMongodbOperationTime.recordDataPoint(mb.startTime, ts, val, operationAttributeValue.String())
 }
 
+// RecordMongodbOplogLimitDataPoint adds a data point to mongodb.oplog.limit metric.
+func (mb *MetricsBuilder) RecordMongodbOplogLimitDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbOplogLimit.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbOplogUsageDataPoint adds a data point to mongodb.oplog.usage metric.
+func (mb *MetricsBuilder) RecordMongodbOplogUsageDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricMongodbOplogUsage.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbOplogWindowDataPoint adds a data point to mongodb.oplog.window metric.
+func (mb *MetricsBuilder) RecordMongodbOplogWindowDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricMongodbOplogWindow.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordMongodbPageFaultsDataPoint adds a data point to mongodb.page_faults metric.
 func (mb *MetricsBuilder) RecordMongodbPageFaultsDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricMongodbPageFaults.recordDataPoint(mb.startTime, ts, val)
@@ -4709,6 +5378,26 @@ func (mb *MetricsBuilder) RecordMongodbReplQueriesPerSecDataPoint(ts pcommon.Tim
 // RecordMongodbReplUpdatesPerSecDataPoint adds a data point to mongodb.repl_updates_per_sec metric.
 func (mb *MetricsBuilder) RecordMongodbReplUpdatesPerSecDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricMongodbReplUpdatesPerSec.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordMongodbReplicaStatusDataPoint adds a data point to mongodb.replica.status metric.
+func (mb *MetricsBuilder) RecordMongodbReplicaStatusDataPoint(ts pcommon.Timestamp, val int64, mongodbReplicaStateAttributeValue AttributeMongodbReplicaState) {
+	mb.metricMongodbReplicaStatus.recordDataPoint(mb.startTime, ts, val, mongodbReplicaStateAttributeValue.String())
+}
+
+// RecordMongodbReplicaSetHeadroomDataPoint adds a data point to mongodb.replica_set.headroom metric.
+func (mb *MetricsBuilder) RecordMongodbReplicaSetHeadroomDataPoint(ts pcommon.Timestamp, val float64, mongodbReplicaNameAttributeValue string) {
+	mb.metricMongodbReplicaSetHeadroom.recordDataPoint(mb.startTime, ts, val, mongodbReplicaNameAttributeValue)
+}
+
+// RecordMongodbReplicaSetLagDataPoint adds a data point to mongodb.replica_set.lag metric.
+func (mb *MetricsBuilder) RecordMongodbReplicaSetLagDataPoint(ts pcommon.Timestamp, val float64, mongodbReplicaNameAttributeValue string, mongodbReplicaSetLagTypeAttributeValue AttributeMongodbReplicaSetLagType) {
+	mb.metricMongodbReplicaSetLag.recordDataPoint(mb.startTime, ts, val, mongodbReplicaNameAttributeValue, mongodbReplicaSetLagTypeAttributeValue.String())
+}
+
+// RecordMongodbReplicaSetMemberCountDataPoint adds a data point to mongodb.replica_set.member.count metric.
+func (mb *MetricsBuilder) RecordMongodbReplicaSetMemberCountDataPoint(ts pcommon.Timestamp, val int64, mongodbReplicaStateAttributeValue AttributeMongodbReplicaState) {
+	mb.metricMongodbReplicaSetMemberCount.recordDataPoint(mb.startTime, ts, val, mongodbReplicaStateAttributeValue.String())
 }
 
 // RecordMongodbSessionCountDataPoint adds a data point to mongodb.session.count metric.

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
@@ -86,6 +86,10 @@ func TestMetricsBuilder(t *testing.T) {
 			aggMap["mongodb.operation.latency.time"] = mb.metricMongodbOperationLatencyTime.config.AggregationStrategy
 			aggMap["mongodb.operation.repl.count"] = mb.metricMongodbOperationReplCount.config.AggregationStrategy
 			aggMap["mongodb.operation.time"] = mb.metricMongodbOperationTime.config.AggregationStrategy
+			aggMap["mongodb.replica.status"] = mb.metricMongodbReplicaStatus.config.AggregationStrategy
+			aggMap["mongodb.replica_set.headroom"] = mb.metricMongodbReplicaSetHeadroom.config.AggregationStrategy
+			aggMap["mongodb.replica_set.lag"] = mb.metricMongodbReplicaSetLag.config.AggregationStrategy
+			aggMap["mongodb.replica_set.member.count"] = mb.metricMongodbReplicaSetMemberCount.config.AggregationStrategy
 			aggMap["mongodb.storage.size"] = mb.metricMongodbStorageSize.config.AggregationStrategy
 			aggMap["mongodb.wt.concurrent_transaction.ticket.in_use"] = mb.metricMongodbWtConcurrentTransactionTicketInUse.config.AggregationStrategy
 			aggMap["mongodb.wt.log.operation.count"] = mb.metricMongodbWtLogOperationCount.config.AggregationStrategy
@@ -258,6 +262,15 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 
 			allMetricsCount++
+			mb.RecordMongodbOplogLimitDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordMongodbOplogUsageDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordMongodbOplogWindowDataPoint(ts, 1)
+
+			allMetricsCount++
 			mb.RecordMongodbPageFaultsDataPoint(ts, 1)
 
 			allMetricsCount++
@@ -280,6 +293,30 @@ func TestMetricsBuilder(t *testing.T) {
 
 			allMetricsCount++
 			mb.RecordMongodbReplUpdatesPerSecDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordMongodbReplicaStatusDataPoint(ts, 1, AttributeMongodbReplicaStateStartup)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbReplicaStatusDataPoint(ts, 3, AttributeMongodbReplicaStatePrimary)
+			}
+
+			allMetricsCount++
+			mb.RecordMongodbReplicaSetHeadroomDataPoint(ts, 1, "mongodb.replica.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbReplicaSetHeadroomDataPoint(ts, 3, "mongodb.replica.name-val-2")
+			}
+
+			allMetricsCount++
+			mb.RecordMongodbReplicaSetLagDataPoint(ts, 1, "mongodb.replica.name-val", AttributeMongodbReplicaSetLagTypeApplied)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbReplicaSetLagDataPoint(ts, 3, "mongodb.replica.name-val-2", AttributeMongodbReplicaSetLagTypeDurable)
+			}
+
+			allMetricsCount++
+			mb.RecordMongodbReplicaSetMemberCountDataPoint(ts, 1, AttributeMongodbReplicaStateStartup)
+			if tt.name == "reaggregate_set" {
+				mb.RecordMongodbReplicaSetMemberCountDataPoint(ts, 3, AttributeMongodbReplicaStatePrimary)
+			}
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbSessionCountDataPoint(ts, 1)
@@ -349,6 +386,10 @@ func TestMetricsBuilder(t *testing.T) {
 				assert.Empty(t, mb.metricMongodbOperationLatencyTime.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbOperationReplCount.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbOperationTime.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbReplicaStatus.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbReplicaSetHeadroom.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbReplicaSetLag.aggDataPoints)
+				assert.Empty(t, mb.metricMongodbReplicaSetMemberCount.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbStorageSize.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbWtConcurrentTransactionTicketInUse.aggDataPoints)
 				assert.Empty(t, mb.metricMongodbWtLogOperationCount.aggDataPoints)
@@ -1469,6 +1510,46 @@ func TestMetricsBuilder(t *testing.T) {
 						_, ok := dp.Attributes().Get("operation")
 						assert.False(t, ok)
 					}
+				case "mongodb.oplog.limit":
+					assert.False(t, validatedMetrics["mongodb.oplog.limit"], "Found a duplicate in the metrics slice: mongodb.oplog.limit")
+					validatedMetrics["mongodb.oplog.limit"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The maximum amount of storage the oplog is allowed to use.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
+					assert.False(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "mongodb.oplog.usage":
+					assert.False(t, validatedMetrics["mongodb.oplog.usage"], "Found a duplicate in the metrics slice: mongodb.oplog.usage")
+					validatedMetrics["mongodb.oplog.usage"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+					assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+					assert.Equal(t, "The amount of storage the oplog is using.", mi.Description())
+					assert.Equal(t, "By", mi.Unit())
+					assert.False(t, mi.Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+					dp := mi.Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "mongodb.oplog.window":
+					assert.False(t, validatedMetrics["mongodb.oplog.window"], "Found a duplicate in the metrics slice: mongodb.oplog.window")
+					validatedMetrics["mongodb.oplog.window"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+					assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+					assert.Equal(t, "The time span between the oldest and the newest entry retained in the oplog.", mi.Description())
+					assert.Equal(t, "s", mi.Unit())
+					dp := mi.Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
 				case "mongodb.page_faults":
 					assert.False(t, validatedMetrics["mongodb.page_faults"], "Found a duplicate in the metrics slice: mongodb.page_faults")
 					validatedMetrics["mongodb.page_faults"] = true
@@ -1567,6 +1648,179 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+				case "mongodb.replica.status":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodb.replica.status"], "Found a duplicate in the metrics slice: mongodb.replica.status")
+						validatedMetrics["mongodb.replica.status"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The current state of the scraped replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						mongodbReplicaStateAttrVal, ok := dp.Attributes().Get("mongodb.replica.state")
+						assert.True(t, ok)
+						assert.Equal(t, "startup", mongodbReplicaStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodb.replica.status"], "Found a duplicate in the metrics slice: mongodb.replica.status")
+						validatedMetrics["mongodb.replica.status"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The current state of the scraped replica.", mi.Description())
+						assert.Equal(t, "1", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["mongodb.replica.status"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("mongodb.replica.state")
+						assert.False(t, ok)
+					}
+				case "mongodb.replica_set.headroom":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodb.replica_set.headroom"], "Found a duplicate in the metrics slice: mongodb.replica_set.headroom")
+						validatedMetrics["mongodb.replica_set.headroom"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The time margin a replica set member has before it falls off the end of the oplog.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						mongodbReplicaNameAttrVal, ok := dp.Attributes().Get("mongodb.replica.name")
+						assert.True(t, ok)
+						assert.Equal(t, "mongodb.replica.name-val", mongodbReplicaNameAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodb.replica_set.headroom"], "Found a duplicate in the metrics slice: mongodb.replica_set.headroom")
+						validatedMetrics["mongodb.replica_set.headroom"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The time margin a replica set member has before it falls off the end of the oplog.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodb.replica_set.headroom"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("mongodb.replica.name")
+						assert.False(t, ok)
+					}
+				case "mongodb.replica_set.lag":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodb.replica_set.lag"], "Found a duplicate in the metrics slice: mongodb.replica_set.lag")
+						validatedMetrics["mongodb.replica_set.lag"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The time a replica set member is behind the primary.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						mongodbReplicaNameAttrVal, ok := dp.Attributes().Get("mongodb.replica.name")
+						assert.True(t, ok)
+						assert.Equal(t, "mongodb.replica.name-val", mongodbReplicaNameAttrVal.Str())
+						mongodbReplicaSetLagTypeAttrVal, ok := dp.Attributes().Get("mongodb.replica_set.lag.type")
+						assert.True(t, ok)
+						assert.Equal(t, "applied", mongodbReplicaSetLagTypeAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodb.replica_set.lag"], "Found a duplicate in the metrics slice: mongodb.replica_set.lag")
+						validatedMetrics["mongodb.replica_set.lag"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, mi.Type())
+						assert.Equal(t, 1, mi.Gauge().DataPoints().Len())
+						assert.Equal(t, "The time a replica set member is behind the primary.", mi.Description())
+						assert.Equal(t, "s", mi.Unit())
+						dp := mi.Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+						switch aggMap["mongodb.replica_set.lag"] {
+						case "sum":
+							assert.InDelta(t, float64(4), dp.DoubleValue(), 0.01)
+						case "avg":
+							assert.InDelta(t, float64(2), dp.DoubleValue(), 0.01)
+						case "min":
+							assert.InDelta(t, float64(1), dp.DoubleValue(), 0.01)
+						case "max":
+							assert.InDelta(t, float64(3), dp.DoubleValue(), 0.01)
+						}
+						_, ok := dp.Attributes().Get("mongodb.replica.name")
+						assert.False(t, ok)
+						_, ok = dp.Attributes().Get("mongodb.replica_set.lag.type")
+						assert.False(t, ok)
+					}
+				case "mongodb.replica_set.member.count":
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["mongodb.replica_set.member.count"], "Found a duplicate in the metrics slice: mongodb.replica_set.member.count")
+						validatedMetrics["mongodb.replica_set.member.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of members in the replica set.", mi.Description())
+						assert.Equal(t, "{member}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						mongodbReplicaStateAttrVal, ok := dp.Attributes().Get("mongodb.replica.state")
+						assert.True(t, ok)
+						assert.Equal(t, "startup", mongodbReplicaStateAttrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["mongodb.replica_set.member.count"], "Found a duplicate in the metrics slice: mongodb.replica_set.member.count")
+						validatedMetrics["mongodb.replica_set.member.count"] = true
+						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
+						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
+						assert.Equal(t, "The number of members in the replica set.", mi.Description())
+						assert.Equal(t, "{member}", mi.Unit())
+						assert.False(t, mi.Sum().IsMonotonic())
+						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
+						dp := mi.Sum().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["mongodb.replica_set.member.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("mongodb.replica.state")
+						assert.False(t, ok)
+					}
 				case "mongodb.session.count":
 					assert.False(t, validatedMetrics["mongodb.session.count"], "Found a duplicate in the metrics slice: mongodb.session.count")
 					validatedMetrics["mongodb.session.count"] = true

--- a/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
@@ -88,6 +88,12 @@ all_set:
     mongodb.operation.time:
       enabled: true
       attributes: ["operation"]
+    mongodb.oplog.limit:
+      enabled: true
+    mongodb.oplog.usage:
+      enabled: true
+    mongodb.oplog.window:
+      enabled: true
     mongodb.page_faults:
       enabled: true
     mongodb.queries.rate:
@@ -104,6 +110,18 @@ all_set:
       enabled: true
     mongodb.repl_updates_per_sec:
       enabled: true
+    mongodb.replica.status:
+      enabled: true
+      attributes: ["mongodb.replica.state"]
+    mongodb.replica_set.headroom:
+      enabled: true
+      attributes: ["mongodb.replica.name"]
+    mongodb.replica_set.lag:
+      enabled: true
+      attributes: ["mongodb.replica.name","mongodb.replica_set.lag.type"]
+    mongodb.replica_set.member.count:
+      enabled: true
+      attributes: ["mongodb.replica.state"]
     mongodb.session.count:
       enabled: true
     mongodb.storage.size:
@@ -234,6 +252,12 @@ reaggregate_set:
     mongodb.operation.time:
       enabled: true
       attributes: []
+    mongodb.oplog.limit:
+      enabled: true
+    mongodb.oplog.usage:
+      enabled: true
+    mongodb.oplog.window:
+      enabled: true
     mongodb.page_faults:
       enabled: true
     mongodb.queries.rate:
@@ -250,6 +274,18 @@ reaggregate_set:
       enabled: true
     mongodb.repl_updates_per_sec:
       enabled: true
+    mongodb.replica.status:
+      enabled: true
+      attributes: []
+    mongodb.replica_set.headroom:
+      enabled: true
+      attributes: []
+    mongodb.replica_set.lag:
+      enabled: true
+      attributes: []
+    mongodb.replica_set.member.count:
+      enabled: true
+      attributes: []
     mongodb.session.count:
       enabled: true
     mongodb.storage.size:
@@ -380,6 +416,12 @@ none_set:
     mongodb.operation.time:
       enabled: false
       attributes: ["operation"]
+    mongodb.oplog.limit:
+      enabled: false
+    mongodb.oplog.usage:
+      enabled: false
+    mongodb.oplog.window:
+      enabled: false
     mongodb.page_faults:
       enabled: false
     mongodb.queries.rate:
@@ -396,6 +438,18 @@ none_set:
       enabled: false
     mongodb.repl_updates_per_sec:
       enabled: false
+    mongodb.replica.status:
+      enabled: false
+      attributes: ["mongodb.replica.state"]
+    mongodb.replica_set.headroom:
+      enabled: false
+      attributes: ["mongodb.replica.name"]
+    mongodb.replica_set.lag:
+      enabled: false
+      attributes: ["mongodb.replica.name","mongodb.replica_set.lag.type"]
+    mongodb.replica_set.member.count:
+      enabled: false
+      attributes: ["mongodb.replica.state"]
     mongodb.session.count:
       enabled: false
     mongodb.storage.size:

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -205,6 +205,32 @@ attributes:
   mongodb.query.truncated:
     description: Whether the value carried by db.query.text is a truncated rendering of the MongoDB command, as indicated by `$truncated` in the currentOp output.
     type: bool
+  mongodb.replica.name:
+    description: The name of the replica, in host:port form.
+    type: string
+    requirement_level: recommended
+  mongodb.replica.state:
+    description: The state of a replica within the replica set.
+    type: string
+    requirement_level: recommended
+    enum:
+      - startup
+      - primary
+      - secondary
+      - recovering
+      - startup2
+      - unknown
+      - arbiter
+      - down
+      - rollback
+      - removed
+  mongodb.replica_set.lag.type:
+    description: The replication progress that the lag is measured against.
+    type: string
+    requirement_level: recommended
+    enum:
+      - applied
+      - durable
   mongodb.wt.concurrent_transaction.ticket.type:
     description: The WiredTiger concurrent-transaction ticket type.
     type: string
@@ -646,6 +672,34 @@ metrics:
       aggregation_temporality: cumulative
       monotonic: true
     attributes: [operation]
+  mongodb.oplog.limit:
+    description: The maximum amount of storage the oplog is allowed to use.
+    stability: development
+    unit: By
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.oplog.usage:
+    description: The amount of storage the oplog is using.
+    stability: development
+    unit: By
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: []
+  mongodb.oplog.window:
+    description: The time span between the oldest and the newest entry retained in the oplog.
+    stability: development
+    unit: s
+    enabled: false
+    gauge:
+      value_type: double
+    attributes: []
   mongodb.page_faults:
     description: The number of page faults.
     stability: development
@@ -719,6 +773,43 @@ metrics:
       value_type: double
       aggregation_temporality: delta
       monotonic: false
+  mongodb.replica.status:
+    description: The current state of the scraped replica.
+    extended_documentation: A timeseries is produced for every possible state. The value is 1 for the state the instance is currently in, and 0 for all others.
+    stability: development
+    unit: "1"
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: [mongodb.replica.state]
+  mongodb.replica_set.headroom:
+    description: The time margin a replica set member has before it falls off the end of the oplog.
+    stability: development
+    unit: s
+    enabled: false
+    gauge:
+      value_type: double
+    attributes: [mongodb.replica.name]
+  mongodb.replica_set.lag:
+    description: The time a replica set member is behind the primary.
+    stability: development
+    unit: s
+    enabled: false
+    gauge:
+      value_type: double
+    attributes: [mongodb.replica.name, mongodb.replica_set.lag.type]
+  mongodb.replica_set.member.count:
+    description: The number of members in the replica set.
+    stability: development
+    unit: "{member}"
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    attributes: [mongodb.replica.state]
   mongodb.session.count:
     description: The total number of active sessions.
     stability: development

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -764,6 +764,191 @@ func (s *mongodbScraper) recordLockDeadlockCount(now pcommon.Timestamp, doc bson
 	}
 }
 
+// Replica Set and Oplog Stats
+const (
+	replicaSetMembersKey       = "members"
+	replicaSetMemberDurableKey = "lastDurableWallTime"
+	replicaSetMemberNameKey    = "name"
+	replicaSetMemberOptimeKey  = "optimeDate"
+	replicaSetMemberSelfKey    = "self"
+	replicaSetMemberStateKey   = "state"
+)
+
+// replicaSetMemberStates maps every member state MongoDB reports to its attribute value. The
+// numeric state is used rather than its string rendering, which MongoDB decorates for a member
+// it cannot reach ("(not reachable/healthy)" rather than "DOWN").
+var replicaSetMemberStates = map[int64]metadata.AttributeMongodbReplicaState{
+	0:  metadata.AttributeMongodbReplicaStateStartup,
+	1:  metadata.AttributeMongodbReplicaStatePrimary,
+	2:  metadata.AttributeMongodbReplicaStateSecondary,
+	3:  metadata.AttributeMongodbReplicaStateRecovering,
+	5:  metadata.AttributeMongodbReplicaStateStartup2,
+	6:  metadata.AttributeMongodbReplicaStateUnknown,
+	7:  metadata.AttributeMongodbReplicaStateArbiter,
+	8:  metadata.AttributeMongodbReplicaStateDown,
+	9:  metadata.AttributeMongodbReplicaStateRollback,
+	10: metadata.AttributeMongodbReplicaStateRemoved,
+}
+
+// replicaSetLag holds the replication lag of a single secondary, in seconds.
+type replicaSetLag struct {
+	member     string
+	applied    float64
+	durable    float64
+	hasDurable bool
+}
+
+func (s *mongodbScraper) recordOplogUsage(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
+	metricPath := []string{"storageStats", "size"}
+	metricName := "mongodb.oplog.usage"
+	val, err := collectMetric(doc, metricPath)
+	if err != nil {
+		errs.AddPartial(1, fmt.Errorf(collectMetricError, metricName, err))
+		return
+	}
+	s.mb.RecordMongodbOplogUsageDataPoint(now, val)
+}
+
+func (s *mongodbScraper) recordOplogLimit(now pcommon.Timestamp, doc bson.M, errs *scrapererror.ScrapeErrors) {
+	metricPath := []string{"storageStats", "maxSize"}
+	metricName := "mongodb.oplog.limit"
+	val, err := collectMetric(doc, metricPath)
+	if err != nil {
+		errs.AddPartial(1, fmt.Errorf(collectMetricError, metricName, err))
+		return
+	}
+	s.mb.RecordMongodbOplogLimitDataPoint(now, val)
+}
+
+// oplogWindowSeconds returns the time span the oplog covers. Only the seconds component of a
+// BSON timestamp carries wall-clock meaning; the ordinal disambiguates entries within a second.
+func oplogWindowSeconds(oldest, newest bson.Timestamp) float64 {
+	return float64(newest.T) - float64(oldest.T)
+}
+
+func (s *mongodbScraper) recordOplogWindow(now pcommon.Timestamp, oldest, newest bson.Timestamp) {
+	s.mb.RecordMongodbOplogWindowDataPoint(now, oplogWindowSeconds(oldest, newest))
+}
+
+// recordReplicaSetMemberCount emits a data point for every known state, so that a state no
+// member is in is reported as zero rather than as a missing series.
+func (s *mongodbScraper) recordReplicaSetMemberCount(now pcommon.Timestamp, members bson.A) {
+	counts := make(map[metadata.AttributeMongodbReplicaState]int64, len(replicaSetMemberStates))
+	for _, state := range replicaSetMemberStates {
+		counts[state] = 0
+	}
+	for _, member := range members {
+		if state, ok := replicaSetMemberStates[getInt64Value(member, replicaSetMemberStateKey)]; ok {
+			counts[state]++
+		}
+	}
+	for state, count := range counts {
+		s.mb.RecordMongodbReplicaSetMemberCountDataPoint(now, count, state)
+	}
+}
+
+// recordReplicaStatus emits a data point for every known state, valued 1 for the state
+// the scraped instance is currently in and 0 for the rest, so each state is its own timeseries.
+func (s *mongodbScraper) recordReplicaStatus(now pcommon.Timestamp, members bson.A, errs *scrapererror.ScrapeErrors) {
+	metricName := "mongodb.replica.status"
+	member, ok := replicaSetSelf(members)
+	if !ok {
+		errs.AddPartial(1, fmt.Errorf(collectMetricError, metricName, errKeyNotFound))
+		return
+	}
+	current, ok := replicaSetMemberStates[getInt64Value(member, replicaSetMemberStateKey)]
+	if !ok {
+		errs.AddPartial(1, fmt.Errorf(collectMetricError, metricName, errKeyNotFound))
+		return
+	}
+	for _, state := range replicaSetMemberStates {
+		var value int64
+		if state == current {
+			value = 1
+		}
+		s.mb.RecordMongodbReplicaStatusDataPoint(now, value, state)
+	}
+}
+
+func (s *mongodbScraper) recordReplicaSetLag(now pcommon.Timestamp, lags []replicaSetLag) {
+	for _, lag := range lags {
+		s.mb.RecordMongodbReplicaSetLagDataPoint(now, lag.applied, lag.member, metadata.AttributeMongodbReplicaSetLagTypeApplied)
+		if lag.hasDurable {
+			s.mb.RecordMongodbReplicaSetLagDataPoint(now, lag.durable, lag.member, metadata.AttributeMongodbReplicaSetLagTypeDurable)
+		}
+	}
+}
+
+func (s *mongodbScraper) recordReplicaSetHeadroom(now pcommon.Timestamp, lags []replicaSetLag, oplogWindow float64) {
+	for _, lag := range lags {
+		s.mb.RecordMongodbReplicaSetHeadroomDataPoint(now, oplogWindow-lag.applied, lag.member)
+	}
+}
+
+// replicaSetSelf returns the member the replica set status was read from.
+func replicaSetSelf(members bson.A) (any, bool) {
+	for _, member := range members {
+		if getValue[bool](member, replicaSetMemberSelfKey) {
+			return member, true
+		}
+	}
+	return nil, false
+}
+
+// replicaSetLags returns how far behind the primary every secondary is. It is only meaningful
+// on the primary, which is the only member holding an up-to-date view of the others' progress.
+func replicaSetLags(members bson.A) []replicaSetLag {
+	primary, ok := replicaSetMemberInState(members, metadata.AttributeMongodbReplicaStatePrimary)
+	if !ok {
+		return nil
+	}
+	primaryOptime, ok := replicaSetTimeMillis(primary, replicaSetMemberOptimeKey)
+	if !ok {
+		return nil
+	}
+	primaryDurable, primaryHasDurable := replicaSetTimeMillis(primary, replicaSetMemberDurableKey)
+
+	var lags []replicaSetLag
+	for _, member := range members {
+		if replicaSetMemberStates[getInt64Value(member, replicaSetMemberStateKey)] != metadata.AttributeMongodbReplicaStateSecondary {
+			continue
+		}
+		optime, ok := replicaSetTimeMillis(member, replicaSetMemberOptimeKey)
+		if !ok {
+			continue
+		}
+		lag := replicaSetLag{
+			member:  getValue[string](member, replicaSetMemberNameKey),
+			applied: float64(primaryOptime-optime) / 1000.0,
+		}
+		if durable, ok := replicaSetTimeMillis(member, replicaSetMemberDurableKey); ok && primaryHasDurable {
+			lag.durable = float64(primaryDurable-durable) / 1000.0
+			lag.hasDurable = true
+		}
+		lags = append(lags, lag)
+	}
+	return lags
+}
+
+func replicaSetMemberInState(members bson.A, state metadata.AttributeMongodbReplicaState) (any, bool) {
+	for _, member := range members {
+		if replicaSetMemberStates[getInt64Value(member, replicaSetMemberStateKey)] == state {
+			return member, true
+		}
+	}
+	return nil, false
+}
+
+// replicaSetTimeMillis returns the value of a BSON date field as milliseconds since the epoch.
+func replicaSetTimeMillis(member any, key string) (int64, bool) {
+	value, ok := lookup(member, key)
+	if !ok {
+		return 0, false
+	}
+	date, ok := value.(bson.DateTime)
+	return int64(date), ok
+}
+
 // Index Stats
 func (s *mongodbScraper) recordIndexAccess(now pcommon.Timestamp, documents []bson.M, dbName, collectionName string, errs *scrapererror.ScrapeErrors) {
 	metricName := "mongodb.index.access.count"

--- a/receiver/mongodbreceiver/metrics_test.go
+++ b/receiver/mongodbreceiver/metrics_test.go
@@ -7,14 +7,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/scraper/scrapererror"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver/internal/metadata"
+)
+
+const (
+	oplogOldestSecond = 1756425600
+	oplogNewestSecond = 1756512000
+	oplogWindow       = float64(oplogNewestSecond - oplogOldestSecond)
 )
 
 // findMetric returns the emitted metric with the given name, failing the test if absent.
@@ -251,4 +259,339 @@ func TestRecordWTMetricsNonWiredTiger(t *testing.T) {
 
 	md := s.mb.Emit()
 	require.Equal(t, 0, md.ResourceMetrics().Len())
+}
+
+// metricNames returns the names of every emitted metric.
+func metricNames(md pmetric.Metrics) []string {
+	var names []string
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		sms := md.ResourceMetrics().At(i).ScopeMetrics()
+		for j := 0; j < sms.Len(); j++ {
+			ms := sms.At(j).Metrics()
+			for k := 0; k < ms.Len(); k++ {
+				names = append(names, ms.At(k).Name())
+			}
+		}
+	}
+	return names
+}
+
+// newReplicaSetScraper builds a scraper with every replica set and oplog metric enabled.
+func newReplicaSetScraper(t *testing.T) *mongodbScraper {
+	t.Helper()
+	cfg := createDefaultConfig().(*Config)
+	metrics := &cfg.MetricsBuilderConfig.Metrics
+	metrics.MongodbOplogUsage.Enabled = true
+	metrics.MongodbOplogLimit.Enabled = true
+	metrics.MongodbOplogWindow.Enabled = true
+	metrics.MongodbReplicaSetHeadroom.Enabled = true
+	metrics.MongodbReplicaSetLag.Enabled = true
+	metrics.MongodbReplicaSetMemberCount.Enabled = true
+	metrics.MongodbReplicaStatus.Enabled = true
+	return newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
+}
+
+func loadReplicaSetMembers(t *testing.T) bson.A {
+	t.Helper()
+	status, err := loadTestFileAsMap("./testdata/replSetGetStatus.json")
+	require.NoError(t, err)
+	members, ok := status[replicaSetMembersKey].(bson.A)
+	require.True(t, ok)
+	return members
+}
+
+func TestRecordOplogUsage(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	doc, err := loadTestFileAsMap("./testdata/oplogStats.json")
+	require.NoError(t, err)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordOplogUsage(now, doc, errs)
+	s.recordOplogLimit(now, doc, errs)
+	require.NoError(t, errs.Combine())
+
+	emitted := s.mb.Emit()
+	usage := findMetric(t, emitted, "mongodb.oplog.usage")
+	require.Equal(t, pmetric.MetricTypeSum, usage.Type())
+	require.False(t, usage.Sum().IsMonotonic())
+	require.Equal(t, 1, usage.Sum().DataPoints().Len())
+	require.Equal(t, int64(1073741824), usage.Sum().DataPoints().At(0).IntValue())
+
+	limit := findMetric(t, emitted, "mongodb.oplog.limit")
+	require.Equal(t, 1, limit.Sum().DataPoints().Len())
+	require.Equal(t, int64(2147483648), limit.Sum().DataPoints().At(0).IntValue())
+}
+
+func TestRecordOplogWindow(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordOplogWindow(now, bson.Timestamp{T: oplogOldestSecond, I: 1}, bson.Timestamp{T: oplogNewestSecond, I: 4})
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.oplog.window")
+	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
+	require.Equal(t, 1, m.Gauge().DataPoints().Len())
+	require.InDelta(t, oplogWindow, m.Gauge().DataPoints().At(0).DoubleValue(), 0)
+}
+
+func TestRecordReplicaSetMemberCount(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	members := loadReplicaSetMembers(t)
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordReplicaSetMemberCount(now, members)
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.replica_set.member.count")
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	require.False(t, m.Sum().IsMonotonic())
+
+	dps := m.Sum().DataPoints()
+	// Every known state is reported, so a state no member is in reads as zero.
+	require.Equal(t, len(replicaSetMemberStates), dps.Len())
+	counts := map[string]int64{}
+	for i := 0; i < dps.Len(); i++ {
+		state, ok := dps.At(i).Attributes().Get("mongodb.replica.state")
+		require.True(t, ok)
+		counts[state.Str()] = dps.At(i).IntValue()
+	}
+	require.Equal(t, int64(1), counts[metadata.AttributeMongodbReplicaStatePrimary.String()])
+	require.Equal(t, int64(1), counts[metadata.AttributeMongodbReplicaStateSecondary.String()])
+	require.Equal(t, int64(1), counts[metadata.AttributeMongodbReplicaStateArbiter.String()])
+	require.Equal(t, int64(0), counts[metadata.AttributeMongodbReplicaStateDown.String()])
+}
+
+func TestRecordReplicaSetMemberCountUnreachableMember(t *testing.T) {
+	// MongoDB renders the state of a member it cannot reach as "(not reachable/healthy)" rather
+	// than "DOWN", so the member state must be read from the numeric field.
+	s := newReplicaSetScraper(t)
+	members := bson.A{
+		bson.D{
+			bson.E{Key: replicaSetMemberNameKey, Value: "mongo-0:27017"},
+			bson.E{Key: replicaSetMemberStateKey, Value: int32(1)},
+			bson.E{Key: "stateStr", Value: "PRIMARY"},
+		},
+		bson.D{
+			bson.E{Key: replicaSetMemberNameKey, Value: "mongo-1:27017"},
+			bson.E{Key: replicaSetMemberStateKey, Value: int32(8)},
+			bson.E{Key: "stateStr", Value: "(not reachable/healthy)"},
+		},
+	}
+
+	s.recordReplicaSetMemberCount(pcommon.NewTimestampFromTime(time.Now()), members)
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.replica_set.member.count")
+	dps := m.Sum().DataPoints()
+	counts := map[string]int64{}
+	total := int64(0)
+	for i := 0; i < dps.Len(); i++ {
+		state, ok := dps.At(i).Attributes().Get("mongodb.replica.state")
+		require.True(t, ok)
+		counts[state.Str()] = dps.At(i).IntValue()
+		total += dps.At(i).IntValue()
+	}
+	require.Equal(t, int64(1), counts[metadata.AttributeMongodbReplicaStateDown.String()])
+	require.Equal(t, int64(1), counts[metadata.AttributeMongodbReplicaStatePrimary.String()])
+	// Every member is accounted for; none is dropped by an unrecognized state rendering.
+	require.Equal(t, int64(len(members)), total)
+}
+
+func TestRecordReplicaStatus(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	members := loadReplicaSetMembers(t)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordReplicaStatus(now, members, errs)
+	require.NoError(t, errs.Combine())
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.replica.status")
+	require.Equal(t, pmetric.MetricTypeSum, m.Type())
+	require.False(t, m.Sum().IsMonotonic())
+
+	// A timeseries is produced for every state: 1 for the instance's current state, 0 for the rest.
+	dps := m.Sum().DataPoints()
+	require.Equal(t, len(replicaSetMemberStates), dps.Len())
+	values := map[string]int64{}
+	for i := 0; i < dps.Len(); i++ {
+		state, ok := dps.At(i).Attributes().Get("mongodb.replica.state")
+		require.True(t, ok)
+		values[state.Str()] = dps.At(i).IntValue()
+	}
+	require.Equal(t, int64(1), values[metadata.AttributeMongodbReplicaStatePrimary.String()])
+	require.Equal(t, int64(0), values[metadata.AttributeMongodbReplicaStateSecondary.String()])
+	require.Equal(t, int64(0), values[metadata.AttributeMongodbReplicaStateDown.String()])
+	var total int64
+	for _, v := range values {
+		total += v
+	}
+	require.Equal(t, int64(1), total, "exactly one state may be set to 1")
+}
+
+func TestRecordReplicaStatusWithoutSelf(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	errs := &scrapererror.ScrapeErrors{}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordReplicaStatus(now, bson.A{bson.D{bson.E{Key: replicaSetMemberStateKey, Value: int32(1)}}}, errs)
+
+	require.Error(t, errs.Combine())
+	require.Empty(t, metricNames(s.mb.Emit()))
+}
+
+func TestRecordReplicaSetLag(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	members := loadReplicaSetMembers(t)
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordReplicaSetLag(now, replicaSetLags(members))
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.replica_set.lag")
+	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
+	dps := m.Gauge().DataPoints()
+	require.Equal(t, 2, dps.Len())
+
+	lags := map[string]float64{}
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		member, ok := dp.Attributes().Get("mongodb.replica.name")
+		require.True(t, ok)
+		lagType, ok := dp.Attributes().Get("mongodb.replica_set.lag.type")
+		require.True(t, ok)
+		lags[member.Str()+"/"+lagType.Str()] = dp.DoubleValue()
+	}
+	require.Equal(t, map[string]float64{
+		"mongo-1:27017/" + metadata.AttributeMongodbReplicaSetLagTypeApplied.String(): 1.5,
+		"mongo-1:27017/" + metadata.AttributeMongodbReplicaSetLagTypeDurable.String(): 3,
+	}, lags)
+}
+
+func TestRecordReplicaSetLagWithoutDurableTime(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	members := bson.A{
+		bson.D{
+			bson.E{Key: replicaSetMemberNameKey, Value: "mongo-0:27017"},
+			bson.E{Key: replicaSetMemberStateKey, Value: int32(1)},
+			bson.E{Key: replicaSetMemberOptimeKey, Value: bson.DateTime(1756512000000)},
+		},
+		bson.D{
+			bson.E{Key: replicaSetMemberNameKey, Value: "mongo-1:27017"},
+			bson.E{Key: replicaSetMemberStateKey, Value: int32(2)},
+			bson.E{Key: replicaSetMemberOptimeKey, Value: bson.DateTime(1756511998500)},
+		},
+	}
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordReplicaSetLag(now, replicaSetLags(members))
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.replica_set.lag")
+	require.Equal(t, 1, m.Gauge().DataPoints().Len())
+	lagType, ok := m.Gauge().DataPoints().At(0).Attributes().Get("mongodb.replica_set.lag.type")
+	require.True(t, ok)
+	require.Equal(t, metadata.AttributeMongodbReplicaSetLagTypeApplied.String(), lagType.Str())
+}
+
+func TestRecordReplicaSetHeadroom(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	members := loadReplicaSetMembers(t)
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	s.recordReplicaSetHeadroom(now, replicaSetLags(members), oplogWindow)
+
+	m := findMetric(t, s.mb.Emit(), "mongodb.replica_set.headroom")
+	require.Equal(t, pmetric.MetricTypeGauge, m.Type())
+	require.Equal(t, 1, m.Gauge().DataPoints().Len())
+	dp := m.Gauge().DataPoints().At(0)
+	require.InDelta(t, oplogWindow-1.5, dp.DoubleValue(), 0)
+	member, ok := dp.Attributes().Get("mongodb.replica.name")
+	require.True(t, ok)
+	require.Equal(t, "mongo-1:27017", member.Str())
+}
+
+func TestCollectReplicaSetMetrics(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	status, err := loadTestFileAsMap("./testdata/replSetGetStatus.json")
+	require.NoError(t, err)
+	oplogStats, err := loadTestFileAsMap("./testdata/oplogStats.json")
+	require.NoError(t, err)
+
+	fc := &fakeClient{}
+	fc.On("OplogStats", mock.Anything).Return(oplogStats, nil)
+	fc.On("OplogBounds", mock.Anything).
+		Return(bson.Timestamp{T: oplogOldestSecond}, bson.Timestamp{T: oplogNewestSecond}, nil)
+	fc.On("RunCommand", mock.Anything, adminDatabase, bson.M{replSetGetStatusCommand: 1}).Return(status, nil)
+	s.client = fc
+
+	errs := &scrapererror.ScrapeErrors{}
+	s.collectReplicaSetMetrics(t.Context(), pcommon.NewTimestampFromTime(time.Now()), errs)
+	require.NoError(t, errs.Combine())
+
+	require.ElementsMatch(t, []string{
+		"mongodb.oplog.limit",
+		"mongodb.oplog.usage",
+		"mongodb.oplog.window",
+		"mongodb.replica_set.headroom",
+		"mongodb.replica_set.lag",
+		"mongodb.replica_set.member.count",
+		"mongodb.replica.status",
+	}, metricNames(s.mb.Emit()))
+}
+
+func TestCollectReplicaSetMetricsOnSecondary(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	status, err := loadTestFileAsMap("./testdata/replSetGetStatusSecondary.json")
+	require.NoError(t, err)
+	oplogStats, err := loadTestFileAsMap("./testdata/oplogStats.json")
+	require.NoError(t, err)
+
+	fc := &fakeClient{}
+	fc.On("OplogStats", mock.Anything).Return(oplogStats, nil)
+	fc.On("OplogBounds", mock.Anything).
+		Return(bson.Timestamp{T: oplogOldestSecond}, bson.Timestamp{T: oplogNewestSecond}, nil)
+	fc.On("RunCommand", mock.Anything, adminDatabase, bson.M{replSetGetStatusCommand: 1}).Return(status, nil)
+	s.client = fc
+
+	errs := &scrapererror.ScrapeErrors{}
+	s.collectReplicaSetMetrics(t.Context(), pcommon.NewTimestampFromTime(time.Now()), errs)
+	require.NoError(t, errs.Combine())
+
+	// Lag and headroom are only reported by the primary.
+	require.ElementsMatch(t, []string{
+		"mongodb.oplog.limit",
+		"mongodb.oplog.usage",
+		"mongodb.oplog.window",
+		"mongodb.replica_set.member.count",
+		"mongodb.replica.status",
+	}, metricNames(s.mb.Emit()))
+}
+
+func TestCollectReplicaSetMetricsWithoutReplication(t *testing.T) {
+	s := newReplicaSetScraper(t)
+	noReplication := mongo.CommandError{Code: 76, Name: "NoReplicationEnabled", Message: "not running with --replSet"}
+
+	fc := &fakeClient{}
+	fc.On("OplogStats", mock.Anything).Return(nil, noReplication)
+	fc.On("OplogBounds", mock.Anything).Return(bson.Timestamp{}, bson.Timestamp{}, mongo.ErrNoDocuments)
+	fc.On("RunCommand", mock.Anything, adminDatabase, bson.M{replSetGetStatusCommand: 1}).Return(nil, noReplication)
+	s.client = fc
+
+	errs := &scrapererror.ScrapeErrors{}
+	s.collectReplicaSetMetrics(t.Context(), pcommon.NewTimestampFromTime(time.Now()), errs)
+
+	// A standalone or a mongos exposes no replica set state; the scrape must not fail over it.
+	require.NoError(t, errs.Combine())
+	require.Empty(t, metricNames(s.mb.Emit()))
+}
+
+func TestCollectReplicaSetMetricsDisabled(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	s := newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
+	// The mock has no expectations, so it fails the test if any command is issued.
+	s.client = &fakeClient{}
+
+	errs := &scrapererror.ScrapeErrors{}
+	s.collectReplicaSetMetrics(t.Context(), pcommon.NewTimestampFromTime(time.Now()), errs)
+
+	require.NoError(t, errs.Combine())
+	require.Empty(t, metricNames(s.mb.Emit()))
 }

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,8 @@ var (
 )
 
 const (
+	adminDatabase               = "admin"
+	replSetGetStatusCommand     = "replSetGetStatus"
 	defaultServiceName          = "unknown_service:mongodb"
 	namespaceKey                = "ns"
 	commandKey                  = "command"
@@ -569,6 +572,7 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.
 	s.mb.RecordMongodbDatabaseCountDataPoint(now, int64(len(dbNames)))
 	s.recordAdminStats(now, serverStatus, errs)
 	s.collectTopStats(ctx, now, errs)
+	s.collectReplicaSetMetrics(ctx, now, errs)
 
 	// Collect metrics for each database
 	for _, dbName := range dbNames {
@@ -613,6 +617,127 @@ func (s *mongodbScraper) collectTopStats(ctx context.Context, now pcommon.Timest
 		return
 	}
 	s.recordOperationTime(now, topStats, errs)
+}
+
+// replicationUnavailableCodes are the server error codes returned when the deployment does not
+// expose replica set state: a standalone mongod, a mongos router, a member whose replica set has
+// not been initiated, or a deployment such as MongoDB Atlas that restricts access to the local
+// database.
+var replicationUnavailableCodes = []int{
+	13, // Unauthorized
+	26, // NamespaceNotFound
+	59, // CommandNotFound
+	76, // NoReplicationEnabled
+	94, // NotYetInitialized
+}
+
+func isReplicationUnavailable(err error) bool {
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return true
+	}
+	var srvErr mongo.ServerError
+	if !errors.As(err, &srvErr) {
+		return false
+	}
+	return slices.ContainsFunc(replicationUnavailableCodes, srvErr.HasErrorCode)
+}
+
+// reportReplicationError records err as a partial scrape failure, unless it only means the
+// deployment does not expose replica set state, in which case the metrics are skipped.
+func (s *mongodbScraper) reportReplicationError(err error, message string, failed int, errs *scrapererror.ScrapeErrors) {
+	if isReplicationUnavailable(err) {
+		s.logger.Debug(message, zap.Error(err))
+		return
+	}
+	errs.AddPartial(failed, fmt.Errorf("%s: %w", message, err))
+}
+
+func (s *mongodbScraper) collectReplicaSetMetrics(ctx context.Context, now pcommon.Timestamp, errs *scrapererror.ScrapeErrors) {
+	metrics := s.config.MetricsBuilderConfig.Metrics
+
+	if metrics.MongodbOplogUsage.Enabled || metrics.MongodbOplogLimit.Enabled {
+		s.collectOplogStats(ctx, now, errs)
+	}
+
+	var oplogWindow float64
+	var hasOplogWindow bool
+	if metrics.MongodbOplogWindow.Enabled || metrics.MongodbReplicaSetHeadroom.Enabled {
+		oplogWindow, hasOplogWindow = s.collectOplogWindow(ctx, now, errs)
+	}
+
+	if metrics.MongodbReplicaSetHeadroom.Enabled || metrics.MongodbReplicaSetLag.Enabled ||
+		metrics.MongodbReplicaSetMemberCount.Enabled || metrics.MongodbReplicaStatus.Enabled {
+		s.collectReplicaSetStatus(ctx, now, oplogWindow, hasOplogWindow, errs)
+	}
+}
+
+func (s *mongodbScraper) collectOplogStats(ctx context.Context, now pcommon.Timestamp, errs *scrapererror.ScrapeErrors) {
+	oplogStats, err := s.client.OplogStats(ctx)
+	if err != nil {
+		s.reportReplicationError(err, "failed to fetch oplog stats metrics", 2, errs)
+		return
+	}
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbOplogUsage.Enabled {
+		s.recordOplogUsage(now, oplogStats, errs)
+	}
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbOplogLimit.Enabled {
+		s.recordOplogLimit(now, oplogStats, errs)
+	}
+}
+
+// collectOplogWindow returns the time span the oplog covers, which mongodb.replica_set.headroom
+// is measured against.
+func (s *mongodbScraper) collectOplogWindow(ctx context.Context, now pcommon.Timestamp, errs *scrapererror.ScrapeErrors) (float64, bool) {
+	oldest, newest, err := s.client.OplogBounds(ctx)
+	if err != nil {
+		s.reportReplicationError(err, "failed to fetch oplog window metrics", 1, errs)
+		return 0, false
+	}
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbOplogWindow.Enabled {
+		s.recordOplogWindow(now, oldest, newest)
+	}
+	return oplogWindowSeconds(oldest, newest), true
+}
+
+func (s *mongodbScraper) collectReplicaSetStatus(ctx context.Context, now pcommon.Timestamp, oplogWindow float64, hasOplogWindow bool, errs *scrapererror.ScrapeErrors) {
+	status, err := s.client.RunCommand(ctx, adminDatabase, bson.M{replSetGetStatusCommand: 1})
+	if err != nil {
+		s.reportReplicationError(err, "failed to fetch replica set status metrics", 4, errs)
+		return
+	}
+
+	members, ok := status[replicaSetMembersKey].(bson.A)
+	if !ok {
+		errs.AddPartial(4, fmt.Errorf("failed to fetch replica set members: expected %T, got %T", bson.A{}, status[replicaSetMembersKey]))
+		return
+	}
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbReplicaSetMemberCount.Enabled {
+		s.recordReplicaSetMemberCount(now, members)
+	}
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbReplicaStatus.Enabled {
+		s.recordReplicaStatus(now, members, errs)
+	}
+
+	// Lag and headroom are only reported by the primary. A secondary sees the other members
+	// through heartbeats, so its view of their progress trails the primary's.
+	self, ok := replicaSetSelf(members)
+	if !ok || replicaSetMemberStates[getInt64Value(self, replicaSetMemberStateKey)] != metadata.AttributeMongodbReplicaStatePrimary {
+		return
+	}
+	lags := replicaSetLags(members)
+
+	if s.config.MetricsBuilderConfig.Metrics.MongodbReplicaSetLag.Enabled {
+		s.recordReplicaSetLag(now, lags)
+	}
+
+	if hasOplogWindow && s.config.MetricsBuilderConfig.Metrics.MongodbReplicaSetHeadroom.Enabled {
+		s.recordReplicaSetHeadroom(now, lags, oplogWindow)
+	}
 }
 
 func (s *mongodbScraper) collectIndexStats(ctx context.Context, now pcommon.Timestamp, databaseName, collectionName string, errs *scrapererror.ScrapeErrors) {
@@ -801,13 +926,13 @@ func serverAddressAndPort(serverStatus bson.M) (string, int64, error) {
 }
 
 func (s *mongodbScraper) findSecondaryHosts(ctx context.Context) ([]string, error) {
-	result, err := s.client.RunCommand(ctx, "admin", bson.M{"replSetGetStatus": 1})
+	result, err := s.client.RunCommand(ctx, adminDatabase, bson.M{replSetGetStatusCommand: 1})
 	if err != nil {
 		s.logger.Error("Failed to get replica set status", zap.Error(err))
 		return nil, fmt.Errorf("failed to get replica set status: %w", err)
 	}
 
-	members, ok := result["members"].(bson.A)
+	members, ok := result[replicaSetMembersKey].(bson.A)
 	if !ok {
 		return nil, fmt.Errorf("invalid members format: expected type primitive.A but got %T, value: %v", result["members"], result["members"])
 	}

--- a/receiver/mongodbreceiver/testdata/oplogStats.json
+++ b/receiver/mongodbreceiver/testdata/oplogStats.json
@@ -1,0 +1,11 @@
+{
+	"ns": "local.oplog.rs",
+	"storageStats": {
+		"size": {
+			"$numberLong": "1073741824"
+		},
+		"maxSize": {
+			"$numberLong": "2147483648"
+		}
+	}
+}

--- a/receiver/mongodbreceiver/testdata/replSetGetStatus.json
+++ b/receiver/mongodbreceiver/testdata/replSetGetStatus.json
@@ -1,0 +1,62 @@
+{
+	"set": "rs0",
+	"myState": {
+		"$numberInt": "1"
+	},
+	"members": [
+		{
+			"_id": {
+				"$numberInt": "0"
+			},
+			"name": "mongo-0:27017",
+			"state": {
+				"$numberInt": "1"
+			},
+			"stateStr": "PRIMARY",
+			"self": true,
+			"optimeDate": {
+				"$date": {
+					"$numberLong": "1756512000000"
+				}
+			},
+			"lastDurableWallTime": {
+				"$date": {
+					"$numberLong": "1756512000000"
+				}
+			}
+		},
+		{
+			"_id": {
+				"$numberInt": "1"
+			},
+			"name": "mongo-1:27017",
+			"state": {
+				"$numberInt": "2"
+			},
+			"stateStr": "SECONDARY",
+			"optimeDate": {
+				"$date": {
+					"$numberLong": "1756511998500"
+				}
+			},
+			"lastDurableWallTime": {
+				"$date": {
+					"$numberLong": "1756511997000"
+				}
+			}
+		},
+		{
+			"_id": {
+				"$numberInt": "2"
+			},
+			"name": "mongo-2:27017",
+			"state": {
+				"$numberInt": "7"
+			},
+			"stateStr": "ARBITER"
+		}
+	],
+	"ok": {
+		"$numberDouble": "1.0"
+	}
+}

--- a/receiver/mongodbreceiver/testdata/replSetGetStatusSecondary.json
+++ b/receiver/mongodbreceiver/testdata/replSetGetStatusSecondary.json
@@ -1,0 +1,52 @@
+{
+	"set": "rs0",
+	"myState": {
+		"$numberInt": "2"
+	},
+	"members": [
+		{
+			"_id": {
+				"$numberInt": "0"
+			},
+			"name": "mongo-0:27017",
+			"state": {
+				"$numberInt": "1"
+			},
+			"stateStr": "PRIMARY",
+			"optimeDate": {
+				"$date": {
+					"$numberLong": "1756512000000"
+				}
+			},
+			"lastDurableWallTime": {
+				"$date": {
+					"$numberLong": "1756512000000"
+				}
+			}
+		},
+		{
+			"_id": {
+				"$numberInt": "1"
+			},
+			"name": "mongo-1:27017",
+			"state": {
+				"$numberInt": "2"
+			},
+			"stateStr": "SECONDARY",
+			"self": true,
+			"optimeDate": {
+				"$date": {
+					"$numberLong": "1756511998500"
+				}
+			},
+			"lastDurableWallTime": {
+				"$date": {
+					"$numberLong": "1756511997000"
+				}
+			}
+		}
+	],
+	"ok": {
+		"$numberDouble": "1.0"
+	}
+}


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The MongoDB receiver has no view of replication health. The `mongodb.operation.repl.count` and
`mongodb.repl_*_per_sec` families cover replicated **operation counters** only, so nothing collected
today tells an operator how far a secondary is behind, how much oplog history is retained, or which
members currently make up the replica set. Those are the first questions asked during a replication
incident, and none of them can be reconstructed from the existing metrics.

This change adds **7 new opt-in metrics** (disabled by default, `stability: development`) covering
oplog capacity and retention, per-member replication lag and oplog headroom, replica set membership,
and the scraped replica's own state.

| # | Metric | Type | Unit | Attributes | DP/scrape |
|---|---|---|---|---|---|
| 1 | `mongodb.oplog.usage` | Sum (int, non-monotonic) | `By` | — | 1 |
| 2 | `mongodb.oplog.limit` | Sum (int, non-monotonic) | `By` | — | 1 |
| 3 | `mongodb.oplog.window` | Gauge (double) | `s` | — | 1 |
| 4 | `mongodb.replica.status` | Sum (int, non-monotonic) | `1` | `mongodb.replica.state` | **10** |
| 5 | `mongodb.replica_set.member.count` | Sum (int, non-monotonic) | `{member}` | `mongodb.replica.state` | **10** |
| 6 | `mongodb.replica_set.lag` | Gauge (double) | `s` | `mongodb.replica.name`, `mongodb.replica_set.lag.type` | **2 × S** |
| 7 | `mongodb.replica_set.headroom` | Gauge (double) | `s` | `mongodb.replica.name` | **1 × S** |

**Totals: 7 metrics · `23 + 3S` data points per scrape**, where **S = number of members in state
`SECONDARY`**. For a 3-member set with 2 secondaries: 29 data points.

Three receiver-specific attributes are introduced:

- `mongodb.replica.name` — the replica, in `host:port` form.
- `mongodb.replica.state` — the ten states MongoDB reports for a member. Shared by
  `mongodb.replica.status` and `mongodb.replica_set.member.count`.
- `mongodb.replica_set.lag.type` — `applied` (how far behind the member is in applying operations)
  and `durable` (how far behind it is in making them durable).

**Naming follows the scope each metric describes.** `mongodb.replica.status` reports the scraped
replica's own state, so the resource identifies which replica and the metric is replica-scoped. The
lag, headroom, and member-count metrics describe the replica set as a whole and *select* a replica
through the `mongodb.replica.name` attribute, so they stay `replica_set`-scoped.

The oplog pair follows the `usage`/`limit` convention used by `system.memory.usage` and
`system.memory.limit`. `mongodb.replica.status` follows the
[status-metric convention](https://opentelemetry.io/docs/specs/semconv/how-to-write-conventions/status-metrics/):
the metric carries the "status" noun while the attribute carries "state", it is an UpDownCounter with
unit `1`, and **a timeseries is produced for every state** — valued 1 for the state the replica is in
and 0 for the rest, so each state is independently alertable.

`mongodb.replica_set.member.count` likewise emits a data point for **every** state on every scrape, so
a state no member is in reads as `0` rather than as a missing series. "Zero primaries" is the single
most important replication alert and it must be expressible as a threshold, not as an absent-series
check.

**Member state is read from the numeric `state` field, not `stateStr`.** MongoDB renders the state of
a member it cannot reach as `"(not reachable/healthy)"` rather than `"DOWN"`, so keying on the string
silently drops that member from `mongodb.replica_set.member.count` — exactly when the metric matters
most. The numeric field is stable across those renderings.

**Cost and topology gating.** Unlike most of this receiver's metrics, these are not read from the
`serverStatus` document already fetched on every scrape, so they need additional commands. Those
commands are issued **only when at least one of the seven metrics is enabled** — the default
configuration adds no load. They are skipped, without failing the scrape, wherever replica set state
is not exposed: a standalone `mongod`, a `mongos` router, or a set that has not been initiated. An
`Unauthorized` response is not skipped: it means the user lacks the `clusterMonitor` role, so it is
reported as a partial scrape error counting only the enabled metrics that the failed read feeds.

**Lag and headroom are reported only by the primary.** A secondary learns the other members' progress
through heartbeats, so its view of them trails the primary's. Scraping a secondary still yields the
oplog metrics, `mongodb.replica.status`, and `mongodb.replica_set.member.count`.

**Why `mongodb.replica_set.headroom` is computed in the receiver.** It is the oplog window minus a
member's applied lag — the time margin before that member falls off the end of the oplog and needs a
resync, which is the question the two inputs exist to answer. Computing it downstream means joining
`mongodb.oplog.window` (no member attribute) against `mongodb.replica_set.lag` (per member, per lag
type) in every dashboard and alert; the attribute sets do not line up, so the join is awkward in most
backends.

These metrics can be enabled in the collector configuration:

```yaml
receivers:
  mongodb:
    hosts:
      - endpoint: localhost:27017
    metrics:
      mongodb.oplog.usage:
        enabled: true
      mongodb.oplog.limit:
        enabled: true
      mongodb.oplog.window:
        enabled: true
      mongodb.replica.status:
        enabled: true
      mongodb.replica_set.member.count:
        enabled: true
      mongodb.replica_set.lag:
        enabled: true
      mongodb.replica_set.headroom:
        enabled: true
```

Reading replica set status and the oplog requires the `clusterMonitor` role, which the receiver
README already documents as the expected monitoring role.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50654

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests added to `metrics_test.go`, driving the record functions and the collection path through
the metrics builder:

- `TestRecordOplogUsage` — asserts the oplog usage and its limit, and that both are non-monotonic Sums.
- `TestRecordOplogWindow` — asserts the window derived from the oldest and newest oplog entry.
- `TestRecordReplicaStatus` — asserts a data point for **every** state, `1` for the replica's current
  state, `0` for the rest, and that exactly one series is set.
- `TestRecordReplicaStatusWithoutSelf` — asserts a partial error and no data points when the scraped
  replica cannot be identified among the members.
- `TestRecordReplicaSetMemberCount` — asserts a data point for every state, with the states present
  in the fixture counted and the absent ones reported as `0`.
- `TestRecordReplicaSetMemberCountUnreachableMember` — asserts a member reported as `state: 8` with
  `stateStr: "(not reachable/healthy)"` is counted as `down`, and that no member is dropped.
- `TestRecordReplicaSetLag` — asserts both lag types for the secondary (`applied` 1.5 s from a
  1,500 ms difference, `durable` 3 s from a 3,000 ms difference).
- `TestRecordReplicaSetLagWithoutDurableTime` — asserts the `applied` data point still emits when the
  durable timestamp is absent.
- `TestRecordReplicaSetHeadroom` — asserts the window-minus-lag value and its member attribute.
- `TestCollectReplicaSetMetrics` — end-to-end over a mocked client on a primary; all seven metrics emit.
- `TestCollectReplicaSetMetricsOnSecondary` — the same fixture scraped from a secondary; lag and
  headroom do not emit, everything else does.
- `TestCollectReplicaSetMetricsWithoutReplication` — a `NoReplicationEnabled` error and an empty oplog
  produce **no scrape error** and no data points.
- `TestCollectReplicaSetMetricsDisabled` — with the default configuration, the mocked client has no
  expectations set, so the test fails if any command is issued.

New fixtures `testdata/replSetGetStatus.json`, `testdata/replSetGetStatusSecondary.json`, and
`testdata/oplogStats.json`. Auto-generated tests in `internal/metadata/generated_metrics_test.go` and
`generated_config_test.go` cover the new metric configs and builders. Existing tests pass unchanged —
the new metrics are disabled by default, so no existing scrape path is affected.

Additionally verified end-to-end against a live 3-member replica set (MongoDB 7.0, Docker): all seven
metrics emit with the expected cardinality, a secondary emits five of the seven, a standalone emits
none without raising a scrape error, and pausing a member moved
`mongodb.replica_set.member.count{state=down}` from 0 to 1.

<!--Describe the documentation added.-->
#### Documentation
Auto-generated `documentation.md` updated for the 7 new metrics and 3 new attributes. `README.md`
gains a note under `## Metrics` recording that `mongodb.oplog.*`, `mongodb.replica.*`, and
`mongodb.replica_set.*` are emitted only by replica set members — skipped on standalone deployments,
on `mongos`, and on uninitiated sets — that they require the `clusterMonitor` role, that lag and
headroom are reported only by the primary, and that `mongodb.replica_set.member.count` must not be
summed across members.

#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
