### PR TITLE
[cmd/opampsupervisor] Fix close of closed channel panic in e2e test

### DIFF
--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1347,6 +1347,7 @@ func TestSupervisorStartsWithNoOpAMPServer(t *testing.T) {
 	cfg, hash, inputFile, outputFile := createSimplePipelineCollectorConf(t)
 
 	configuredChan := make(chan struct{})
+	var configuredOnce sync.Once
 	connected := atomic.Bool{}
 	server := newUnstartedOpAMPServer(t, defaultConnectingHandler,
 		types.ConnectionCallbacks{
@@ -1356,7 +1357,7 @@ func TestSupervisorStartsWithNoOpAMPServer(t *testing.T) {
 			OnMessage: func(ctx context.Context, conn types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				lastCfgHash := message.GetRemoteConfigStatus().GetLastRemoteConfigHash()
 				if bytes.Equal(lastCfgHash, hash) {
-					close(configuredChan)
+					configuredOnce.Do(func() { close(configuredChan) })
 				}
 
 				return &protobufs.ServerToAgent{}


### PR DESCRIPTION
#### Description

`TestSupervisorStartsWithNoOpAMPServer` panics with `close of closed channel`, which aborts the whole opampsupervisor e2e test binary (seen on the `supervisor-test (windows-2025)` job).

The server's `OnMessage` callback closes `configuredChan` whenever an agent message carries the expected config hash. The agent keeps reporting that same hash in later status messages, so a second matching message closes the already-closed channel and panics. It shows up on Windows because a late agent message arrives during the slower shutdown.

Guard the close with a `sync.Once` so it fires at most once. Test-only change.

#### Link to tracking issue
N/A

#### Authorship

- [x] I, a human, wrote this pull request description myself.