### PR TITLE
[chore] [receiver/prometheusreceiver] Fix flaky end-to-end tests

### DIFF
--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -222,16 +222,7 @@ service:
 	}
 
 	require.Positive(t, totalSamples, "Expected at least 1 sample")
-	// The mock target alternates between two series on every scrape, so after the
-	// first scrape each scrape reports the series that just disappeared as stale.
-	// This test verifies that staleness markers are emitted end-to-end, so assert
-	// that we observed at least one stale marker.
-	//
-	// We intentionally do not assert on the ratio of stale markers to total
-	// samples. The remote write exporter batches samples across scrapes, so the
-	// fraction of stale markers within the first few collected write requests
-	// varies with timing (fewer scrapes are captured under load), which made a
-	// ratio threshold sitting at the ~0.47 steady-state mean flaky. See
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50434
+	// Assert staleness markers are emitted end-to-end. A ratio threshold near the
+	// ~0.47 steady-state mean was flaky as sample counts vary under load (#50434).
 	require.Positivef(t, staleMarkerCount, "Expected at least one stale marker out of %d samples", totalSamples)
 }

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -222,10 +222,16 @@ service:
 	}
 
 	require.Positive(t, totalSamples, "Expected at least 1 sample")
-	// On every alternative scrape the prior scrape will be reported as sale.
-	// Expect at least:
-	//    * The first scrape will NOT return stale markers
-	//    * (N-1 / alternatives) = ((10-1) / 2) = ~40% chance of stale markers being emitted.
-	chance := float64(staleMarkerCount) / float64(totalSamples)
-	require.GreaterOrEqualf(t, chance, 0.4, "Expected at least one stale marker: %.3f", chance)
+	// The mock target alternates between two series on every scrape, so after the
+	// first scrape each scrape reports the series that just disappeared as stale.
+	// This test verifies that staleness markers are emitted end-to-end, so assert
+	// that we observed at least one stale marker.
+	//
+	// We intentionally do not assert on the ratio of stale markers to total
+	// samples. The remote write exporter batches samples across scrapes, so the
+	// fraction of stale markers within the first few collected write requests
+	// varies with timing (fewer scrapes are captured under load), which made a
+	// ratio threshold sitting at the ~0.47 steady-state mean flaky. See
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50434
+	require.Positivef(t, staleMarkerCount, "Expected at least one stale marker out of %d samples", totalSamples)
 }

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -212,16 +212,8 @@ func setupMockPrometheus(tds ...*testData) (*mockPrometheus, *PromConfig, error)
 		job := make(map[string]any)
 		job["job_name"] = tds[i].name
 		job["metrics_path"] = metricPaths[i]
-		// The end-to-end tests validate each scrape against a specific mock page by
-		// position (Nth successful scrape == Nth page). When a scrape's request
-		// reaches the mock (advancing its page counter) but the receiver fails to
-		// read the response within the scrape timeout, that page is dropped and the
-		// page-to-scrape mapping shifts, causing spurious value mismatches. Prometheus
-		// caps scrape_timeout at scrape_interval, and it defaults to the interval when
-		// unset, so a 100ms interval leaves only a 100ms timeout. That is not enough
-		// headroom on loaded CI runners and made these tests flaky. Use a larger
-		// interval so scrapes have ample time to complete before timing out. See
-		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50434
+		// Give scrapes timeout headroom; a short interval caps scrape_timeout and
+		// desyncs the page/scrape mapping under load (#50434).
 		job["scrape_interval"] = "500ms"
 		job["static_configs"] = []map[string]any{{"targets": []string{u.Host}}}
 		jobs = append(jobs, job)

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -212,7 +212,17 @@ func setupMockPrometheus(tds ...*testData) (*mockPrometheus, *PromConfig, error)
 		job := make(map[string]any)
 		job["job_name"] = tds[i].name
 		job["metrics_path"] = metricPaths[i]
-		job["scrape_interval"] = "100ms"
+		// The end-to-end tests validate each scrape against a specific mock page by
+		// position (Nth successful scrape == Nth page). When a scrape's request
+		// reaches the mock (advancing its page counter) but the receiver fails to
+		// read the response within the scrape timeout, that page is dropped and the
+		// page-to-scrape mapping shifts, causing spurious value mismatches. Prometheus
+		// caps scrape_timeout at scrape_interval, and it defaults to the interval when
+		// unset, so a 100ms interval leaves only a 100ms timeout. That is not enough
+		// headroom on loaded CI runners and made these tests flaky. Use a larger
+		// interval so scrapes have ample time to complete before timing out. See
+		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50434
+		job["scrape_interval"] = "500ms"
 		job["static_configs"] = []map[string]any{{"targets": []string{u.Host}}}
 		jobs = append(jobs, job)
 	}


### PR DESCRIPTION
#### Description
This PR fixes two independent flakes reported in #50434.

`TestCoreMetricsEndToEnd` validates each scrape against a specific mock page by position (Nth successful scrape == Nth page). The mock advances its page counter on every request it serves. When a scrape's request reaches the mock (advancing the counter) but the receiver cannot read the response within the scrape timeout, that page is dropped while the counter still advances, shifting the page-to-scrape mapping and producing spurious value mismatches. Prometheus caps `scrape_timeout` at `scrape_interval` and defaults it to the interval, so a 100ms interval left only a 100ms timeout, which is not enough headroom on loaded CI runners. The shared test scrape interval is raised to 500ms so scrapes have time to complete before timing out.

`TestStalenessMarkersEndToEnd` asserted that the ratio of staleness markers to total samples was >= 0.4, which sits right at the ~0.47 steady-state mean. The remote write exporter batches samples across scrapes, so the fraction observed within the first few collected write requests varies with timing and dips below the threshold under load. The test now asserts that at least one staleness marker is emitted, which is what it documents.

#### Link to tracking issue
Fixes #50434


#### Testing
Tuned.

#### Documentation
~

#### Authorship

- [x] I, a human, wrote this pull request description myself.