### PR TITLE
[cmd/opampsupervisor] Deprecate `reports_remote_config` capability option

### DIFF
--- a/.chloggen/dpaasman00_deprecate-reports-remote-config.yaml
+++ b/.chloggen/dpaasman00_deprecate-reports-remote-config.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: deprecation
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: cmd/opampsupervisor

--- a/.chloggen/dpaasman00_deprecate-reports-remote-config.yaml
+++ b/.chloggen/dpaasman00_deprecate-reports-remote-config.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the `reports_remote_config` capability config option. The `accepts_remote_config` option now enables both the AcceptsRemoteConfig and ReportsRemoteConfig OpAMP capabilities.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [49763]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `reports_remote_config` is still accepted but has no effect. The supervisor logs an error at startup when it is set to `true`.
+  Configurations with `accepts_remote_config: true` and `reports_remote_config: false` now report remote config status.
+  The option will fail startup in v0.163.0 and be removed in v0.165.0.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1166,7 +1166,6 @@ capabilities:
   reports_effective_config: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
 
 storage:
   directory: %q

--- a/cmd/opampsupervisor/examples/supervisor.yaml
+++ b/cmd/opampsupervisor/examples/supervisor.yaml
@@ -12,7 +12,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
 
 agent:
   executable: /otelcontribcol

--- a/cmd/opampsupervisor/examples/supervisor_darwin.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_darwin.yaml
@@ -13,7 +13,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
 
 agent:
   executable: ../../bin/otelcontribcol_darwin_arm64

--- a/cmd/opampsupervisor/examples/supervisor_docker.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_docker.yaml
@@ -13,7 +13,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
 
 agent:
   executable: /otelcontribcol

--- a/cmd/opampsupervisor/examples/supervisor_fallback.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_fallback.yaml
@@ -19,7 +19,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 agent:

--- a/cmd/opampsupervisor/examples/supervisor_linux.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_linux.yaml
@@ -13,7 +13,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
 
 agent:
   executable: ../../bin/otelcontribcol_linux_amd64

--- a/cmd/opampsupervisor/examples/supervisor_windows.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_windows.yaml
@@ -13,7 +13,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
 
 agent:
   executable: ../../bin/otelcontribcol_windows_amd64.exe

--- a/cmd/opampsupervisor/specification/README.md
+++ b/cmd/opampsupervisor/specification/README.md
@@ -81,7 +81,9 @@ server:
 # Keys with boolean true/false values that enable a particular
 # OpAMP capability.
 capabilities:
-  # The Supervisor will accept remote configuration from the Server.
+  # The Supervisor will accept remote configuration from the Server and
+  # report remote configuration status to the Server. Enables both the
+  # AcceptsRemoteConfig and ReportsRemoteConfig OpAMP capabilities.
   accepts_remote_config: # false if unspecified
 
   # The Supervisor will accept restart requests.
@@ -114,7 +116,10 @@ capabilities:
   # The Collector will report Health.
   reports_health: # true if unspecified
 
-  # The Supervisor will report remote config status to the Server.
+  # DEPRECATED: This option has no effect and will be removed in v0.165.0.
+  # Remote config status is reported whenever accepts_remote_config is
+  # enabled. See
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49763
   reports_remote_config: # false if unspecified
 
   # The Supervisor will report available Collector components to the Server.

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -98,10 +98,15 @@ type Capabilities struct {
 	ReportsOwnLogs                 bool `mapstructure:"reports_own_logs"`
 	ReportsOwnTraces               bool `mapstructure:"reports_own_traces"`
 	ReportsHealth                  bool `mapstructure:"reports_health"`
-	ReportsRemoteConfig            bool `mapstructure:"reports_remote_config"`
 	ReportsAvailableComponents     bool `mapstructure:"reports_available_components"`
 	ReportsHeartbeat               bool `mapstructure:"reports_heartbeat"`
 	AcceptsPackages                bool `mapstructure:"accepts_packages"`
+
+	// Deprecated: ReportsRemoteConfig has no effect. AcceptsRemoteConfig enables both the
+	// AcceptsRemoteConfig and ReportsRemoteConfig OpAMP capabilities. This field will be
+	// removed in a future release.
+	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49763
+	ReportsRemoteConfig bool `mapstructure:"reports_remote_config"`
 }
 
 func (c Capabilities) SupportedCapabilities() protobufs.AgentCapabilities {
@@ -127,12 +132,11 @@ func (c Capabilities) SupportedCapabilities() protobufs.AgentCapabilities {
 		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnTraces
 	}
 
+	// AcceptsRemoteConfig enables both the AcceptsRemoteConfig and ReportsRemoteConfig
+	// OpAMP capabilities; accepting remote config without reporting its status is not useful.
 	if c.AcceptsRemoteConfig {
-		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig
-	}
-
-	if c.ReportsRemoteConfig {
-		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig
+		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig |
+			protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig
 	}
 
 	if c.AcceptsRestartCommand {

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -968,6 +968,18 @@ func TestCapabilities_SupportedCapabilities(t *testing.T) {
 				protobufs.AgentCapabilities_AgentCapabilities_ReportsPackageStatuses,
 		},
 		{
+			name:         "AcceptsRemoteConfig enables ReportsRemoteConfig",
+			capabilities: Capabilities{AcceptsRemoteConfig: true},
+			expectedAgentCapabilities: protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus |
+				protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig |
+				protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig,
+		},
+		{
+			name:                      "Deprecated ReportsRemoteConfig has no effect",
+			capabilities:              Capabilities{ReportsRemoteConfig: true},
+			expectedAgentCapabilities: protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus,
+		},
+		{
 			name: "Many capabilities",
 			capabilities: Capabilities{
 				AcceptsRemoteConfig:            true,

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -384,6 +384,15 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		return errors.New("accepts_packages capability is not yet fully implemented")
 	}
 
+	if s.config.Capabilities.ReportsRemoteConfig { //nolint:staticcheck // SA1019: deprecated field is read only to warn about its use
+		s.telemetrySettings.Logger.Error(
+			"The reports_remote_config capability is deprecated and has no effect. " +
+				"Remote config status is reported whenever accepts_remote_config is enabled. " +
+				"Remove reports_remote_config from the supervisor config; it will be removed in a future release. " +
+				"See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49763 for details.",
+		)
+	}
+
 	if err = s.getFeatureGates(); err != nil {
 		return fmt.Errorf("could not get feature gates from the Collector: %w", err)
 	}
@@ -2436,7 +2445,7 @@ func (s *Supervisor) saveLastReceivedOwnTelemetrySettings(set *protobufs.Connect
 
 // saveAndReportConfigStatus saves the config status to the persistent state and reports it to the server.
 func (s *Supervisor) saveAndReportConfigStatus(status protobufs.RemoteConfigStatuses, errorMessage string) {
-	if !s.config.Capabilities.ReportsRemoteConfig {
+	if !s.config.Capabilities.AcceptsRemoteConfig {
 		s.telemetrySettings.Logger.Debug("supervisor is not configured to report remote config status")
 		return
 	}
@@ -2466,7 +2475,7 @@ func (s *Supervisor) saveAndReportConfigStatus(status protobufs.RemoteConfigStat
 // the status is reported without overwriting the persisted status of the
 // config that triggered the rollback, and true is returned.
 func (s *Supervisor) reportActiveConfigStatus(status protobufs.RemoteConfigStatuses, errorMessage string) bool {
-	if !s.config.Capabilities.ReportsRemoteConfig {
+	if !s.config.Capabilities.AcceptsRemoteConfig {
 		s.telemetrySettings.Logger.Debug("supervisor is not configured to report remote config status")
 		return false
 	}

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -61,7 +61,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:
@@ -82,7 +81,6 @@ capabilities:
   reports_own_metrics: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:
@@ -1366,7 +1364,7 @@ service:
 			telemetrySettings: newNopTelemetrySettings(),
 			pidProvider:       staticPIDProvider(88888),
 			config: config.Supervisor{
-				Capabilities: config.Capabilities{AcceptsRemoteConfig: true, ReportsRemoteConfig: true},
+				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
 				Storage: config.Storage{
 					Directory: configStorageDir,
 				},
@@ -1470,7 +1468,7 @@ service:
 			telemetrySettings: newNopTelemetrySettings(),
 			pidProvider:       staticPIDProvider(88888),
 			config: config.Supervisor{
-				Capabilities: config.Capabilities{AcceptsRemoteConfig: true, ReportsRemoteConfig: true},
+				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
 				Storage: config.Storage{
 					Directory: configStorageDir,
 				},
@@ -1545,7 +1543,7 @@ service:
 			telemetrySettings: newNopTelemetrySettings(),
 			pidProvider:       defaultPIDProvider{},
 			config: config.Supervisor{
-				Capabilities: config.Capabilities{AcceptsRemoteConfig: true, ReportsRemoteConfig: true},
+				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
 				Storage: config.Storage{
 					Directory: configStorageDir,
 				},
@@ -1668,7 +1666,7 @@ service:
 			telemetrySettings: newNopTelemetrySettings(),
 			pidProvider:       staticPIDProvider(88888),
 			config: config.Supervisor{
-				Capabilities: config.Capabilities{AcceptsRemoteConfig: true, ReportsRemoteConfig: true},
+				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
 				Storage: config.Storage{
 					Directory: configStorageDir,
 				},
@@ -2506,7 +2504,7 @@ func TestSupervisor_saveAndReportConfigStatus(t *testing.T) {
 				AutomaticConfigRollback: true,
 			},
 			Capabilities: config.Capabilities{
-				ReportsRemoteConfig: true,
+				AcceptsRemoteConfig: true,
 			},
 			Storage: config.Storage{
 				Directory: filepath.Dir(persistentState.configPath),
@@ -2573,7 +2571,7 @@ func TestSupervisor_reportLastWorkingRemoteConfigStatus(t *testing.T) {
 		telemetrySettings: newNopTelemetrySettings(),
 		config: config.Supervisor{
 			Capabilities: config.Capabilities{
-				ReportsRemoteConfig: true,
+				AcceptsRemoteConfig: true,
 			},
 		},
 		persistentState: persistentState,
@@ -3593,7 +3591,6 @@ capabilities:
   reports_own_metrics: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/supervisor/testdata/supervisor_windows_service_test_config.yaml
+++ b/cmd/opampsupervisor/supervisor/testdata/supervisor_windows_service_test_config.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 agent:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_accepts_conn.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_accepts_conn.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_opamp_connection_settings: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_agent_description.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_agent_description.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_auth_bearer_accepts_conn.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_auth_bearer_accepts_conn.yaml
@@ -9,7 +9,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_opamp_connection_settings: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_basic.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_basic.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_emit_telemetry.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_emit_telemetry.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_exec_config.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_exec_config.yaml
@@ -6,7 +6,6 @@ capabilities:
   reports_own_metrics: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_fallback.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_fallback.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck.yaml
@@ -11,7 +11,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_http.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_http.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_logging.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_logging.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_no_fg.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_no_fg.yaml
@@ -9,7 +9,6 @@ capabilities:
   reports_own_traces: false
   reports_health: false
   accepts_remote_config: false
-  reports_remote_config: false
 
 storage:
   directory: '{{.storage_dir}}'

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_nocap.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_nocap.yaml
@@ -9,7 +9,6 @@ capabilities:
   reports_own_traces: false
   reports_health: false
   accepts_remote_config: false
-  reports_remote_config: false
 
 storage:
   directory: '{{.storage_dir}}'

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_persistence.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_persistence.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
 
 storage:
   directory: '{{.storage_dir}}'

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_report_status.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_report_status.yaml
@@ -10,7 +10,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_reports_available_components.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_reports_available_components.yaml
@@ -7,7 +7,6 @@ capabilities:
   reports_own_metrics: false
   reports_health: false
   accepts_remote_config: false
-  reports_remote_config: false
 
 storage:
   directory: '{{.storage_dir}}'

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_reports_heartbeat.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_reports_heartbeat.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_opamp_connection_settings: true
   reports_heartbeat: true
 

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_server_port.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_server_port.yaml
@@ -8,7 +8,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
   accepts_restart_command: true
 
 storage:

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_test.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_test.yaml
@@ -10,7 +10,6 @@ capabilities:
   reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
-  reports_remote_config: true
 
 storage:
   directory: '{{.storage_dir}}'


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `accepts_remote_config` option now enables both the AcceptsRemoteConfig and ReportsRemoteConfig OpAMP capabilities. `reports_remote_config` is still parsed but has no effect. Instead the supervisor logs an error at startup when it is set to true.

This is phase 1 of the deprecation plan in #49763. This should release in v0.161.0.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
#49763 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests updated.

<!--Describe the documentation added.-->
#### Documentation
Code and readme comments updated

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
