### PR TITLE
[receiver/cloudflare] compare the shared secret in constant time

### DIFF
--- a/.chloggen/cloudflarereceiver-constant-time-secret.yaml
+++ b/.chloggen/cloudflarereceiver-constant-time-secret.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/cloudflare
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Compare the configured shared secret in constant time.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50708]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `X-CF-Secret` header was compared to the configured secret with `!=`, which returns as soon
+  as it finds a differing byte. `crypto/subtle.ConstantTimeCompare` is used instead, matching the
+  approach already taken in `extension/bearertokenauth`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/cloudflarereceiver-constant-time-secret.yaml
+++ b/.chloggen/cloudflarereceiver-constant-time-secret.yaml
@@ -10,7 +10,7 @@ component: receiver/cloudflare
 note: Compare the configured shared secret in constant time.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [50708]
+issues: [50691]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/cloudflarereceiver/logs.go
+++ b/receiver/cloudflarereceiver/logs.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -158,7 +159,7 @@ func (l *logsReceiver) handleRequest(rw http.ResponseWriter, req *http.Request) 
 			rw.WriteHeader(http.StatusUnauthorized)
 			l.logger.Debug("Got payload with no Secret when it was specified in config, dropping...")
 			return
-		} else if secretHeader != l.cfg.Secret {
+		} else if subtle.ConstantTimeCompare([]byte(secretHeader), []byte(l.cfg.Secret)) != 1 {
 			rw.WriteHeader(http.StatusUnauthorized)
 			l.logger.Debug("Got payload with invalid Secret, dropping...")
 			return

--- a/receiver/cloudflarereceiver/logs_test.go
+++ b/receiver/cloudflarereceiver/logs_test.go
@@ -245,6 +245,24 @@ func TestHandleRequest(t *testing.T) {
 			expectedStatusCode: http.StatusUnauthorized,
 		},
 		{
+			// Same length as the configured secret, differing only in the final byte.
+			// A comparison that short-circuits on the first mismatch would reject this
+			// just as fast as a wholly different value; the point of the case is that
+			// it is still rejected once the comparison is constant-time.
+			name: "Wrong secret of equal length",
+			request: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{},
+				Body:   io.NopCloser(bytes.NewBufferString(`{"ClientIP": "127.0.0.1"}`)),
+				Header: map[string][]string{
+					textproto.CanonicalMIMEHeaderKey(secretHeaderName): {"abc124"},
+				},
+			},
+			logExpected:        false,
+			consumerFailure:    false,
+			expectedStatusCode: http.StatusUnauthorized,
+		},
+		{
 			name: "Invalid payload",
 			request: &http.Request{
 				Method: http.MethodPost,


### PR DESCRIPTION
#### Description

The `X-CF-Secret` header is compared to the configured secret with `!=`:

```go
} else if secretHeader != l.cfg.Secret {
```

Go's string comparison returns as soon as it finds a differing byte, so how long the check takes depends on how many leading bytes matched. This uses `crypto/subtle.ConstantTimeCompare` instead.

This is hardening rather than a reported exploit — I am not claiming a practical attack, and over a network the signal would be buried in jitter. The argument for changing it is consistency: `extension/bearertokenauth` already does exactly this for the equivalent check, so the codebase has a settled answer for "compare a caller-supplied secret" and this receiver is not using it.

Behavior is unchanged. A missing header is still 401, a non-matching secret is still 401, and a matching one still proceeds.

#### Testing

Added a case to `TestHandleRequest` for a wrong secret of the *same length* as the configured one, differing only in the final byte — the shape a short-circuiting comparison distinguishes fastest, and the one worth pinning as still-rejected.

`receiver/cloudflarereceiver` passes; `gofmt` is clean.

#### Documentation

None — no configuration or behavior change.

---

*Disclosure: prepared with AI assistance. The commit carries an `Assisted-by:` trailer per AGENTS.md; this description is my own.*

#### Authorship

- [ ] I, a human, wrote this pull request description myself.