### PR TITLE
[receiver/kafka]: Add opt-in signal_header

### DIFF
--- a/.chloggen/kafkareceiver-signal-header.yaml
+++ b/.chloggen/kafkareceiver-signal-header.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow consuming more than one signal from the same Kafka topic with `signal_header`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50244]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Set `signal_header: true` and point each signal's `topics` at the same name. Attach
+  this receiver to every pipeline that should read it. Those pipelines share one Kafka
+  consumer. Records with a missing, duplicate, or unknown `otelcol.signal` header, or a
+  signal with no pipeline, are permanent errors. Do not consume mixed signals without
+  this setting, and do not turn it off while mixed records are still in the topic.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -73,6 +73,7 @@ The following settings can be optionally configured:
   - `exclude_topic` (Deprecated [v0.142.0]: use `exclude_topics`)
      (default = ""): If this is set, it will take precedence over default value of `exclude_topics`
   - `exclude_topics` (default = ""): When using regex topic patterns (prefix with `^`), this regex pattern excludes matching topics.
+- `signal_header` (default = false): Routes records using the `otelcol.signal` header (`logs`, `metrics`, `traces`, or `profiles`). When this receiver is attached to more than one signal pipeline, they share a single Kafka consumer. See [Shared signal topic](#shared-signal-topic).
 - `group_id` (default = otel-collector): The consumer group that receiver will be consuming messages from
 - `client_id` (default = otel-collector): The consumer client ID that receiver will use
 - `rack_id` (default = ""): The rack identifier for this client. When set and brokers are configured with a rack-aware replica selector, the client will prefer fetching from the closest replica.
@@ -153,6 +154,69 @@ The following settings can be optionally configured:
   - `metrics`
     - `kafka_receiver_records_delay`:
       - `enabled` (default = false) Whether the metric kafka_receiver_records_delay will be reported or not.
+
+### Shared signal topic
+
+To consume more than one signal from the same topic, enable `signal_header` and point each signal's
+`topics` at that topic. Attach this receiver to every pipeline that should read it:
+
+```yaml
+receivers:
+  kafka/shared:
+    signal_header: true
+    group_id: otel-shared
+    logs:
+      topics: [otlp]
+    metrics:
+      topics: [otlp]
+    traces:
+      topics: [otlp]
+    profiles:
+      topics: [otlp]
+
+service:
+  pipelines:
+    logs:
+      receivers: [kafka/shared]
+    metrics:
+      receivers: [kafka/shared]
+    traces:
+      receivers: [kafka/shared]
+    profiles:
+      receivers: [kafka/shared]
+```
+
+The receiver starts one Kafka consumer for the component and subscribes to the union of those
+topics. Each signal still uses its own `encoding`. That consumer commits one offset per partition,
+so if one signal's pipeline blocks, later records of the other signals on that partition wait. You
+also cannot add consumers for only one signal. A shared topic is a good fit when you are
+partition-constrained or running at low throughput. Keep separate topics when you need independent
+retention or to scale consumers per signal.
+
+`exclude_topics` applies to that shared consumer, so every attached signal must set the same
+exclusions or component creation fails. Each of those signals must still include a `^` regex topic,
+a literal-only signal cannot set exclusions even if another attached signal uses regex.
+
+If any topic uses a `^` regex prefix, the whole subscription switches to regex matching and literal
+names are converted to anchored patterns. That makes each metadata refresh list every topic in the
+cluster.
+
+Records with a missing, duplicate, or unknown `otelcol.signal` header, or a signal that has no
+pipeline, are permanent errors. They increment `otelcol_kafka_receiver_records_routing_failed`.
+Whether the record is committed or the partition blocks is controlled by `message_marking`.
+
+To migrate:
+
+1. Upgrade the exporter and receiver with no config change.
+2. Enable `signal_header` on the exporter. Leave the per-signal topics as they are. Existing
+   receivers ignore the extra header.
+3. Add a new receiver with `signal_header: true` and a new `group_id`, attached to every signal
+   pipeline on the shared topic.
+4. Move the exporter topics onto the shared topic.
+5. Drain the old topics, then remove the old receivers.
+
+To roll back, move the exporters back to the old topics first. Do not turn `signal_header` off, or
+run a receiver without it, while mixed records are still in the topic.
 
 ### Supported encodings
 

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -45,6 +45,10 @@ type Config struct {
 	// HeaderExtraction controls extraction of headers from Kafka records.
 	HeaderExtraction HeaderExtraction `mapstructure:"header_extraction"`
 
+	// SignalHeader routes records using the "otelcol.signal" Kafka header and
+	// shares one consumer across the signal pipelines that use this receiver.
+	SignalHeader bool `mapstructure:"signal_header"`
+
 	// ErrorBackoff controls backoff/retry behavior when the next consumer
 	// returns an error.
 	ErrorBackOff configretry.BackOffConfig `mapstructure:"error_backoff"`

--- a/receiver/kafkareceiver/config.schema.yaml
+++ b/receiver/kafkareceiver/config.schema.yaml
@@ -89,6 +89,9 @@ properties:
   profiles:
     description: Profiles holds configuration about how profiles should be consumed.
     $ref: topic_encoding_config
+  signal_header:
+    description: SignalHeader routes records using the "otelcol.signal" Kafka header and shares one consumer across the signal pipelines that use this receiver.
+    type: boolean
   telemetry:
     description: Telemetry controls optional telemetry configuration.
     $ref: telemetry_config

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -63,6 +63,7 @@ func TestLoadConfig(t *testing.T) {
 					Topics:   []string{"logs"},
 					Encoding: "direct",
 				}
+				cfg.SignalHeader = true
 				cfg.ErrorBackOff = configretry.BackOffConfig{
 					Enabled:         true,
 					InitialInterval: 1 * time.Second,

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -145,11 +145,7 @@ func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 	c.host = host
 	c.reportStatus(componentstatus.StatusStarting)
 
-	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
-		ReceiverID:             c.settings.ID,
-		Transport:              transport,
-		ReceiverCreateSettings: c.settings,
-	})
+	obsrecv, err := newObsReport(c.settings)
 	if err != nil {
 		return err
 	}
@@ -209,6 +205,14 @@ func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 
 	go c.consumeLoop(context.Background())
 	return nil
+}
+
+func newObsReport(set receiver.Settings) (*receiverhelper.ObsReport, error) {
+	return receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             set.ID,
+		Transport:              transport,
+		ReceiverCreateSettings: set,
+	})
 }
 
 func (c *franzConsumer) consumeLoop(ctx context.Context) {

--- a/receiver/kafkareceiver/documentation.md
+++ b/receiver/kafkareceiver/documentation.md
@@ -247,6 +247,22 @@ This metric is reported with an assumption that the exporter and the receiver cl
 | topic | The Kafka topic. | Any Str | - |
 | partition | The Kafka topic partition. | Any Int | - |
 
+### otelcol_kafka_receiver_records_routing_failed
+
+Number of records that could not be routed using the otelcol.signal header.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| topic | The Kafka topic. | Any Str | - |
+| partition | The Kafka topic partition. | Any Int | - |
+| reason | The reason a Kafka record could not be routed. | Str: ``missing_header``, ``duplicate_header``, ``unknown_signal``, ``unconfigured_signal`` | - |
+
 ### otelcol_kafka_receiver_unmarshal_failed_log_records
 
 Number of log records failed to be unmarshaled

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/xreceiver"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadata"
 )
@@ -32,14 +33,19 @@ const (
 
 // NewFactory creates Kafka receiver factory.
 func NewFactory() receiver.Factory {
+	f := kafkaReceiverFactory{receivers: sharedcomponent.NewSharedComponents()}
 	return xreceiver.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
-		xreceiver.WithTraces(createTracesReceiver, metadata.TracesStability),
-		xreceiver.WithMetrics(createMetricsReceiver, metadata.MetricsStability),
-		xreceiver.WithLogs(createLogsReceiver, metadata.LogsStability),
-		xreceiver.WithProfiles(createProfilesReceiver, metadata.ProfilesStability),
+		xreceiver.WithTraces(f.createTraces, metadata.TracesStability),
+		xreceiver.WithMetrics(f.createMetrics, metadata.MetricsStability),
+		xreceiver.WithLogs(f.createLogs, metadata.LogsStability),
+		xreceiver.WithProfiles(f.createProfiles, metadata.ProfilesStability),
 	)
+}
+
+type kafkaReceiverFactory struct {
+	receivers *sharedcomponent.SharedComponents
 }
 
 func createDefaultConfig() component.Config {
@@ -74,6 +80,75 @@ func createDefaultConfig() component.Config {
 			ExtractHeaders: false,
 		},
 	}
+}
+
+// createShared reuses a muxReceiver per config when signal_header is
+// enabled. Each Create* call registers that signal so all attached pipelines
+// share one Kafka consumer.
+func (f *kafkaReceiverFactory) createShared(cfg *Config,
+	set receiver.Settings, register func(*muxReceiver) error,
+) (*sharedcomponent.SharedComponent, error) {
+	var err error
+	shared := f.receivers.GetOrAdd(cfg, func() component.Component {
+		var receiver *muxReceiver
+		receiver, err = newMuxReceiver(cfg, set)
+		return receiver
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := register(shared.Unwrap().(*muxReceiver)); err != nil {
+		return nil, err
+	}
+	return shared, nil
+}
+
+func (f *kafkaReceiverFactory) createTraces(ctx context.Context,
+	set receiver.Settings, cfg component.Config, nextConsumer consumer.Traces,
+) (receiver.Traces, error) {
+	config := cfg.(*Config)
+	if !config.SignalHeader {
+		return createTracesReceiver(ctx, set, cfg, nextConsumer)
+	}
+	return f.createShared(config, set, func(mux *muxReceiver) error {
+		return mux.registerTraces(set, nextConsumer)
+	})
+}
+
+func (f *kafkaReceiverFactory) createMetrics(ctx context.Context,
+	set receiver.Settings, cfg component.Config, nextConsumer consumer.Metrics,
+) (receiver.Metrics, error) {
+	config := cfg.(*Config)
+	if !config.SignalHeader {
+		return createMetricsReceiver(ctx, set, cfg, nextConsumer)
+	}
+	return f.createShared(config, set, func(mux *muxReceiver) error {
+		return mux.registerMetrics(set, nextConsumer)
+	})
+}
+
+func (f *kafkaReceiverFactory) createLogs(ctx context.Context,
+	set receiver.Settings, cfg component.Config, nextConsumer consumer.Logs,
+) (receiver.Logs, error) {
+	config := cfg.(*Config)
+	if !config.SignalHeader {
+		return createLogsReceiver(ctx, set, cfg, nextConsumer)
+	}
+	return f.createShared(config, set, func(mux *muxReceiver) error {
+		return mux.registerLogs(set, nextConsumer)
+	})
+}
+
+func (f *kafkaReceiverFactory) createProfiles(ctx context.Context,
+	set receiver.Settings, cfg component.Config, nextConsumer xconsumer.Profiles,
+) (xreceiver.Profiles, error) {
+	config := cfg.(*Config)
+	if !config.SignalHeader {
+		return createProfilesReceiver(ctx, set, cfg, nextConsumer)
+	}
+	return f.createShared(config, set, func(mux *muxReceiver) error {
+		return mux.registerProfiles(set, nextConsumer)
+	})
 }
 
 func createTracesReceiver(

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -9,12 +9,57 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/receiver/xreceiver"
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadata"
 )
+
+type trackingMeterProvider struct {
+	metric.MeterProvider
+	dropped []string
+}
+
+func (p *trackingMeterProvider) DropInjectedAttributes(attrs ...string) metric.MeterProvider {
+	p.dropped = append(p.dropped, attrs...)
+	return p.MeterProvider
+}
+
+type trackingTracerProvider struct {
+	trace.TracerProvider
+	dropped     []string
+	tracerCalls int
+}
+
+func (p *trackingTracerProvider) DropInjectedAttributes(attrs ...string) trace.TracerProvider {
+	p.dropped = append(p.dropped, attrs...)
+	return p.TracerProvider
+}
+
+func (p *trackingTracerProvider) Tracer(name string, options ...trace.TracerOption) trace.Tracer {
+	p.tracerCalls++
+	return p.TracerProvider.Tracer(name, options...)
+}
+
+type trackingCore struct {
+	zapcore.Core
+	dropped []string
+}
+
+func (c *trackingCore) DropInjectedAttributes(attrs ...string) zapcore.Core {
+	c.dropped = append(c.dropped, attrs...)
+	return c.Core
+}
 
 func encodingFromReceiver(tb testing.TB, r any, section string) string {
 	tb.Helper()
@@ -36,12 +81,103 @@ func encodingFromReceiver(tb testing.TB, r any, section string) string {
 	return ""
 }
 
+func signalHeaderConfig() *Config {
+	cfg := createDefaultConfig().(*Config)
+	cfg.SignalHeader = true
+	return cfg
+}
+
+func createAllSignals(t *testing.T, cfg *Config) (traces, metrics, logs, profiles any) {
+	t.Helper()
+	factory := NewFactory()
+	settings := receivertest.NewNopSettings(metadata.Type)
+	var err error
+	traces, err = factory.CreateTraces(t.Context(), settings, cfg, new(consumertest.TracesSink))
+	require.NoError(t, err)
+	metrics, err = factory.CreateMetrics(t.Context(), settings, cfg, new(consumertest.MetricsSink))
+	require.NoError(t, err)
+	logs, err = factory.CreateLogs(t.Context(), settings, cfg, new(consumertest.LogsSink))
+	require.NoError(t, err)
+	profiles, err = factory.(xreceiver.Factory).CreateProfiles(t.Context(), settings, cfg, new(consumertest.ProfilesSink))
+	require.NoError(t, err)
+	return traces, metrics, logs, profiles
+}
+
+func unwrapMux(r any) *muxReceiver {
+	return r.(*sharedcomponent.SharedComponent).Unwrap().(*muxReceiver)
+}
+
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	assert.NotNil(t, cfg, "failed to create default config")
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 	assert.Equal(t, configkafka.NewDefaultClientConfig(), cfg.ClientConfig)
 	assert.Equal(t, configkafka.NewDefaultConsumerConfig(), cfg.ConsumerConfig)
+}
+
+func TestSignalHeaderReceiverIsShared(t *testing.T) {
+	cfg := signalHeaderConfig()
+	cfg.Traces.Topics = []string{"^shared$"}
+	cfg.Metrics.Topics = []string{"^shared$"}
+	cfg.Logs.Topics = []string{"^logs$"}
+	cfg.Profiles.Topics = []string{"^shared$"}
+	cfg.Traces.ExcludeTopics = []string{"^debug$"}
+	cfg.Metrics.ExcludeTopics = []string{"^debug$"}
+	cfg.Logs.ExcludeTopics = []string{"^debug$"}
+	cfg.Profiles.ExcludeTopics = []string{"^debug$"}
+
+	traces, metrics, logs, profiles := createAllSignals(t, cfg)
+	assert.Same(t, traces, metrics)
+	assert.Same(t, traces, logs)
+	assert.Same(t, traces, profiles)
+	mux := unwrapMux(traces)
+	assert.Equal(t, []string{"^shared$", "^logs$"}, mux.topics)
+	assert.Equal(t, []string{"^debug$"}, mux.excludeTopics)
+}
+
+func TestSignalHeaderReceiverRejectsDifferentExclusions(t *testing.T) {
+	cfg := signalHeaderConfig()
+	cfg.Traces.Topics = []string{"^otel-.*"}
+	cfg.Traces.ExcludeTopics = []string{"^otel-metrics$"}
+	cfg.Metrics.Topics = []string{"otel-metrics"}
+	factory := NewFactory()
+	settings := receivertest.NewNopSettings(metadata.Type)
+
+	_, err := factory.CreateTraces(t.Context(), settings, cfg, new(consumertest.TracesSink))
+	require.NoError(t, err)
+	_, err = factory.CreateMetrics(t.Context(), settings, cfg, new(consumertest.MetricsSink))
+	assert.ErrorContains(t, err, "signal_header requires identical exclude_topics")
+}
+
+func TestSignalHeaderReceiverPreservesLiteralTopicsWithRegex(t *testing.T) {
+	cfg := signalHeaderConfig()
+	cfg.Traces.Topics = []string{"^traces-.*"}
+	cfg.Logs.Topics = []string{"otlp.logs"}
+	factory := NewFactory()
+	settings := receivertest.NewNopSettings(metadata.Type)
+
+	traces, err := factory.CreateTraces(t.Context(), settings, cfg, new(consumertest.TracesSink))
+	require.NoError(t, err)
+	_, err = factory.CreateLogs(t.Context(), settings, cfg, new(consumertest.LogsSink))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"^traces-.*", `^otlp\.logs$`}, unwrapMux(traces).topics)
+}
+
+func TestSignalHeaderReceiverDropsSignalFromSharedTelemetry(t *testing.T) {
+	meter := &trackingMeterProvider{MeterProvider: metricnoop.NewMeterProvider()}
+	tracer := &trackingTracerProvider{TracerProvider: tracenoop.NewTracerProvider()}
+	core := &trackingCore{Core: zap.NewNop().Core()}
+	settings := receivertest.NewNopSettings(metadata.Type)
+	settings.MeterProvider = meter
+	settings.TracerProvider = tracer
+	settings.Logger = zap.New(core)
+
+	_, err := newMuxReceiver(signalHeaderConfig(), settings)
+	require.NoError(t, err)
+	want := []string{kafka.SignalHeaderKey}
+	assert.Equal(t, want, meter.dropped)
+	assert.Equal(t, want, tracer.dropped)
+	assert.Equal(t, want, core.dropped)
 }
 
 func TestCreateTraces(t *testing.T) {

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jaegertracing/jaeger-idl v0.11.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.159.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.159.0
@@ -33,6 +34,8 @@ require (
 	go.opentelemetry.io/collector/pdata v1.65.1-0.20260901210140-566f9531b8c8
 	go.opentelemetry.io/collector/pdata/pprofile v0.159.1-0.20260901210140-566f9531b8c8
 	go.opentelemetry.io/collector/pdata/testdata v0.159.1-0.20260901210140-566f9531b8c8
+	go.opentelemetry.io/collector/pipeline v1.65.1-0.20260901210140-566f9531b8c8
+	go.opentelemetry.io/collector/pipeline/xpipeline v0.159.1-0.20260901210140-566f9531b8c8
 	go.opentelemetry.io/collector/receiver v1.65.1-0.20260901210140-566f9531b8c8
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.159.1-0.20260901210140-566f9531b8c8
 	go.opentelemetry.io/collector/receiver/receivertest v0.159.1-0.20260901210140-566f9531b8c8
@@ -107,8 +110,6 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.65.1-0.20260901210140-566f9531b8c8 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.159.1-0.20260901210140-566f9531b8c8 // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.159.1-0.20260901210140-566f9531b8c8 // indirect
-	go.opentelemetry.io/collector/pipeline v1.65.1-0.20260901210140-566f9531b8c8 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.159.1-0.20260901210140-566f9531b8c8 // indirect
 	go.opentelemetry.io/otel/sdk v1.46.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
@@ -122,6 +123,8 @@ require (
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent => ../../internal/sharedcomponent
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils => ../../pkg/core/xidutils
 

--- a/receiver/kafkareceiver/internal/metadata/generated_telemetry.go
+++ b/receiver/kafkareceiver/internal/metadata/generated_telemetry.go
@@ -40,6 +40,7 @@ type TelemetryBuilder struct {
 	KafkaReceiverReadLatency                 metric.Float64Histogram
 	KafkaReceiverRecords                     metric.Int64Counter
 	KafkaReceiverRecordsDelay                metric.Float64Histogram
+	KafkaReceiverRecordsRoutingFailed        metric.Int64Counter
 	KafkaReceiverUnmarshalFailedLogRecords   metric.Int64Counter
 	KafkaReceiverUnmarshalFailedMetricPoints metric.Int64Counter
 	KafkaReceiverUnmarshalFailedProfiles     metric.Int64Counter
@@ -166,6 +167,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithDescription("The time in seconds between producing and receiving a batch of records. [Development]"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries([]float64{0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000}...),
+	)
+	errs = errors.Join(errs, err)
+	builder.KafkaReceiverRecordsRoutingFailed, err = builder.meter.Int64Counter(
+		"otelcol_kafka_receiver_records_routing_failed",
+		metric.WithDescription("Number of records that could not be routed using the otelcol.signal header. [Development]"),
+		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.KafkaReceiverUnmarshalFailedLogRecords, err = builder.meter.Int64Counter(

--- a/receiver/kafkareceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/receiver/kafkareceiver/internal/metadatatest/generated_telemetrytest.go
@@ -252,6 +252,22 @@ func AssertEqualKafkaReceiverRecordsDelay(t *testing.T, tt *componenttest.Teleme
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualKafkaReceiverRecordsRoutingFailed(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_kafka_receiver_records_routing_failed",
+		Description: "Number of records that could not be routed using the otelcol.signal header. [Development]",
+		Unit:        "1",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_kafka_receiver_records_routing_failed")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualKafkaReceiverUnmarshalFailedLogRecords(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_kafka_receiver_unmarshal_failed_log_records",

--- a/receiver/kafkareceiver/internal/metadatatest/generated_telemetrytest_test.go
+++ b/receiver/kafkareceiver/internal/metadatatest/generated_telemetrytest_test.go
@@ -34,6 +34,7 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.KafkaReceiverReadLatency.Record(context.Background(), 1)
 	tb.KafkaReceiverRecords.Add(context.Background(), 1)
 	tb.KafkaReceiverRecordsDelay.Record(context.Background(), 1)
+	tb.KafkaReceiverRecordsRoutingFailed.Add(context.Background(), 1)
 	tb.KafkaReceiverUnmarshalFailedLogRecords.Add(context.Background(), 1)
 	tb.KafkaReceiverUnmarshalFailedMetricPoints.Add(context.Background(), 1)
 	tb.KafkaReceiverUnmarshalFailedProfiles.Add(context.Background(), 1)
@@ -82,6 +83,9 @@ func TestSetupTelemetry(t *testing.T) {
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualKafkaReceiverRecordsDelay(t, testTel,
 		[]metricdata.HistogramDataPoint[float64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualKafkaReceiverRecordsRoutingFailed(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualKafkaReceiverUnmarshalFailedLogRecords(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -5,8 +5,13 @@ package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"iter"
+	"regexp"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -21,17 +26,34 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pipeline"
+	"go.opentelemetry.io/collector/pipeline/xpipeline"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/xreceiver"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadata"
 )
 
 const transport = "kafka"
+
+const (
+	routingFailureMissingHeader      = "missing_header"
+	routingFailureDuplicateHeader    = "duplicate_header"
+	routingFailureUnknownSignal      = "unknown_signal"
+	routingFailureUnconfiguredSignal = "unconfigured_signal"
+)
+
+var (
+	errSignalHeaderMissing  = errors.New("signal header is missing")
+	errSignalHeaderMultiple = errors.New("multiple signal headers")
+)
 
 type consumeMessageFunc func(ctx context.Context, record *kgo.Record, attrs attribute.Set) error
 
@@ -69,7 +91,14 @@ type messageHandler[T plog.Logs | pmetric.Metrics | ptrace.Traces | pprofile.Pro
 }
 
 func newLogsReceiver(config *Config, set receiver.Settings, nextConsumer consumer.Logs) (receiver.Logs, error) {
-	newConsumeMessageFunc := func(host component.Host,
+	return newFranzKafkaConsumer(config, set,
+		config.Logs.Topics, config.Logs.ExcludeTopics,
+		newLogsConsumeMessage(config, set, nextConsumer),
+	)
+}
+
+func newLogsConsumeMessage(config *Config, set receiver.Settings, nextConsumer consumer.Logs) newConsumeMessageFunc {
+	return func(host component.Host,
 		obsrecv *receiverhelper.ObsReport,
 		telBldr *metadata.TelemetryBuilder,
 	) (consumeMessageFunc, error) {
@@ -92,11 +121,17 @@ func newLogsReceiver(config *Config, set receiver.Settings, nextConsumer consume
 			)
 		}, nil
 	}
-	return newFranzKafkaConsumer(config, set, config.Logs.Topics, config.Logs.ExcludeTopics, newConsumeMessageFunc)
 }
 
 func newMetricsReceiver(config *Config, set receiver.Settings, nextConsumer consumer.Metrics) (receiver.Metrics, error) {
-	newConsumeMessageFunc := func(host component.Host,
+	return newFranzKafkaConsumer(config, set,
+		config.Metrics.Topics, config.Metrics.ExcludeTopics,
+		newMetricsConsumeMessage(config, set, nextConsumer),
+	)
+}
+
+func newMetricsConsumeMessage(config *Config, set receiver.Settings, nextConsumer consumer.Metrics) newConsumeMessageFunc {
+	return func(host component.Host,
 		obsrecv *receiverhelper.ObsReport,
 		telBldr *metadata.TelemetryBuilder,
 	) (consumeMessageFunc, error) {
@@ -119,11 +154,17 @@ func newMetricsReceiver(config *Config, set receiver.Settings, nextConsumer cons
 			)
 		}, nil
 	}
-	return newFranzKafkaConsumer(config, set, config.Metrics.Topics, config.Metrics.ExcludeTopics, newConsumeMessageFunc)
 }
 
 func newTracesReceiver(config *Config, set receiver.Settings, nextConsumer consumer.Traces) (receiver.Traces, error) {
-	consumeFn := func(host component.Host,
+	return newFranzKafkaConsumer(config, set,
+		config.Traces.Topics, config.Traces.ExcludeTopics,
+		newTracesConsumeMessage(config, set, nextConsumer),
+	)
+}
+
+func newTracesConsumeMessage(config *Config, set receiver.Settings, nextConsumer consumer.Traces) newConsumeMessageFunc {
+	return func(host component.Host,
 		obsrecv *receiverhelper.ObsReport,
 		telBldr *metadata.TelemetryBuilder,
 	) (consumeMessageFunc, error) {
@@ -146,11 +187,17 @@ func newTracesReceiver(config *Config, set receiver.Settings, nextConsumer consu
 			)
 		}, nil
 	}
-	return newFranzKafkaConsumer(config, set, config.Traces.Topics, config.Traces.ExcludeTopics, consumeFn)
 }
 
 func newProfilesReceiver(config *Config, set receiver.Settings, nextConsumer xconsumer.Profiles) (xreceiver.Profiles, error) {
-	consumeFn := func(host component.Host,
+	return newFranzKafkaConsumer(config, set,
+		config.Profiles.Topics, config.Profiles.ExcludeTopics,
+		newProfilesConsumeMessage(config, set, nextConsumer),
+	)
+}
+
+func newProfilesConsumeMessage(config *Config, set receiver.Settings, nextConsumer xconsumer.Profiles) newConsumeMessageFunc {
+	return func(host component.Host,
 		obsrecv *receiverhelper.ObsReport,
 		telBldr *metadata.TelemetryBuilder,
 	) (consumeMessageFunc, error) {
@@ -173,7 +220,257 @@ func newProfilesReceiver(config *Config, set receiver.Settings, nextConsumer xco
 			)
 		}, nil
 	}
-	return newFranzKafkaConsumer(config, set, config.Profiles.Topics, config.Profiles.ExcludeTopics, consumeFn)
+}
+
+type muxReceiver struct {
+	*franzConsumer
+
+	config   *Config
+	logs     *registeredConsumer[consumer.Logs]
+	metrics  *registeredConsumer[consumer.Metrics]
+	traces   *registeredConsumer[consumer.Traces]
+	profiles *registeredConsumer[xconsumer.Profiles]
+
+	topicConfigRegistered bool
+}
+
+type registeredConsumer[T any] struct {
+	settings receiver.Settings
+	next     T
+}
+
+func newMuxReceiver(config *Config, set receiver.Settings) (*muxReceiver, error) {
+	r := &muxReceiver{config: config}
+	consumer, err := newFranzKafkaConsumer(config, withoutSignalTelemetry(set),
+		nil, nil, r.newConsumeMessage,
+	)
+	if err != nil {
+		return nil, err
+	}
+	r.franzConsumer = consumer
+	return r, nil
+}
+
+type injectedCore interface {
+	DropInjectedAttributes(...string) zapcore.Core
+}
+
+type injectedMeterProvider interface {
+	DropInjectedAttributes(...string) metric.MeterProvider
+}
+
+type injectedTracerProvider interface {
+	DropInjectedAttributes(...string) trace.TracerProvider
+}
+
+// withoutSignalTelemetry drops otelcol.signal from the shared Kafka client's
+// logger, meter, and tracer. GetOrAdd constructs the mux on the first
+// Create*, so without the drop, broker and fetch metrics would be tagged as
+// that pipeline's signal even though one consumer serves every attached
+// pipeline. Consume-path obs still uses each pipeline's original settings.
+// The type asserts copy collector/internal/telemetry.DropInjectedAttributes,
+// contrib cannot import that package.
+func withoutSignalTelemetry(set receiver.Settings) receiver.Settings {
+	set.Logger = set.Logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		if injected, ok := core.(injectedCore); ok {
+			return injected.DropInjectedAttributes(kafka.SignalHeaderKey)
+		}
+		return core
+	}))
+	if injected, ok := set.MeterProvider.(injectedMeterProvider); ok {
+		set.MeterProvider = injected.DropInjectedAttributes(kafka.SignalHeaderKey)
+	}
+	if injected, ok := set.TracerProvider.(injectedTracerProvider); ok {
+		set.TracerProvider = injected.DropInjectedAttributes(kafka.SignalHeaderKey)
+	}
+	return set
+}
+
+func (r *muxReceiver) registerLogs(set receiver.Settings, next consumer.Logs) error {
+	if err := r.addTopicConfig(pipeline.SignalLogs, r.config.Logs); err != nil {
+		return err
+	}
+	r.logs = &registeredConsumer[consumer.Logs]{settings: set, next: next}
+	return nil
+}
+
+func (r *muxReceiver) registerMetrics(set receiver.Settings, next consumer.Metrics) error {
+	if err := r.addTopicConfig(pipeline.SignalMetrics, r.config.Metrics); err != nil {
+		return err
+	}
+	r.metrics = &registeredConsumer[consumer.Metrics]{settings: set, next: next}
+	return nil
+}
+
+func (r *muxReceiver) registerTraces(set receiver.Settings, next consumer.Traces) error {
+	if err := r.addTopicConfig(pipeline.SignalTraces, r.config.Traces); err != nil {
+		return err
+	}
+	r.traces = &registeredConsumer[consumer.Traces]{settings: set, next: next}
+	return nil
+}
+
+func (r *muxReceiver) registerProfiles(set receiver.Settings, next xconsumer.Profiles) error {
+	if err := r.addTopicConfig(xpipeline.SignalProfiles, r.config.Profiles); err != nil {
+		return err
+	}
+	r.profiles = &registeredConsumer[xconsumer.Profiles]{settings: set, next: next}
+	return nil
+}
+
+// addTopicConfig merges this signal's topics into the shared consumer before
+// Start. Each Create* only sees that signal's topic list, and we open one
+// Kafka client, so without the merge, those topics would never be subscribed
+// and their records would never be read. exclude_topics must be the same on
+// every attached signal: that client has one exclude list.
+func (r *muxReceiver) addTopicConfig(signal pipeline.Signal, config TopicEncodingConfig) error {
+	excludeTopics := appendUnique(nil, config.ExcludeTopics...)
+	if r.topicConfigRegistered && !sameStringSet(r.excludeTopics, excludeTopics) {
+		return fmt.Errorf(
+			"signal_header requires identical exclude_topics for all attached signal pipelines: %s.exclude_topics=%v differs from %v",
+			signal.String(), excludeTopics, r.excludeTopics,
+		)
+	}
+
+	r.topics = normalizeTopics(appendUnique(r.topics, config.Topics...))
+	r.excludeTopics = excludeTopics
+	r.topicConfigRegistered = true
+	return nil
+}
+
+// normalizeTopics turns literal names into exact-match regex when the shared
+// subscription includes a regex topic. Franz-go ConsumeRegex applies to every
+// name, so without this a literal like otlp.logs would be treated as a
+// pattern and could match more than that topic.
+func normalizeTopics(topics []string) []string {
+	if !slices.ContainsFunc(topics, func(topic string) bool {
+		return strings.HasPrefix(topic, "^")
+	}) {
+		return topics
+	}
+
+	normalized := make([]string, 0, len(topics))
+	for _, topic := range topics {
+		if !strings.HasPrefix(topic, "^") {
+			topic = "^" + regexp.QuoteMeta(topic) + "$"
+		}
+		normalized = appendUnique(normalized, topic)
+	}
+	return normalized
+}
+
+func appendUnique(dst []string, values ...string) []string {
+	for _, value := range values {
+		if !slices.Contains(dst, value) {
+			dst = append(dst, value)
+		}
+	}
+	return dst
+}
+
+func sameStringSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for _, value := range left {
+		if !slices.Contains(right, value) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *muxReceiver) newConsumeMessage(host component.Host,
+	_ *receiverhelper.ObsReport, telBldr *metadata.TelemetryBuilder,
+) (consumeMessageFunc, error) {
+	handlers := make(map[pipeline.Signal]consumeMessageFunc, 4)
+	if r.logs != nil {
+		if err := addHandler(handlers, pipeline.SignalLogs, r.logs.settings,
+			newLogsConsumeMessage(r.config, r.logs.settings, r.logs.next),
+			host, telBldr,
+		); err != nil {
+			return nil, err
+		}
+	}
+	if r.metrics != nil {
+		if err := addHandler(handlers, pipeline.SignalMetrics, r.metrics.settings,
+			newMetricsConsumeMessage(r.config, r.metrics.settings, r.metrics.next),
+			host, telBldr,
+		); err != nil {
+			return nil, err
+		}
+	}
+	if r.traces != nil {
+		if err := addHandler(handlers, pipeline.SignalTraces, r.traces.settings,
+			newTracesConsumeMessage(r.config, r.traces.settings, r.traces.next),
+			host, telBldr,
+		); err != nil {
+			return nil, err
+		}
+	}
+	if r.profiles != nil {
+		if err := addHandler(handlers, xpipeline.SignalProfiles, r.profiles.settings,
+			newProfilesConsumeMessage(r.config, r.profiles.settings, r.profiles.next),
+			host, telBldr,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	return func(ctx context.Context, record *kgo.Record, attrs attribute.Set) error {
+		signal, err := signalFromHeaders(record.Headers)
+		if err != nil {
+			recordRoutingFailure(ctx, telBldr, record, routingFailureReason(err))
+			return consumererror.NewPermanent(err)
+		}
+		consumeFunc, ok := handlers[signal]
+		if !ok {
+			recordRoutingFailure(ctx, telBldr, record, routingFailureUnconfiguredSignal)
+			return consumererror.NewPermanent(fmt.Errorf("signal %q has no configured pipeline", signal))
+		}
+		return consumeFunc(ctx, record, attrs)
+	}, nil
+}
+
+func addHandler(handlers map[pipeline.Signal]consumeMessageFunc,
+	signal pipeline.Signal,
+	set receiver.Settings,
+	newFn newConsumeMessageFunc,
+	host component.Host,
+	telBldr *metadata.TelemetryBuilder,
+) error {
+	obsrecv, err := newObsReport(set)
+	if err != nil {
+		return err
+	}
+	handler, err := newFn(host, obsrecv, telBldr)
+	if err != nil {
+		return err
+	}
+	handlers[signal] = handler
+	return nil
+}
+
+func routingFailureReason(err error) string {
+	switch {
+	case errors.Is(err, errSignalHeaderMissing):
+		return routingFailureMissingHeader
+	case errors.Is(err, errSignalHeaderMultiple):
+		return routingFailureDuplicateHeader
+	default:
+		return routingFailureUnknownSignal
+	}
+}
+
+func recordRoutingFailure(ctx context.Context,
+	t *metadata.TelemetryBuilder, record *kgo.Record, reason string,
+) {
+	attrs := attribute.NewSet(
+		attribute.String("topic", record.Topic),
+		attribute.Int64("partition", int64(record.Partition)),
+		attribute.String("reason", reason),
+	)
+	t.KafkaReceiverRecordsRoutingFailed.Add(ctx, 1, metric.WithAttributeSet(attrs))
 }
 
 type logsHandler struct {
@@ -402,6 +699,28 @@ func getMessageHeaderResourceAttributes(headers []kgo.RecordHeader, headerKeys m
 			}
 		}
 	}
+}
+
+func signalFromHeaders(h []kgo.RecordHeader) (s pipeline.Signal, _ error) {
+	var value []byte
+	var found bool
+	for i := range h {
+		if h[i].Key != kafka.SignalHeaderKey {
+			continue
+		}
+		if found {
+			return pipeline.Signal{}, errSignalHeaderMultiple
+		}
+		found = true
+		value = h[i].Value
+	}
+	if !found {
+		return pipeline.Signal{}, errSignalHeaderMissing
+	}
+	if err := s.UnmarshalText(value); err != nil {
+		return pipeline.Signal{}, fmt.Errorf("unknown signal %q", value)
+	}
+	return s, nil
 }
 
 // buildHeaderAttrKeys pre-computes the mapping from raw header names to their

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -32,8 +32,11 @@ import (
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/testdata"
+	"go.opentelemetry.io/collector/pipeline"
+	"go.opentelemetry.io/collector/pipeline/xpipeline"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.opentelemetry.io/collector/receiver/xreceiver"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
@@ -41,6 +44,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/kafkatest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/ptracetest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadata"
@@ -76,6 +80,234 @@ func TestReceiver(t *testing.T) {
 		args := <-received
 		assert.NoError(t, ptracetest.CompareTraces(traces, args.data))
 	})
+}
+
+func TestSignalFromHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []kgo.RecordHeader
+		want    pipeline.Signal
+		wantErr string
+	}{
+		{
+			name: "traces",
+			headers: []kgo.RecordHeader{{
+				Key:   kafka.SignalHeaderKey,
+				Value: []byte(pipeline.SignalTraces.String()),
+			}},
+			want: pipeline.SignalTraces,
+		},
+		{
+			name:    "missing",
+			wantErr: "missing",
+		},
+		{
+			name: "duplicate",
+			headers: []kgo.RecordHeader{
+				{Key: kafka.SignalHeaderKey, Value: []byte(pipeline.SignalTraces.String())},
+				{Key: kafka.SignalHeaderKey, Value: []byte(pipeline.SignalMetrics.String())},
+			},
+			wantErr: "multiple",
+		},
+		{
+			name: "unknown",
+			headers: []kgo.RecordHeader{{
+				Key:   kafka.SignalHeaderKey,
+				Value: []byte("unknown"),
+			}},
+			wantErr: `unknown signal "unknown"`,
+		},
+		{
+			name: "empty",
+			headers: []kgo.RecordHeader{{
+				Key: kafka.SignalHeaderKey,
+			}},
+			wantErr: `unknown signal ""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := signalFromHeaders(tt.headers)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestReceiver_SignalHeaderRouting(t *testing.T) {
+	kafkaClient, cfg := mustNewSignalHeaderCluster(t)
+	topic := []string{"otlp"}
+	cfg.Logs.Topics, cfg.Logs.Encoding = topic, "otlp_json"
+	cfg.Metrics.Topics, cfg.Traces.Topics, cfg.Profiles.Topics = topic, topic, topic
+	cfg.HeaderExtraction.ExtractHeaders = true
+	cfg.HeaderExtraction.Headers = []string{"tenant"}
+
+	logsSink := new(consumertest.LogsSink)
+	metricsSink := new(consumertest.MetricsSink)
+	tracesSink := new(consumertest.TracesSink)
+	profilesSink := new(consumertest.ProfilesSink)
+	factory := NewFactory()
+	settings := receivertest.NewNopSettings(metadata.Type)
+	r, err := factory.CreateLogs(t.Context(), settings, cfg, logsSink)
+	require.NoError(t, err)
+	_, err = factory.CreateMetrics(t.Context(), settings, cfg, metricsSink)
+	require.NoError(t, err)
+	_, err = factory.CreateTraces(t.Context(), settings, cfg, tracesSink)
+	require.NoError(t, err)
+	_, err = factory.(xreceiver.Factory).CreateProfiles(t.Context(), settings, cfg, profilesSink)
+	require.NoError(t, err)
+	require.NoError(t, r.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, r.Shutdown(context.Background())) //nolint:usetesting
+	})
+
+	logsData, err := (&plog.JSONMarshaler{}).MarshalLogs(testdata.GenerateLogs(1))
+	require.NoError(t, err)
+	metricsData, err := (&pmetric.ProtoMarshaler{}).MarshalMetrics(testdata.GenerateMetrics(1))
+	require.NoError(t, err)
+	tracesData, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(testdata.GenerateTraces(1))
+	require.NoError(t, err)
+	profilesData, err := (&pprofile.ProtoMarshaler{}).MarshalProfiles(testdata.GenerateProfiles(1))
+	require.NoError(t, err)
+
+	tracesRecord := signalRecord(pipeline.SignalTraces.String(), tracesData)
+	tracesRecord.Headers = append(tracesRecord.Headers, kgo.RecordHeader{
+		Key:   "tenant",
+		Value: []byte("acme"),
+	})
+	results := kafkaClient.ProduceSync(t.Context(),
+		signalRecord(pipeline.SignalLogs.String(), logsData),
+		tracesRecord,
+		signalRecord(pipeline.SignalMetrics.String(), metricsData),
+		signalRecord(xpipeline.SignalProfiles.String(), profilesData),
+	)
+	require.NoError(t, results.FirstErr())
+
+	require.Eventually(t, func() bool {
+		return len(logsSink.AllLogs()) == 1 &&
+			len(metricsSink.AllMetrics()) == 1 &&
+			len(tracesSink.AllTraces()) == 1 &&
+			len(profilesSink.AllProfiles()) == 1
+	}, 10*time.Second, 10*time.Millisecond)
+	tenant, ok := tracesSink.AllTraces()[0].ResourceSpans().At(0).Resource().Attributes().Get("kafka.header.tenant")
+	require.True(t, ok)
+	assert.Equal(t, "acme", tenant.Str())
+	assert.Equal(t, []string{pipeline.SignalTraces.String()}, client.FromContext(tracesSink.Contexts()[0]).Metadata.Get(kafka.SignalHeaderKey))
+}
+
+func TestReceiver_SignalHeaderUsesSignalTelemetry(t *testing.T) {
+	kafkaClient, cfg := mustNewSignalHeaderCluster(t)
+	cfg.Traces.Topics = []string{"otlp"}
+	cfg.Logs.Topics = []string{"otlp"}
+
+	tracesSettings, tracesTracer, tracesLogs := trackingSettings()
+	logsSettings, logsTracer, logsLogs := trackingSettings()
+	factory := NewFactory()
+	r, err := factory.CreateTraces(t.Context(), tracesSettings, cfg, new(consumertest.TracesSink))
+	require.NoError(t, err)
+	_, err = factory.CreateLogs(t.Context(), logsSettings, cfg, new(consumertest.LogsSink))
+	require.NoError(t, err)
+	require.NoError(t, r.Start(t.Context(), componenttest.NewNopHost()))
+	assert.Equal(t, 1, tracesTracer.tracerCalls)
+	assert.Equal(t, 1, logsTracer.tracerCalls)
+	t.Cleanup(func() {
+		require.NoError(t, r.Shutdown(context.Background())) //nolint:usetesting
+	})
+
+	results := kafkaClient.ProduceSync(t.Context(), signalRecord(pipeline.SignalLogs.String(), []byte("junk")))
+	require.NoError(t, results.FirstErr())
+	const unmarshalMsg = "failed to unmarshal message"
+	require.Eventually(t, func() bool {
+		return logsLogs.FilterMessage(unmarshalMsg).Len()+tracesLogs.FilterMessage(unmarshalMsg).Len() > 0
+	}, 10*time.Second, 10*time.Millisecond)
+	assert.Equal(t, 1, logsLogs.FilterMessage(unmarshalMsg).Len())
+	assert.Empty(t, tracesLogs.FilterMessage(unmarshalMsg).All())
+}
+
+func TestReceiver_SignalHeaderRoutingErrors(t *testing.T) {
+	kafkaClient, cfg := mustNewSignalHeaderCluster(t)
+	cfg.Traces.Topics = []string{"otlp"}
+
+	received := make(chan consumerArgs[ptrace.Traces], 1)
+	settings, tel, _ := mustNewSettings(t)
+	r, err := NewFactory().CreateTraces(t.Context(), settings, cfg, newChannelTracesConsumer(received))
+	require.NoError(t, err)
+	require.NoError(t, r.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, r.Shutdown(context.Background())) //nolint:usetesting
+	})
+
+	data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(testdata.GenerateTraces(1))
+	require.NoError(t, err)
+	results := kafkaClient.ProduceSync(t.Context(),
+		&kgo.Record{Topic: "otlp", Value: data},
+		&kgo.Record{
+			Topic: "otlp",
+			Value: data,
+			Headers: []kgo.RecordHeader{
+				{Key: kafka.SignalHeaderKey, Value: []byte(pipeline.SignalTraces.String())},
+				{Key: kafka.SignalHeaderKey, Value: []byte(pipeline.SignalMetrics.String())},
+			},
+		},
+		signalRecord("unknown", data),
+		signalRecord(pipeline.SignalLogs.String(), data),
+		signalRecord(pipeline.SignalTraces.String(), data),
+	)
+	require.NoError(t, results.FirstErr())
+	<-received
+
+	require.Eventually(t, func() bool {
+		_, getMetricErr := tel.GetMetric("otelcol_kafka_receiver_records_routing_failed")
+		return getMetricErr == nil
+	}, 10*time.Second, 10*time.Millisecond)
+	point := func(reason string) metricdata.DataPoint[int64] {
+		return metricdata.DataPoint[int64]{
+			Value: 1,
+			Attributes: attribute.NewSet(
+				attribute.String("topic", "otlp"),
+				attribute.Int64("partition", 0),
+				attribute.String("reason", reason),
+			),
+		}
+	}
+	metadatatest.AssertEqualKafkaReceiverRecordsRoutingFailed(t, tel, []metricdata.DataPoint[int64]{
+		point("missing_header"),
+		point("duplicate_header"),
+		point("unknown_signal"),
+		point("unconfigured_signal"),
+	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+}
+
+func signalRecord(signal string, value []byte) *kgo.Record {
+	return &kgo.Record{
+		Topic: "otlp",
+		Value: value,
+		Headers: []kgo.RecordHeader{{
+			Key:   kafka.SignalHeaderKey,
+			Value: []byte(signal),
+		}},
+	}
+}
+
+func mustNewSignalHeaderCluster(tb testing.TB) (*kgo.Client, *Config) {
+	tb.Helper()
+	client, cfg := mustNewFakeCluster(tb, kfake.SeedTopics(1, "otlp"))
+	cfg.SignalHeader = true
+	return client, cfg
+}
+
+func trackingSettings() (receiver.Settings, *trackingTracerProvider, *observer.ObservedLogs) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	set := receivertest.NewNopSettings(metadata.Type)
+	tp := &trackingTracerProvider{TracerProvider: set.TracerProvider}
+	set.Logger = zap.New(core)
+	set.TracerProvider = tp
+	return set, tp, logs
 }
 
 func TestReceiver_Headers_Metadata(t *testing.T) {

--- a/receiver/kafkareceiver/metadata.yaml
+++ b/receiver/kafkareceiver/metadata.yaml
@@ -35,6 +35,10 @@ attributes:
   partition:
     description: The Kafka topic partition.
     type: int
+  reason:
+    description: The reason a Kafka record could not be routed.
+    type: string
+    enum: [missing_header, duplicate_header, unknown_signal, unconfigured_signal]
   topic:
     description: The Kafka topic.
     type: string
@@ -195,6 +199,15 @@ telemetry:
         value_type: double
         bucket_boundaries: [0, 0.005, 0.010, 0.025, 0.050, 0.075, 0.100, 0.250, 0.500, 0.750, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]
       attributes: [topic, partition]
+    kafka_receiver_records_routing_failed:
+      enabled: true
+      description: Number of records that could not be routed using the otelcol.signal header.
+      stability: development
+      unit: "1"
+      sum:
+        value_type: int
+        monotonic: true
+      attributes: [topic, partition, reason]
     kafka_receiver_unmarshal_failed_log_records:
       enabled: true
       description: Number of log records failed to be unmarshaled

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -13,6 +13,7 @@ kafka/legacy_topic:
     encoding: otlp_proto
     
 kafka/logs:
+  signal_header: true
   logs:
     topics: 
     - logs


### PR DESCRIPTION
#### Description

This is the other half of #50244. With signal_header, you attach the same kafka receiver to every pipeline that should read the topic, and they share one consumer. It subscribes to all of those signals' topics and sends each record where the header says. Encoding and the rest of the pipeline are untouched and downstream of this routing.

The factory `Create*` calls go through `createShared`, which reuses one `muxReceiver` per config. That mux embeds `franzConsumer` (Kafka client) and, on each `Create*`, `register*` stores that pipeline's next consumer and settings and merges its topics. `Start` runs once: the client opens, the mux builds a handler map (unmarshalers need the host), and the poll loop reads otelcol.signal and calls its handler.

There is only one Kafka client, so `exclude_topics` has to be the same on every attached signal. If the header is missing, duplicated, unknown, or names a signal you didn't attach, that's a permanent error and we count it on `otelcol_kafka_receiver_records_routing_failed`.

<details><summary>Diagram</summary>
<p>

Created this diagram below to show how the pieces fit together, this should make it easier to review the PR although I explained above with words as well, perhaps this helps clarify the interaction, though.

```mermaid
sequenceDiagram
    participant C as Collector
    participant F as createShared
    participant M as muxReceiver
    participant K as franzConsumer

    Note over C: All Create* run before any Start

    C->>F: CreateTraces(set, next)
    F->>M: GetOrAdd: newMuxReceiver
    M->>K: embed consumer (topics nil, hook stored)
    F->>M: registerTraces
    M->>K: union traces topics

    C->>F: CreateLogs / Metrics / Profiles
    F->>M: GetOrAdd hit
    F->>M: register*
    M->>K: union that signal's topics

    Note over C: Then Start once (sharedcomponent)

    C->>K: Start(host)
    K->>M: newConsumeMessage(host)
    M->>M: addHandler per registered slot
    Note over M: unmarshalers need host extensions
    K->>K: open Kafka client, consumeLoop
```

</p>
</details> 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50244

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tested

<!--Describe the documentation added.-->
#### Documentation
Updated readme

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.
