### PR TITLE
[chore][processor/log_dedup] Add unit tests for getKeyValue

### DIFF
--- a/processor/logdedupprocessor/counter_test.go
+++ b/processor/logdedupprocessor/counter_test.go
@@ -365,11 +365,11 @@ func Test_getKeyValue(t *testing.T) {
 			name: "gets nested value",
 			valueMap: func() pcommon.Map {
 				m := pcommon.NewMap()
-				nested := m.PutEmptyMap("user")
-				nested.PutStr("name", "Chethan")
+				nested := m.PutEmptyMap("parent")
+				nested.PutStr("child", "value")
 				return m
 			}(),
-			keyParts: []string{"user", "name"},
+			keyParts: []string{"parent", "child"},
 			expected: "Chethan",
 			ok:       true,
 		},
@@ -377,21 +377,21 @@ func Test_getKeyValue(t *testing.T) {
 			name: "returns false when nested key does not exist",
 			valueMap: func() pcommon.Map {
 				m := pcommon.NewMap()
-				nested := m.PutEmptyMap("user")
-				nested.PutStr("name", "Chethan")
+				nested := m.PutEmptyMap("parent")
+				nested.PutStr("child", "value")
 				return m
 			}(),
-			keyParts: []string{"user", "age"},
+			keyParts: []string{"parent", "missing"},
 			ok:       false,
 		},
 		{
 			name: "returns false when intermediate value is not a map",
 			valueMap: func() pcommon.Map {
 				m := pcommon.NewMap()
-				m.PutStr("user", "Chethan")
+				m.PutStr("parent", "value")
 				return m
 			}(),
-			keyParts: []string{"user", "name"},
+			keyParts: []string{"parent", "child"},
 			ok:       false,
 		},
 	}

--- a/processor/logdedupprocessor/counter_test.go
+++ b/processor/logdedupprocessor/counter_test.go
@@ -370,7 +370,7 @@ func Test_getKeyValue(t *testing.T) {
 				return m
 			}(),
 			keyParts: []string{"parent", "child"},
-			expected: "Chethan",
+			expected: "value",
 			ok:       true,
 		},
 		{

--- a/processor/logdedupprocessor/counter_test.go
+++ b/processor/logdedupprocessor/counter_test.go
@@ -332,6 +332,82 @@ func Test_getLogKey(t *testing.T) {
 	}
 }
 
+func Test_getKeyValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		valueMap pcommon.Map
+		keyParts []string
+		expected string
+		ok       bool
+	}{
+		{
+			name: "gets value for existing key",
+			valueMap: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("key", "value")
+				return m
+			}(),
+			keyParts: []string{"key"},
+			expected: "value",
+			ok:       true,
+		},
+		{
+			name: "returns false when key does not exist",
+			valueMap: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("key", "value")
+				return m
+			}(),
+			keyParts: []string{"missing"},
+			ok:       false,
+		},
+		{
+			name: "gets nested value",
+			valueMap: func() pcommon.Map {
+				m := pcommon.NewMap()
+				nested := m.PutEmptyMap("user")
+				nested.PutStr("name", "Chethan")
+				return m
+			}(),
+			keyParts: []string{"user", "name"},
+			expected: "Chethan",
+			ok:       true,
+		},
+		{
+			name: "returns false when nested key does not exist",
+			valueMap: func() pcommon.Map {
+				m := pcommon.NewMap()
+				nested := m.PutEmptyMap("user")
+				nested.PutStr("name", "Chethan")
+				return m
+			}(),
+			keyParts: []string{"user", "age"},
+			ok:       false,
+		},
+		{
+			name: "returns false when intermediate value is not a map",
+			valueMap: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("user", "Chethan")
+				return m
+			}(),
+			keyParts: []string{"user", "name"},
+			ok:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok := getKeyValue(tt.valueMap, tt.keyParts)
+
+			require.Equal(t, tt.ok, ok)
+			if tt.ok {
+				require.Equal(t, tt.expected, value.Str())
+			}
+		})
+	}
+}
+
 func generateTestLogRecord(t *testing.T, body string) plog.LogRecord {
 	t.Helper()
 	logRecord := plog.NewLogRecord()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds unit test coverage for the `getKeyValue` helper in the log deduplication processor.

It adds tests covering:

- retrieving a value from an existing key
- handling a key that does not exist
- retrieving a value from a nested map
- handling a nested key that does not exist
- handling an intermediate value that is not a map

<!--Describe what testing was performed and which tests were added.-->
#### Testing

The above changes are tested with: `go test .`, `go test -race .`, and `go test -cover .`

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
