### PR TITLE
[exporter/loadbalancing] k8s resolver: skip endpoints that are not ready

### DIFF
--- a/exporter/loadbalancingexporter/resolver_k8s_handler.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_handler.go
@@ -35,7 +35,7 @@ func (h handler) OnAdd(obj any, _ bool) {
 
 	switch object := obj.(type) {
 	case *discoveryv1.EndpointSlice:
-		ok, endpoints = convertToEndpoints(h.returnNames, object)
+		ok, endpoints = convertToEndpoints(h.logger, h.returnNames, object)
 		if !ok {
 			// Some endpoints were missing hostnames and were skipped. Still add
 			// the ones we could resolve; the rest are picked up on a later event
@@ -52,6 +52,7 @@ func (h handler) OnAdd(obj any, _ bool) {
 	changed := false
 	for ep := range endpoints {
 		if _, loaded := h.endpoints.LoadOrStore(ep, true); !loaded {
+			h.logger.Info("adding ready endpoint to load balancing", zap.String("endpoint", ep))
 			changed = true
 		}
 	}
@@ -70,8 +71,8 @@ func (h handler) OnUpdate(oldObj, newObj any) {
 			return
 		}
 
-		_, oldEndpoints := convertToEndpoints(h.returnNames, oldEps)
-		newOk, newEndpoints := convertToEndpoints(h.returnNames, newEps)
+		_, oldEndpoints := convertToEndpoints(h.logger, h.returnNames, oldEps)
+		newOk, newEndpoints := convertToEndpoints(h.logger,h.returnNames, newEps)
 		if !newOk {
 			// The new slice has endpoint(s) without a hostname yet. Those are
 			// skipped and picked up on a later event once their hostname is
@@ -88,9 +89,13 @@ func (h handler) OnUpdate(oldObj, newObj any) {
 		changed := false
 
 		// Iterate through old endpoints and remove those that are not in the new list.
+		// An endpoint that turned not-ready (e.g. its pod started terminating) is filtered
+		// out of newEndpoints by convertToEndpoints and removed here, before the pod object
+		// is deleted.
 		for ep := range oldEndpoints {
 			if _, ok := newEndpoints[ep]; !ok {
 				h.endpoints.Delete(ep)
+				h.logger.Info("removing endpoint from load balancing", zap.String("endpoint", ep))
 				changed = true
 			}
 		}
@@ -98,6 +103,7 @@ func (h handler) OnUpdate(oldObj, newObj any) {
 		// Iterate through new endpoints and add those that are not in the endpoints map already.
 		for ep := range newEndpoints {
 			if _, loaded := h.endpoints.LoadOrStore(ep, true); !loaded {
+				h.logger.Info("adding ready endpoint to load balancing", zap.String("endpoint", ep))
 				changed = true
 			}
 		}
@@ -125,7 +131,7 @@ func (h handler) OnDelete(obj any) {
 		return
 	case *discoveryv1.EndpointSlice:
 		if object != nil {
-			ok, endpoints = convertToEndpoints(h.returnNames, object)
+			ok, endpoints = convertToEndpoints(h.logger, h.returnNames, object)
 			if !ok {
 				// Some endpoints lacked hostnames (and so were never tracked);
 				// still remove the ones we can resolve.
@@ -141,6 +147,7 @@ func (h handler) OnDelete(obj any) {
 	if len(endpoints) != 0 {
 		for endpoint := range endpoints {
 			h.endpoints.Delete(endpoint)
+			h.logger.Info("removing endpoint from load balancing", zap.String("endpoint", endpoint))
 		}
 		_, _ = h.callback(context.Background())
 	}
@@ -157,11 +164,22 @@ func (h handler) OnDelete(obj any) {
 // is populated during a rollout, and dropping the whole slice in that window
 // meant pods that churned out were never removed from the resolver's store,
 // leaking dead pod hostnames without bound.
-func convertToEndpoints(retNames bool, eps ...*discoveryv1.EndpointSlice) (bool, map[string]bool) {
+func convertToEndpoints(logger *zap.Logger, retNames bool, eps ...*discoveryv1.EndpointSlice) (bool, map[string]bool) {
 	res := map[string]bool{}
 	ok := true
 	for _, ep := range eps {
 		for _, endpoint := range ep.Endpoints {
+			// Per the EndpointSlice API, a nil Ready condition means "unknown" and
+			// consumers should treat it as ready. Skip only endpoints that are
+			// explicitly not ready (e.g. their pod is terminating or failing its
+			// readiness probe) so they leave the ring before delivery starts failing.
+			if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
+				logger.Debug("skipping endpoint that is not ready",
+					zap.Strings("addresses", endpoint.Addresses),
+					zap.Boolp("serving", endpoint.Conditions.Serving),
+					zap.Boolp("terminating", endpoint.Conditions.Terminating))
+				continue
+			}
 			for _, addr := range endpoint.Addresses {
 				if retNames {
 					if endpoint.Hostname == nil || *endpoint.Hostname == "" {

--- a/exporter/loadbalancingexporter/resolver_k8s_handler_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_handler_test.go
@@ -7,13 +7,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestConvertToEndpoints(tst *testing.T) {
 	hostname1 := "pod-1"
 	hostname2 := "pod-2"
+	hostname4 := "pod-4"
+	hostname5 := "pod-5"
 
 	// Create dummy EndpointSlice objects
 	endpoints1 := &discoveryv1.EndpointSlice{
@@ -51,6 +55,51 @@ func TestConvertToEndpoints(tst *testing.T) {
 			},
 		},
 	}
+	// A slice mixing an explicitly ready, an explicitly not-ready (terminating), and a
+	// nil-readiness ("unknown", treated as ready per the EndpointSlice API) endpoint.
+	endpointsMixedReadiness := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-endpoints-4",
+			Namespace: "test-namespace",
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses: []string{"192.168.10.104"},
+				Hostname:  &hostname4,
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: ptr.To(true),
+				},
+			},
+			{
+				Addresses: []string{"192.168.10.105"},
+				Hostname:  &hostname5,
+				Conditions: discoveryv1.EndpointConditions{
+					Ready:       ptr.To(false),
+					Serving:     ptr.To(true),
+					Terminating: ptr.To(true),
+				},
+			},
+			{
+				Addresses: []string{"192.168.10.106"},
+			},
+		},
+	}
+	// A slice whose only endpoint is not ready and also misses the hostname: the
+	// readiness filter must skip it before the hostname validation can fail.
+	endpointsNotReadyNoHostname := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-endpoints-5",
+			Namespace: "test-namespace",
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses: []string{"192.168.10.107"},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: ptr.To(false),
+				},
+			},
+		},
+	}
 
 	tests := []struct {
 		name              string
@@ -83,11 +132,25 @@ func TestConvertToEndpoints(tst *testing.T) {
 			expectedEndpoints: map[string]bool{"pod-1": true},
 			wantOk:            false,
 		},
+		{
+			name:              "not-ready endpoint excluded, nil readiness kept (IPs)",
+			returnNames:       false,
+			includedEndpoints: []*discoveryv1.EndpointSlice{endpointsMixedReadiness},
+			expectedEndpoints: map[string]bool{"192.168.10.104": true, "192.168.10.106": true},
+			wantOk:            true,
+		},
+		{
+			name:              "not-ready endpoint excluded (hostnames)",
+			returnNames:       true,
+			includedEndpoints: []*discoveryv1.EndpointSlice{endpoints1, endpointsNotReadyNoHostname},
+			expectedEndpoints: map[string]bool{"pod-1": true},
+			wantOk:            true,
+		},
 	}
 
 	for _, tt := range tests {
 		tst.Run(tt.name, func(tst *testing.T) {
-			ok, res := convertToEndpoints(tt.returnNames, tt.includedEndpoints...)
+			ok, res := convertToEndpoints(zap.NewNop(), tt.returnNames, tt.includedEndpoints...)
 			assert.Equal(tst, tt.expectedEndpoints, res)
 			assert.Equal(tst, tt.wantOk, ok)
 		})


### PR DESCRIPTION
#### Description
OTEL loadbalancing exporter using k8s resolver: skip endpoints that are not ready.

#### Testing
Extended exporter/loadbalancingexporter/resolver_k8s_handler_test.go with validation tests.

#### Authorship

- [*] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
