### PR TITLE
[extension/opamp] Add configurable socket options

### DIFF
--- a/.chloggen/opamp-extension-uds-support.yaml
+++ b/.chloggen/opamp-extension-uds-support.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/opamp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add a `socket` option under `server.ws` and `server.http` to dial the OpAMP server over a Unix domain socket (`transport: unix`) or Windows named pipe (`transport: npipe`)."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50603]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `socket` is set, the `endpoint` only supplies the URL scheme, request path, and Host
+  header; its host and port are ignored.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -291,3 +291,8 @@ providers:
 # file before passing it to OCB, to ensure that local versions are used for all
 # Contrib modules.
 replaces:
+  # TODO(opamp-uds): temporary replace pointing at the opamp-go PR that adds
+  # StartSettings.DialContext (Unix domain socket dialing). Remove and bump to the
+  # tagged opamp-go release before this PR is merged.
+  # https://github.com/open-telemetry/opamp-go/pull/642
+  - github.com/open-telemetry/opamp-go => github.com/dpaasman00/opamp-go v0.0.0-20260831135248-e1c0a80f8377

--- a/extension/opampextension/README.md
+++ b/extension/opampextension/README.md
@@ -28,6 +28,14 @@ The following settings are optional for the websocket client:
     - `tls`: TLS settings.
     - `headers`: HTTP headers to set.
     - `auth`: The ID of an auth extension to use for authentication.
+    - `socket`: A local IPC socket to dial instead of a TCP connection. When
+      set, `endpoint` only supplies the URL scheme, request path, and `Host`
+      header (its host and port are ignored). This is typically set by the
+      Supervisor for the local supervisor-to-collector link and not configured
+      manually.
+      - `transport`: `unix` (Unix domain socket) or `npipe` (Windows named pipe).
+      - `endpoint`: The socket path (e.g. `/var/run/otelcol/opamp.sock`) or
+        named pipe path (e.g. `\\.\pipe\opamp`).
 
 The following settings are optional for the HTTP client:
 
@@ -37,6 +45,8 @@ The following settings are optional for the HTTP client:
     - `headers`: HTTP headers to set.
     - `polling_interval`: The interval at which the extension will poll the server. Defaults to 30s.
     - `auth`: The ID of an auth extension to use for authentication.
+    - `socket`: A local IPC socket to dial instead of a TCP connection, as
+      described for the websocket transport above.
 
 The following settings are optional for both transports:
 

--- a/extension/opampextension/config.go
+++ b/extension/opampextension/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-telemetry/opamp-go/client"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
@@ -96,6 +97,12 @@ type commonFields struct {
 	TLS      configtls.ClientConfig         `mapstructure:"tls,omitempty"`
 	Headers  map[string]configopaque.String `mapstructure:"headers,omitempty"`
 	Auth     component.ID                   `mapstructure:"auth,omitempty"`
+	// Socket, when set, makes the client dial the OpAMP server over a local IPC
+	// socket instead of TCP: a Unix domain socket (transport "unix") or a
+	// Windows named pipe (transport "npipe"). The Endpoint above then only
+	// supplies the URL scheme, request path, and Host header, and its host:port
+	// is otherwise ignored.
+	Socket *confignet.AddrConfig `mapstructure:"socket,omitempty"`
 }
 
 func (c *commonFields) Scheme() string {
@@ -109,6 +116,16 @@ func (c *commonFields) Scheme() string {
 func (c *commonFields) Validate() error {
 	if c.Endpoint == "" {
 		return errors.New("opamp server endpoint must be provided")
+	}
+	if c.Socket != nil {
+		switch c.Socket.Transport {
+		case confignet.TransportTypeUnix, confignet.TransportTypeNpipe:
+		default:
+			return fmt.Errorf("socket::transport must be %q or %q", confignet.TransportTypeUnix, confignet.TransportTypeNpipe)
+		}
+		if c.Socket.Endpoint == "" {
+			return errors.New("socket::endpoint must be provided")
+		}
 	}
 	return nil
 }
@@ -186,6 +203,17 @@ func (s OpAMPServer) GetEndpoint() string {
 		return s.HTTP.Endpoint
 	}
 	return ""
+}
+
+// GetSocket returns the configured local IPC socket address, or nil if not
+// configured.
+func (s OpAMPServer) GetSocket() *confignet.AddrConfig {
+	if s.WS != nil {
+		return s.WS.Socket
+	} else if s.HTTP != nil {
+		return s.HTTP.Socket
+	}
+	return nil
 }
 
 func (s OpAMPServer) GetAuthExtensionID() component.ID {

--- a/extension/opampextension/config.schema.yaml
+++ b/extension/opampextension/config.schema.yaml
@@ -45,6 +45,10 @@ $defs:
           polling_interval:
             type: string
             format: duration
+          socket:
+            description: 'Socket, when set, makes the client dial the OpAMP server over a local IPC socket instead of TCP: a Unix domain socket (transport "unix") or a Windows named pipe (transport "npipe"). The Endpoint above then only supplies the URL scheme, request path, and Host header, and its host:port is otherwise ignored.'
+            x-pointer: true
+            $ref: go.opentelemetry.io/collector/config/confignet.addr_config
           tls:
             $ref: go.opentelemetry.io/collector/config/configtls.client_config
       ws:
@@ -60,6 +64,10 @@ $defs:
             type: object
             additionalProperties:
               $ref: go.opentelemetry.io/collector/config/configopaque.string
+          socket:
+            description: 'Socket, when set, makes the client dial the OpAMP server over a local IPC socket instead of TCP: a Unix domain socket (transport "unix") or a Windows named pipe (transport "npipe"). The Endpoint above then only supplies the URL scheme, request path, and Host header, and its host:port is otherwise ignored.'
+            x-pointer: true
+            $ref: go.opentelemetry.io/collector/config/confignet.addr_config
           tls:
             $ref: go.opentelemetry.io/collector/config/configtls.client_config
 description: Config contains the configuration for the opamp extension. Trying to mirror the OpAMP supervisor config for some consistency.

--- a/extension/opampextension/config_test.go
+++ b/extension/opampextension/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap"
@@ -337,6 +338,91 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			wantErr: func(t assert.TestingT, err error, _ ...any) bool {
 				return assert.Equal(t, "opamp server must have only ws or http set", err.Error())
+			},
+		},
+		{
+			name: "WS with unix socket is valid",
+			fields: fields{
+				Server: &OpAMPServer{
+					WS: &commonFields{
+						Endpoint: "ws://localhost/v1/opamp",
+						Socket: &confignet.AddrConfig{
+							Transport: confignet.TransportTypeUnix,
+							Endpoint:  "/run/otelcol/opamp.sock",
+						},
+					},
+				},
+				InstanceUID: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "HTTP with unix socket is valid",
+			fields: fields{
+				Server: &OpAMPServer{
+					HTTP: &httpFields{
+						commonFields: commonFields{
+							Endpoint: "http://localhost/v1/opamp",
+							Socket: &confignet.AddrConfig{
+								Transport: confignet.TransportTypeUnix,
+								Endpoint:  "/run/otelcol/opamp.sock",
+							},
+						},
+					},
+				},
+				InstanceUID: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "socket with npipe transport is valid",
+			fields: fields{
+				Server: &OpAMPServer{
+					WS: &commonFields{
+						Endpoint: "ws://localhost/v1/opamp",
+						Socket: &confignet.AddrConfig{
+							Transport: confignet.TransportTypeNpipe,
+							Endpoint:  `\\.\pipe\opamp`,
+						},
+					},
+				},
+				InstanceUID: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "socket with tcp transport is rejected",
+			fields: fields{
+				Server: &OpAMPServer{
+					WS: &commonFields{
+						Endpoint: "ws://localhost/v1/opamp",
+						Socket: &confignet.AddrConfig{
+							Transport: confignet.TransportTypeTCP,
+							Endpoint:  "localhost:4320",
+						},
+					},
+				},
+				InstanceUID: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			},
+			wantErr: func(t assert.TestingT, err error, _ ...any) bool {
+				return assert.Equal(t, `socket::transport must be "unix" or "npipe"`, err.Error())
+			},
+		},
+		{
+			name: "socket without endpoint is rejected",
+			fields: fields{
+				Server: &OpAMPServer{
+					WS: &commonFields{
+						Endpoint: "ws://localhost/v1/opamp",
+						Socket: &confignet.AddrConfig{
+							Transport: confignet.TransportTypeUnix,
+						},
+					},
+				},
+				InstanceUID: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			},
+			wantErr: func(t assert.TestingT, err error, _ ...any) bool {
+				return assert.Equal(t, "socket::endpoint must be provided", err.Error())
 			},
 		},
 		{

--- a/extension/opampextension/go.mod
+++ b/extension/opampextension/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/component v1.66.0
 	go.opentelemetry.io/collector/component/componentstatus v0.160.0
 	go.opentelemetry.io/collector/component/componenttest v0.160.0
+	go.opentelemetry.io/collector/config/confignet v1.66.0
 	go.opentelemetry.io/collector/config/configopaque v1.66.0
 	go.opentelemetry.io/collector/config/configtls v1.66.0
 	go.opentelemetry.io/collector/confmap v1.66.0
@@ -30,16 +31,17 @@ require (
 )
 
 require (
+	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/elastic/proxy-connect-dialer-go v0.1.1 // indirect
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20251226215517-609e4778396f // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/michel-laterman/proxy-connect-dialer-go v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -130,3 +132,9 @@ require (
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages => ../opampcustommessages
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status => ../../pkg/status
+
+// TODO(opamp-uds): temporary replace pointing at the opamp-go PR that adds
+// StartSettings.DialContext (Unix domain socket dialing). Remove and bump to the
+// tagged opamp-go release before this PR is merged.
+// https://github.com/open-telemetry/opamp-go/pull/642
+replace github.com/open-telemetry/opamp-go => github.com/dpaasman00/opamp-go v0.0.0-20260831135248-e1c0a80f8377

--- a/extension/opampextension/go.sum
+++ b/extension/opampextension/go.sum
@@ -12,8 +12,12 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dpaasman00/opamp-go v0.0.0-20260831135248-e1c0a80f8377 h1:dfsA99h0LFvwhjvx5oh+ldy/GXnJkNSOxTmffCkxmrI=
+github.com/dpaasman00/opamp-go v0.0.0-20260831135248-e1c0a80f8377/go.mod h1:p1aUAb8vVqtQ9qD8yDBGiqztuI3AkCSh7XTVqhuyy3I=
 github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
 github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/elastic/proxy-connect-dialer-go v0.1.1 h1:kmSFbqC+j6yVlxwPixI/7aTpdp+FH16Oaau1bcClpjI=
+github.com/elastic/proxy-connect-dialer-go v0.1.1/go.mod h1:YYlk9leuhkB2h7STwiNOGa1UkZWalY70jnIF8Ec3Sks=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/foxboron/go-tpm-keyfiles v0.0.0-20251226215517-609e4778396f h1:RJ+BDPLSHQO7cSjKBqjPJSbi1qfk9WcsjQDtZiw3dZw=
@@ -68,8 +72,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIiZhtifTV5OUqqiP82UAl0h87xj/l9k=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
-github.com/michel-laterman/proxy-connect-dialer-go v0.1.0 h1:Q8asukpmyrEheocd+R+6YEI4jcm62sHHalgTMG+LoLw=
-github.com/michel-laterman/proxy-connect-dialer-go v0.1.0/go.mod h1:HTlVkRAqzTRPYbWxgAiwMT9HRZMOqP3Mx7+toa3yJjc=
+github.com/madflojo/testcerts v1.5.0 h1:GhQllyAiGzXVZU+i8O/cQkPTHzN59RxMGtm3uETgXnU=
+github.com/madflojo/testcerts v1.5.0/go.mod h1:MW8sh39gLnkKh4K0Nc55AyHEDl9l/FBLDUsQhpmkuo0=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -84,8 +88,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/oklog/ulid/v2 v2.1.2 h1:IEclFb9JNvzYA6MW2SCxbLzcHTVsfqm3PrqGQJH5zec=
 github.com/oklog/ulid/v2 v2.1.2/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/open-telemetry/opamp-go v0.23.0 h1:k7h7w/muprut9/DAhUC4anX4v7hIdgO02gIsSjV4uq0=
-github.com/open-telemetry/opamp-go v0.23.0/go.mod h1:DIIVdkLefdqPW5L+4I2twmAicVrTB0Bp5XJAfedZzAM=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pierrec/lz4/v4 v4.1.29 h1:CDQY6qZOLI4DW0Nx6R1vRrifrCeQHnNXkMb0hZWXFjg=
 github.com/pierrec/lz4/v4 v4.1.29/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -151,6 +152,16 @@ func (o *opampAgent) Start(ctx context.Context, host component.Host) error {
 			OnMessage: o.onMessage,
 			OnCommand: o.onCommand,
 		},
+	}
+
+	// When configured with a local IPC socket (Unix domain socket or Windows
+	// named pipe), dial it instead of TCP. Both OpAMP transports honor
+	// DialContext. The OpAMPServerURL endpoint then only supplies the URL
+	// scheme, request path, and Host header; its host:port is ignored.
+	if socket := o.cfg.Server.GetSocket(); socket != nil {
+		settings.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return socket.Dial(ctx)
+		}
 	}
 
 	if err := o.createAgentDescription(); err != nil {

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -6,11 +6,14 @@ package opampextension
 import (
 	"context"
 	"errors"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -18,11 +21,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/open-telemetry/opamp-go/server"
+	servertypes "github.com/open-telemetry/opamp-go/server/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensiontest"
@@ -65,6 +71,113 @@ func TestNewOpampAgentAttributes(t *testing.T) {
 	assert.Equal(t, "distro.0", o.serviceVersion)
 	assert.Equal(t, "f8999bc1-4c9b-4619-9bae-7f009d2411ec", o.serviceInstanceID)
 	assert.NoError(t, o.Shutdown(t.Context()))
+}
+
+// TestOpampAgentConnectsOverUnixSocket exercises the full OpAMP handshake from
+// the extension's client to a server listening on a filesystem Unix domain
+// socket, over both the WebSocket and plain HTTP transports. The endpoint host
+// is cosmetic; the configured unix_socket drives the dial. The server-side
+// connection must be a *net.UnixConn so a consumer (e.g. the supervisor) can
+// authenticate the peer via SO_PEERCRED.
+func TestOpampAgentConnectsOverUnixSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix domain socket peer authentication is not supported on Windows")
+	}
+
+	tests := []struct {
+		name   string
+		server func(socketPath string) *OpAMPServer
+	}{
+		{
+			name: "websocket",
+			server: func(socketPath string) *OpAMPServer {
+				return &OpAMPServer{
+					WS: &commonFields{
+						// Host is cosmetic; DialContext dials the socket regardless.
+						Endpoint: "ws://localhost/v1/opamp",
+						Socket: &confignet.AddrConfig{
+							Transport: confignet.TransportTypeUnix,
+							Endpoint:  socketPath,
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "http",
+			server: func(socketPath string) *OpAMPServer {
+				return &OpAMPServer{
+					HTTP: &httpFields{
+						commonFields: commonFields{
+							Endpoint: "http://localhost/v1/opamp",
+							Socket: &confignet.AddrConfig{
+								Transport: confignet.TransportTypeUnix,
+								Endpoint:  socketPath,
+							},
+						},
+					},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// macOS limits the socket path to ~104 bytes, which t.TempDir() can
+			// exceed, so bind under a short base directory.
+			dir, err := os.MkdirTemp("/tmp", "opampuds") //nolint:usetesting // see above
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+			socketPath := filepath.Join(dir, "opamp.sock")
+
+			ln, err := net.Listen("unix", socketPath)
+			require.NoError(t, err)
+
+			var gotUnixConn atomic.Bool
+			connected := make(chan struct{})
+			var once sync.Once
+
+			callbacks := servertypes.Callbacks{
+				OnConnecting: func(_ *http.Request) servertypes.ConnectionResponse {
+					return servertypes.ConnectionResponse{
+						Accept: true,
+						ConnectionCallbacks: servertypes.ConnectionCallbacks{
+							OnConnected: func(_ context.Context, conn servertypes.Connection) {
+								_, ok := conn.Connection().(*net.UnixConn)
+								gotUnixConn.Store(ok)
+								once.Do(func() { close(connected) })
+							},
+						},
+					}
+				},
+			}
+
+			srv := server.New(nil)
+			require.NoError(t, srv.Start(server.StartSettings{
+				Settings:   server.Settings{Callbacks: callbacks},
+				Listener:   ln,
+				ListenPath: "/v1/opamp",
+			}))
+			require.Equal(t, "unix", srv.Addr().Network())
+
+			cfg := createDefaultConfig().(*Config)
+			cfg.Server = tt.server(socketPath)
+			set := extensiontest.NewNopSettings(extensiontest.NopType)
+			o, err := newOpampAgent(cfg, set)
+			require.NoError(t, err)
+			require.NoError(t, o.Start(t.Context(), componenttest.NewNopHost()))
+
+			select {
+			case <-connected:
+			case <-time.After(10 * time.Second):
+				t.Fatal("timed out waiting for the opamp client to connect over the unix socket")
+			}
+			assert.True(t, gotUnixConn.Load(), "server-side connection should be a *net.UnixConn")
+
+			assert.NoError(t, o.Shutdown(t.Context()))
+			assert.NoError(t, srv.Stop(t.Context()))
+		})
+	}
 }
 
 func TestCreateAgentDescription(t *testing.T) {
@@ -1047,6 +1160,10 @@ func (mockOpAMPClient) SetPackageStatuses(*protobufs.PackageStatuses) error {
 }
 
 func (mockOpAMPClient) RequestConnectionSettings(*protobufs.ConnectionSettingsRequest) error {
+	return nil
+}
+
+func (mockOpAMPClient) SetConnectionSettingsStatus(*protobufs.ConnectionSettingsStatus) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds two socket options (`confignet.AddrConfig`: transport + endpoint) under `server.ws` and `server.http` that dials the OpAMP server over a local IPC socket instead of TCP. On Unix use a Unix Domain Socket and on Windows use a Named Pipe.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Partially #50603 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
This PR adds unit tests. The PR stacked on top of this one adds e2e tests with the supervisor.

Changes should be manually tested from the stacked [PR](https://github.com/dpaasman00/opentelemetry-collector-contrib/pull/1).

<!--Describe the documentation added.-->
#### Documentation
Component README updated.
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
