### PR TITLE
[receiver/datadog] Set StartTimestamp from the declared interval

### DIFF
--- a/.chloggen/datadogreceiver-interval-start-timestamp.yaml
+++ b/.chloggen/datadogreceiver-interval-start-timestamp.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set a datapoint's `StartTimestamp` from the interval declared in the payload
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50640]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The window was derived from the previous datapoint's timestamp, so the first point of any stream
+  carried no `StartTimestamp` and downstream consumers could not infer an interval for it. Series
+  that declare no interval keep the previous behaviour.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/datadogreceiver/internal/translator/series.go
+++ b/receiver/datadogreceiver/internal/translator/series.go
@@ -114,7 +114,12 @@ func (mt *MetricsTranslator) TranslateSeriesV1(series SeriesList) pmetric.Metric
 			dp.SetDoubleValue(value)
 
 			stream := identity.OfStream(metricID, dp)
-			if startTs, ok := mt.trackStreamTimestamp(stream, dp.Timestamp()); ok {
+			// Prefer the declared interval; tracking is the fallback for series without one.
+			// Always advance the tracker so that fallback stays valid.
+			startTs, tracked := mt.trackStreamTimestamp(stream, dp.Timestamp())
+			if serie.Interval.IsSet() && serie.GetInterval() > 0 {
+				dp.SetStartTimestamp(dp.Timestamp() - pcommon.Timestamp(serie.GetInterval()*int64(time.Second)))
+			} else if tracked {
 				dp.SetStartTimestamp(startTs)
 			}
 		}
@@ -172,7 +177,12 @@ func (mt *MetricsTranslator) TranslateSeriesV2(series []*gogen.MetricPayload_Met
 			dp.SetDoubleValue(val)
 
 			stream := identity.OfStream(metricID, dp)
-			if startTs, ok := mt.trackStreamTimestamp(stream, dp.Timestamp()); ok {
+			// Prefer the declared interval; tracking is the fallback for series without one.
+			// Always advance the tracker so that fallback stays valid.
+			startTs, tracked := mt.trackStreamTimestamp(stream, dp.Timestamp())
+			if serie.Interval > 0 {
+				dp.SetStartTimestamp(dp.Timestamp() - pcommon.Timestamp(serie.Interval*int64(time.Second)))
+			} else if tracked {
 				dp.SetStartTimestamp(startTs)
 			}
 		}

--- a/receiver/datadogreceiver/internal/translator/series_test.go
+++ b/receiver/datadogreceiver/internal/translator/series_test.go
@@ -718,7 +718,7 @@ func TestTranslateSeriesIntervalSetsStartTimestamp(t *testing.T) {
 		// Without the declared interval this is 0 and no interval can be inferred.
 		require.Equal(t, wantStart, dp.StartTimestamp())
 		// Value scaling by the interval is unchanged.
-		require.Equal(t, float64(interval), dp.DoubleValue())
+		require.InEpsilon(t, float64(interval), dp.DoubleValue(), 1e-9)
 	})
 
 	t.Run("v2 first point of a stream", func(t *testing.T) {
@@ -735,7 +735,7 @@ func TestTranslateSeriesIntervalSetsStartTimestamp(t *testing.T) {
 		dp := result.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0)
 		require.Equal(t, wantTs, dp.Timestamp())
 		require.Equal(t, wantStart, dp.StartTimestamp())
-		require.Equal(t, float64(interval), dp.DoubleValue())
+		require.InEpsilon(t, float64(interval), dp.DoubleValue(), 1e-9)
 	})
 
 	t.Run("no declared interval falls back to inter-arrival tracking", func(t *testing.T) {

--- a/receiver/datadogreceiver/internal/translator/series_test.go
+++ b/receiver/datadogreceiver/internal/translator/series_test.go
@@ -8,11 +8,14 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -686,4 +689,67 @@ func TestTranslateSeriesV2StartTimestampOrdering(t *testing.T) {
 			tt.expect(t, results)
 		})
 	}
+}
+
+// A declared interval sets the window, including on a stream's first point.
+func TestTranslateSeriesIntervalSetsStartTimestamp(t *testing.T) {
+	const (
+		ts       = int64(1636629071)
+		interval = int64(10)
+	)
+	wantStart := pcommon.Timestamp((ts - interval) * time.Second.Nanoseconds())
+	wantTs := pcommon.Timestamp(ts * time.Second.Nanoseconds())
+
+	t.Run("v1 first point of a stream", func(t *testing.T) {
+		mt := createMetricsTranslator()
+		result := mt.TranslateSeriesV1(SeriesList{
+			Series: []datadogV1.Series{
+				{
+					Metric:   "TestRate",
+					Host:     new("Host1"),
+					Type:     new(TypeRate),
+					Interval: *datadog.NewNullableInt64(new(interval)),
+					Points:   testPointsToDatadogPoints([]testPoint{{ts, 1.0}}),
+				},
+			},
+		})
+		dp := result.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0)
+		require.Equal(t, wantTs, dp.Timestamp())
+		// Without the declared interval this is 0 and no interval can be inferred.
+		require.Equal(t, wantStart, dp.StartTimestamp())
+		// Value scaling by the interval is unchanged.
+		require.Equal(t, float64(interval), dp.DoubleValue())
+	})
+
+	t.Run("v2 first point of a stream", func(t *testing.T) {
+		mt := createMetricsTranslator()
+		result := mt.TranslateSeriesV2([]*gogen.MetricPayload_MetricSeries{
+			{
+				Metric:    "TestRate",
+				Type:      gogen.MetricPayload_RATE,
+				Interval:  interval,
+				Resources: []*gogen.MetricPayload_Resource{{Type: "host", Name: "Host1"}},
+				Points:    []*gogen.MetricPayload_MetricPoint{{Timestamp: ts, Value: 1.0}},
+			},
+		})
+		dp := result.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0)
+		require.Equal(t, wantTs, dp.Timestamp())
+		require.Equal(t, wantStart, dp.StartTimestamp())
+		require.Equal(t, float64(interval), dp.DoubleValue())
+	})
+
+	t.Run("no declared interval falls back to inter-arrival tracking", func(t *testing.T) {
+		mt := createMetricsTranslator()
+		mk := func(at int64) SeriesList {
+			return SeriesList{Series: []datadogV1.Series{{
+				Metric: "TestCount", Host: new("Host1"), Type: new(TypeCount),
+				Points: testPointsToDatadogPoints([]testPoint{{at, 1.0}}),
+			}}}
+		}
+		_ = mt.TranslateSeriesV1(mk(ts))
+		second := mt.TranslateSeriesV1(mk(ts + 30))
+		dp := second.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0)
+		require.Equal(t, pcommon.Timestamp(ts*time.Second.Nanoseconds()), dp.StartTimestamp(),
+			"series without a declared interval must still use the previous timestamp")
+	})
 }


### PR DESCRIPTION
#### Description

Implements the fix described in #50640 by deriving a datapoint's window from the interval the sender declared, rather than from the gap between submissions.

The window came from `trackStreamTimestamp`, which returns the timestamp of the stream's *previous* datapoint. So the first point of any stream carries no `StartTimestamp` at all, and every other point's window reflects submission timing rather than the declared interval. Downstream, `opentelemetry-mapping-go`'s `inferDeltaInterval` returns 0 when `StartTimestamp` is 0, the value is never divided by the interval, and a rate series loses its magnitude.

The interval is already parsed and used to scale the value on the line above — it is simply not used to set the window. This prefers it when present and keeps inter-arrival tracking as the fallback for series that declare none, so behaviour is unchanged for those. Both the V1 and V2 translation paths.

The Agent submits the same thing every flush — 100 events over 10s, already divided by the interval:

```
type=rate  interval=10  value=10.0
```

What Datadog ends up storing depends entirely on when the datapoint happens to arrive:

| datapoint | before | after |
|---|---|---|
| first of a stream | `RATE interval=0 value=100.0` — undivided, **10x high** | `RATE interval=10 value=10.0` |
| arrives 10s after the previous | `RATE interval=10 value=10.0` | `RATE interval=10 value=10.0` |
| arrives 37s after the previous | `RATE interval=37 value=2.70` — divided by 37, **3.7x low** | `RATE interval=10 value=10.0` |

Same input, three different stored values, depending only on submission timing. After the change all three produce the value the Agent actually reported.

The middle row is why this is easy to miss: a sender flushing on schedule makes the submission gap equal the declared interval by coincidence, so the wrong mechanism produces the right answer and the metric looks healthy.

Series that declare no interval are untouched — they keep using the previous datapoint's timestamp exactly as before.

_note_: delta sums only. Cumulative sums use `StartTimestamp` for series-begin and reset detection, and rewriting it there makes the exporter drop the datapoint.

_note_: in steady state the old behaviour looks correct — when a sender flushes on schedule the inter-arrival gap happens to equal the declared interval. The failure surfaces on stream initialisation: receiver restart, `Prune()` evicting an idle series, or a new tag combination.

#### Link to tracking issue

Fixes #50640

#### Testing

Added `TestTranslateSeriesIntervalSetsStartTimestamp` covering the V1 and V2 first point of a stream, asserting `StartTimestamp == Timestamp - interval`.

Added a third case for a series with no declared interval, asserting it still uses the previous datapoint's timestamp so the fallback is unchanged.

Verified the test fails without the fix (`expected: 0x16b67975b1fc7200`, `actual: 0x0`). No existing test set `Interval`, so this path was uncovered.

Validation performed:

* `go test ./...` for `receiver/datadogreceiver` — PASS, all packages
* targeted `go test -count=1 -race` for `TestTranslateSeries*` — PASS
* `make chlog-validate` — PASS
* `gofmt -l` — clean

##### End-to-end

Built a collector from this branch with `ocb` and ran it in a five-container chain: DogStatsD client → Datadog Agent 7 → tap → this receiver → OTLP → `datadogexporter` → a sink decoding the intake protobuf. The client emits exactly 100 counter increments every 10s.

Restarting the collector running the receiver clears the stream tracker, which is the condition that exposes the bug:

```
unpatched, after restart:            patched, after restart:
  interval=0    value=99.0             interval=10   value=10.0
  interval=10   value=10.0             interval=10   value=10.0
  interval=10   value=10.0             interval=10   value=10.2
  interval=10   value=10.2             interval=10   value=9.8
  interval=10   value=9.9              ... 9 submissions, all correct
```

The Agent and emitter were untouched between runs.

#### Documentation

None required — no configuration or user-facing surface changes. Changelog entry added under `.chloggen/`.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
