### PR TITLE
Add db.version resource attribute to mongodbreceiver

### DIFF
--- a/.chloggen/mongodbreceiver-db-version-attribute.yaml
+++ b/.chloggen/mongodbreceiver-db-version-attribute.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+component: receiver/mongodb
+note: Add db.system.version resource attribute
+issues: [50710]
+subtext: |-
+  The mongodbreceiver now exposes the MongoDB version as a resource attribute (db.system.version).
+  This follows the pattern used by mysqlreceiver and is disabled by default.
+  The version is already fetched during connection initialization and is now included in resource attributes.
+change_logs: [user]

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -680,6 +680,7 @@ Note: when database profiling is disabled, the receiver falls back to MongoDB's 
 
 | Name | Description | Values | Enabled | Semantic Convention | Stability |
 | ---- | ----------- | ------ | ------- | ------------------- | --------- |
+| db.system.version | The database version of the instance. Examples include "5.0.0", "6.0.4". | Any Str | false | - | - |
 | server.address | The address of the MongoDB host. | Any Str | true | - | - |
 | server.port | The port of the MongoDB host. | Any Int | false | - | - |
 | service.instance.id | A unique identifier of the MongoDB resource as a UUID v5, derived from server address and port. | Any Str | true | - | - |

--- a/receiver/mongodbreceiver/internal/metadata/generated_config.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config.go
@@ -1975,6 +1975,41 @@ func DefaultEventsConfig() EventsConfig {
 	}
 }
 
+// DbSystemVersionResourceAttributeConfig provides config for the db.system.version resource attribute.
+type DbSystemVersionResourceAttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+	// OverrideValue allows users to override the value of this resource attribute.
+	OverrideValue *string `mapstructure:"override_value"`
+	// Experimental: MetricsInclude defines a list of filters for attribute values.
+	// If the list is not empty, only metrics with matching resource attribute values will be emitted.
+	MetricsInclude []filter.Config `mapstructure:"metrics_include"`
+	// Experimental: MetricsExclude defines a list of filters for attribute values.
+	// If the list is not empty, metrics with matching resource attribute values will not be emitted.
+	// MetricsInclude has higher priority than MetricsExclude.
+	MetricsExclude []filter.Config `mapstructure:"metrics_exclude"`
+	// Experimental: EventsInclude defines a list of filters for attribute values.
+	// If the list is not empty, only events with matching resource attribute values will be emitted.
+	EventsInclude []filter.Config `mapstructure:"events_include"`
+	// Experimental: EventsExclude defines a list of filters for attribute values.
+	// If the list is not empty, events with matching resource attribute values will not be emitted.
+	// EventsInclude has higher priority than EventsExclude.
+	EventsExclude []filter.Config `mapstructure:"events_exclude"`
+
+	enabledSetByUser bool
+}
+
+func (rac *DbSystemVersionResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
+	if parser == nil {
+		return nil
+	}
+	err := parser.Unmarshal(rac)
+	if err != nil {
+		return err
+	}
+	rac.enabledSetByUser = parser.IsSet("enabled")
+	return nil
+}
+
 // ServerAddressResourceAttributeConfig provides config for the server.address resource attribute.
 type ServerAddressResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
@@ -2152,6 +2187,7 @@ func (rac *ServiceNamespaceResourceAttributeConfig) Unmarshal(parser *confmap.Co
 
 // ResourceAttributesConfig provides config for mongodb resource attributes.
 type ResourceAttributesConfig struct {
+	DbSystemVersion   DbSystemVersionResourceAttributeConfig   `mapstructure:"db.system.version"`
 	ServerAddress     ServerAddressResourceAttributeConfig     `mapstructure:"server.address"`
 	ServerPort        ServerPortResourceAttributeConfig        `mapstructure:"server.port"`
 	ServiceInstanceID ServiceInstanceIDResourceAttributeConfig `mapstructure:"service.instance.id"`
@@ -2161,6 +2197,9 @@ type ResourceAttributesConfig struct {
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 	return ResourceAttributesConfig{
+		DbSystemVersion: DbSystemVersionResourceAttributeConfig{
+			Enabled: false,
+		},
 		ServerAddress: ServerAddressResourceAttributeConfig{
 			Enabled: true,
 		},
@@ -2183,6 +2222,9 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 // For each enabled resource attribute with a non-nil OverrideValue,
 // the override replaces any existing value in the resource.
 func (rac *ResourceAttributesConfig) applyOverrideValues(res pcommon.Resource) {
+	if rac.DbSystemVersion.Enabled && rac.DbSystemVersion.OverrideValue != nil {
+		res.Attributes().PutStr("db.system.version", *rac.DbSystemVersion.OverrideValue)
+	}
 	if rac.ServerAddress.Enabled && rac.ServerAddress.OverrideValue != nil {
 		res.Attributes().PutStr("server.address", *rac.ServerAddress.OverrideValue)
 	}

--- a/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
@@ -229,6 +229,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
+					DbSystemVersion:   DbSystemVersionResourceAttributeConfig{Enabled: true},
 					ServerAddress:     ServerAddressResourceAttributeConfig{Enabled: true},
 					ServerPort:        ServerPortResourceAttributeConfig{Enabled: true},
 					ServiceInstanceID: ServiceInstanceIDResourceAttributeConfig{Enabled: true},
@@ -443,6 +444,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
+					DbSystemVersion:   DbSystemVersionResourceAttributeConfig{Enabled: false},
 					ServerAddress:     ServerAddressResourceAttributeConfig{Enabled: false},
 					ServerPort:        ServerPortResourceAttributeConfig{Enabled: false},
 					ServiceInstanceID: ServiceInstanceIDResourceAttributeConfig{Enabled: false},
@@ -455,7 +457,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadMetricsBuilderConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MongodbActiveReadsMetricConfig{}, MongodbActiveWritesMetricConfig{}, MongodbCacheOperationsMetricConfig{}, MongodbCollectionCountMetricConfig{}, MongodbCommandsRateMetricConfig{}, MongodbConnectionCountMetricConfig{}, MongodbCursorCountMetricConfig{}, MongodbCursorTimeoutCountMetricConfig{}, MongodbDataSizeMetricConfig{}, MongodbDatabaseCountMetricConfig{}, MongodbDeletesRateMetricConfig{}, MongodbDocumentOperationCountMetricConfig{}, MongodbExtentCountMetricConfig{}, MongodbFlushesRateMetricConfig{}, MongodbGetmoresRateMetricConfig{}, MongodbGlobalLockTimeMetricConfig{}, MongodbHealthMetricConfig{}, MongodbIndexAccessCountMetricConfig{}, MongodbIndexCountMetricConfig{}, MongodbIndexSizeMetricConfig{}, MongodbInsertsRateMetricConfig{}, MongodbLockAcquireCountMetricConfig{}, MongodbLockAcquireTimeMetricConfig{}, MongodbLockAcquireWaitCountMetricConfig{}, MongodbLockDeadlockCountMetricConfig{}, MongodbMemoryUsageMetricConfig{}, MongodbNetworkIoReceiveMetricConfig{}, MongodbNetworkIoTransmitMetricConfig{}, MongodbNetworkRequestCountMetricConfig{}, MongodbObjectCountMetricConfig{}, MongodbOperationCountMetricConfig{}, MongodbOperationLatencyTimeMetricConfig{}, MongodbOperationReplCountMetricConfig{}, MongodbOperationTimeMetricConfig{}, MongodbPageFaultsMetricConfig{}, MongodbQueriesRateMetricConfig{}, MongodbReplCommandsPerSecMetricConfig{}, MongodbReplDeletesPerSecMetricConfig{}, MongodbReplGetmoresPerSecMetricConfig{}, MongodbReplInsertsPerSecMetricConfig{}, MongodbReplQueriesPerSecMetricConfig{}, MongodbReplUpdatesPerSecMetricConfig{}, MongodbSessionCountMetricConfig{}, MongodbStorageSizeMetricConfig{}, MongodbUpdatesRateMetricConfig{}, MongodbUptimeMetricConfig{}, MongodbWtConcurrentTransactionTicketInUseMetricConfig{}, MongodbWtFsyncCountMetricConfig{}, MongodbWtLogOperationCountMetricConfig{}, MongodbWtLogSyncTimeMetricConfig{}, MongodbWtLogWriteMetricConfig{}, MongodbWtcacheBytesReadMetricConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(MongodbActiveReadsMetricConfig{}, MongodbActiveWritesMetricConfig{}, MongodbCacheOperationsMetricConfig{}, MongodbCollectionCountMetricConfig{}, MongodbCommandsRateMetricConfig{}, MongodbConnectionCountMetricConfig{}, MongodbCursorCountMetricConfig{}, MongodbCursorTimeoutCountMetricConfig{}, MongodbDataSizeMetricConfig{}, MongodbDatabaseCountMetricConfig{}, MongodbDeletesRateMetricConfig{}, MongodbDocumentOperationCountMetricConfig{}, MongodbExtentCountMetricConfig{}, MongodbFlushesRateMetricConfig{}, MongodbGetmoresRateMetricConfig{}, MongodbGlobalLockTimeMetricConfig{}, MongodbHealthMetricConfig{}, MongodbIndexAccessCountMetricConfig{}, MongodbIndexCountMetricConfig{}, MongodbIndexSizeMetricConfig{}, MongodbInsertsRateMetricConfig{}, MongodbLockAcquireCountMetricConfig{}, MongodbLockAcquireTimeMetricConfig{}, MongodbLockAcquireWaitCountMetricConfig{}, MongodbLockDeadlockCountMetricConfig{}, MongodbMemoryUsageMetricConfig{}, MongodbNetworkIoReceiveMetricConfig{}, MongodbNetworkIoTransmitMetricConfig{}, MongodbNetworkRequestCountMetricConfig{}, MongodbObjectCountMetricConfig{}, MongodbOperationCountMetricConfig{}, MongodbOperationLatencyTimeMetricConfig{}, MongodbOperationReplCountMetricConfig{}, MongodbOperationTimeMetricConfig{}, MongodbPageFaultsMetricConfig{}, MongodbQueriesRateMetricConfig{}, MongodbReplCommandsPerSecMetricConfig{}, MongodbReplDeletesPerSecMetricConfig{}, MongodbReplGetmoresPerSecMetricConfig{}, MongodbReplInsertsPerSecMetricConfig{}, MongodbReplQueriesPerSecMetricConfig{}, MongodbReplUpdatesPerSecMetricConfig{}, MongodbSessionCountMetricConfig{}, MongodbStorageSizeMetricConfig{}, MongodbUpdatesRateMetricConfig{}, MongodbUptimeMetricConfig{}, MongodbWtConcurrentTransactionTicketInUseMetricConfig{}, MongodbWtFsyncCountMetricConfig{}, MongodbWtLogOperationCountMetricConfig{}, MongodbWtLogSyncTimeMetricConfig{}, MongodbWtLogWriteMetricConfig{}, MongodbWtcacheBytesReadMetricConfig{}, DbSystemVersionResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -757,6 +759,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 		{
 			name: "all_set",
 			want: ResourceAttributesConfig{
+				DbSystemVersion:   DbSystemVersionResourceAttributeConfig{Enabled: true},
 				ServerAddress:     ServerAddressResourceAttributeConfig{Enabled: true},
 				ServerPort:        ServerPortResourceAttributeConfig{Enabled: true},
 				ServiceInstanceID: ServiceInstanceIDResourceAttributeConfig{Enabled: true},
@@ -767,6 +770,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 		{
 			name: "none_set",
 			want: ResourceAttributesConfig{
+				DbSystemVersion:   DbSystemVersionResourceAttributeConfig{Enabled: false},
 				ServerAddress:     ServerAddressResourceAttributeConfig{Enabled: false},
 				ServerPort:        ServerPortResourceAttributeConfig{Enabled: false},
 				ServiceInstanceID: ServiceInstanceIDResourceAttributeConfig{Enabled: false},
@@ -778,7 +782,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := loadResourceAttributesConfig(t, tt.name)
-			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
+			diff := cmp.Diff(tt.want, cfg, cmpopts.IgnoreUnexported(DbSystemVersionResourceAttributeConfig{}, ServerAddressResourceAttributeConfig{}, ServerPortResourceAttributeConfig{}, ServiceInstanceIDResourceAttributeConfig{}, ServiceNameResourceAttributeConfig{}, ServiceNamespaceResourceAttributeConfig{}))
 			require.Emptyf(t, diff, "Config mismatch (-expected +actual):\n%s", diff)
 		})
 	}
@@ -786,6 +790,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 
 func TestResourceAttributesOverrideConfig(t *testing.T) {
 	cfg := loadResourceAttributesConfig(t, "override_set")
+	assert.NotNil(t, cfg.DbSystemVersion.OverrideValue, "override_value should be set for db.system.version")
 	assert.NotNil(t, cfg.ServerAddress.OverrideValue, "override_value should be set for server.address")
 	assert.NotNil(t, cfg.ServerPort.OverrideValue, "override_value should be set for server.port")
 	assert.NotNil(t, cfg.ServiceInstanceID.OverrideValue, "override_value should be set for service.instance.id")

--- a/receiver/mongodbreceiver/internal/metadata/generated_logs.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_logs.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"context"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/receiver/mongodbreceiver/internal/metadata/generated_logs.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_logs.go
@@ -4,7 +4,6 @@ package metadata
 
 import (
 	"context"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -160,6 +159,12 @@ func NewLogsBuilder(lbc LogsBuilderConfig, settings receiver.Settings) *LogsBuil
 		eventDbServerTopQuery:          newEventDbServerTopQuery(lbc.Events.DbServerTopQuery),
 		resourceAttributeIncludeFilter: make(map[string]filter.Filter),
 		resourceAttributeExcludeFilter: make(map[string]filter.Filter),
+	}
+	if lbc.ResourceAttributes.DbSystemVersion.EventsInclude != nil {
+		lb.resourceAttributeIncludeFilter["db.system.version"] = filter.CreateFilter(lbc.ResourceAttributes.DbSystemVersion.EventsInclude)
+	}
+	if lbc.ResourceAttributes.DbSystemVersion.EventsExclude != nil {
+		lb.resourceAttributeExcludeFilter["db.system.version"] = filter.CreateFilter(lbc.ResourceAttributes.DbSystemVersion.EventsExclude)
 	}
 	if lbc.ResourceAttributes.ServerAddress.EventsInclude != nil {
 		lb.resourceAttributeIncludeFilter["server.address"] = filter.CreateFilter(lbc.ResourceAttributes.ServerAddress.EventsInclude)

--- a/receiver/mongodbreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_logs_test.go
@@ -4,6 +4,9 @@ package metadata
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -11,8 +14,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
-	"testing"
-	"time"
 )
 
 type eventsTestDataSet int

--- a/receiver/mongodbreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_logs_test.go
@@ -4,9 +4,6 @@ package metadata
 
 import (
 	"context"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -14,6 +11,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
+	"testing"
+	"time"
 )
 
 type eventsTestDataSet int
@@ -31,6 +30,7 @@ func TestLogsBuilderAppendLogRecord(t *testing.T) {
 	lb := NewLogsBuilder(loadLogsBuilderConfig(t, "all_set"), settings)
 
 	rb := lb.NewResourceBuilder()
+	rb.SetDbSystemVersion("db.system.version-val")
 	rb.SetServerAddress("server.address-val")
 	rb.SetServerPort(11)
 	rb.SetServiceInstanceID("service.instance.id-val")
@@ -139,6 +139,7 @@ func TestLogsBuilder(t *testing.T) {
 			lb.RecordDbServerTopQueryEvent(ctx, timestamp, "db.collection.name-val", "db.namespace-val", "db.operation.name-val", "db.query.text-val", AttributeDbSystemNameMongodb, "mongodb.cursor.id-val", "mongodb.cursor.originating_command-val", "mongodb.explain_plan.hash-val", "mongodb.explain_plan.text-val", []any{"mongodb.operation.comment-item1", "mongodb.operation.comment-item2"}, 26.100000, 31, 31, 26.100000, 31, "mongodb.operation.plan.summary-val", 33, "mongodb.operation.type-val", false)
 
 			rb := lb.NewResourceBuilder()
+			rb.SetDbSystemVersion("db.system.version-val")
 			rb.SetServerAddress("server.address-val")
 			rb.SetServerPort(11)
 			rb.SetServiceInstanceID("service.instance.id-val")

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -3,13 +3,14 @@
 package metadata
 
 import (
+	"slices"
+	"time"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	"slices"
-	"time"
 )
 
 const (

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -3,14 +3,13 @@
 package metadata
 
 import (
-	"slices"
-	"time"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/filter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+	"slices"
+	"time"
 )
 
 const (
@@ -4312,6 +4311,12 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 		metricMongodbWtcacheBytesRead:                   newMetricMongodbWtcacheBytesRead(mbc.Metrics.MongodbWtcacheBytesRead),
 		resourceAttributeIncludeFilter:                  make(map[string]filter.Filter),
 		resourceAttributeExcludeFilter:                  make(map[string]filter.Filter),
+	}
+	if mbc.ResourceAttributes.DbSystemVersion.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["db.system.version"] = filter.CreateFilter(mbc.ResourceAttributes.DbSystemVersion.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.DbSystemVersion.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["db.system.version"] = filter.CreateFilter(mbc.ResourceAttributes.DbSystemVersion.MetricsExclude)
 	}
 	if mbc.ResourceAttributes.ServerAddress.MetricsInclude != nil {
 		mb.resourceAttributeIncludeFilter["server.address"] = filter.CreateFilter(mbc.ResourceAttributes.ServerAddress.MetricsInclude)

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
@@ -321,6 +321,7 @@ func TestMetricsBuilder(t *testing.T) {
 			mb.RecordMongodbWtcacheBytesReadDataPoint(ts, 1)
 
 			rb := mb.NewResourceBuilder()
+			rb.SetDbSystemVersion("db.system.version-val")
 			rb.SetServerAddress("server.address-val")
 			rb.SetServerPort(11)
 			rb.SetServiceInstanceID("service.instance.id-val")

--- a/receiver/mongodbreceiver/internal/metadata/generated_resource.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_resource.go
@@ -21,6 +21,13 @@ func NewResourceBuilder(rac ResourceAttributesConfig) *ResourceBuilder {
 	}
 }
 
+// SetDbSystemVersion sets provided value as "db.system.version" attribute.
+func (rb *ResourceBuilder) SetDbSystemVersion(val string) {
+	if rb.config.DbSystemVersion.Enabled {
+		rb.res.Attributes().PutStr("db.system.version", val)
+	}
+}
+
 // SetServerAddress sets provided value as "server.address" attribute.
 func (rb *ResourceBuilder) SetServerAddress(val string) {
 	if rb.config.ServerAddress.Enabled {

--- a/receiver/mongodbreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_resource_test.go
@@ -15,6 +15,7 @@ func TestResourceBuilder(t *testing.T) {
 		t.Run(tt, func(t *testing.T) {
 			cfg := loadResourceAttributesConfig(t, tt)
 			rb := NewResourceBuilder(cfg)
+			rb.SetDbSystemVersion("db.system.version-val")
 			rb.SetServerAddress("server.address-val")
 			rb.SetServerPort(11)
 			rb.SetServiceInstanceID("service.instance.id-val")
@@ -28,12 +29,17 @@ func TestResourceBuilder(t *testing.T) {
 			case "default":
 				assert.Equal(t, 2, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 5, res.Attributes().Len())
+				assert.Equal(t, 6, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
 			default:
 				assert.Failf(t, "unexpected test case: %s", tt)
+			}
+			dbSystemVersionAttrVal, ok := res.Attributes().Get("db.system.version")
+			assert.Equal(t, tt == "all_set", ok)
+			if ok {
+				assert.Equal(t, "db.system.version-val", dbSystemVersionAttrVal.Str())
 			}
 			serverAddressAttrVal, ok := res.Attributes().Get("server.address")
 			assert.True(t, ok)
@@ -68,6 +74,7 @@ func TestResourceBuilderOverrideValue(t *testing.T) {
 	cfg := loadResourceAttributesConfig(t, "override_set")
 	require.NoError(t, confmap.Validate(cfg))
 	rb := NewResourceBuilder(cfg)
+	rb.SetDbSystemVersion("db.system.version-val")
 	rb.SetServerAddress("server.address-val")
 	rb.SetServerPort(11)
 	rb.SetServiceInstanceID("service.instance.id-val")
@@ -75,6 +82,13 @@ func TestResourceBuilderOverrideValue(t *testing.T) {
 	rb.SetServiceNamespace("service.namespace-val")
 
 	res := rb.Emit()
+	{
+		val, ok := res.Attributes().Get("db.system.version")
+		assert.True(t, ok, "db.system.version should be present")
+		if ok {
+			assert.Equal(t, "override-db.system.version", val.Str())
+		}
+	}
 	{
 		val, ok := res.Attributes().Get("server.address")
 		assert.True(t, ok, "server.address should be present")
@@ -120,6 +134,13 @@ func TestResourceBuilderOverrideWithoutSet(t *testing.T) {
 
 	res := rb.Emit()
 	{
+		val, ok := res.Attributes().Get("db.system.version")
+		assert.True(t, ok, "db.system.version should be present even without calling Set")
+		if ok {
+			assert.Equal(t, "override-db.system.version", val.Str())
+		}
+	}
+	{
 		val, ok := res.Attributes().Get("server.address")
 		assert.True(t, ok, "server.address should be present even without calling Set")
 		if ok {
@@ -159,6 +180,7 @@ func TestResourceBuilderOverrideWithoutSet(t *testing.T) {
 // TestResourceBuilderOverrideDisabled disables all attributes, so override should not apply.
 func TestResourceBuilderOverrideDisabled(t *testing.T) {
 	cfg := loadResourceAttributesConfig(t, "override_set")
+	cfg.DbSystemVersion.Enabled = false
 	cfg.ServerAddress.Enabled = false
 	cfg.ServerPort.Enabled = false
 	cfg.ServiceInstanceID.Enabled = false
@@ -175,12 +197,14 @@ func TestResourceBuilderOverrideDisabled(t *testing.T) {
 func TestResourceBuilderNoOverride(t *testing.T) {
 	cfg := loadResourceAttributesConfig(t, "all_set")
 	require.NoError(t, confmap.Validate(cfg))
+	assert.Nil(t, cfg.DbSystemVersion.OverrideValue, "OverrideValue should be nil for db.system.version")
 	assert.Nil(t, cfg.ServerAddress.OverrideValue, "OverrideValue should be nil for server.address")
 	assert.Nil(t, cfg.ServerPort.OverrideValue, "OverrideValue should be nil for server.port")
 	assert.Nil(t, cfg.ServiceInstanceID.OverrideValue, "OverrideValue should be nil for service.instance.id")
 	assert.Nil(t, cfg.ServiceName.OverrideValue, "OverrideValue should be nil for service.name")
 	assert.Nil(t, cfg.ServiceNamespace.OverrideValue, "OverrideValue should be nil for service.namespace")
 	rb := NewResourceBuilder(cfg)
+	rb.SetDbSystemVersion("db.system.version-val")
 	rb.SetServerAddress("server.address-val")
 	rb.SetServerPort(11)
 	rb.SetServiceInstanceID("service.instance.id-val")
@@ -188,7 +212,12 @@ func TestResourceBuilderNoOverride(t *testing.T) {
 	rb.SetServiceNamespace("service.namespace-val")
 
 	res := rb.Emit()
-	assert.Equal(t, 5, res.Attributes().Len())
+	assert.Equal(t, 6, res.Attributes().Len())
+	dbSystemVersionAttrVal, ok := res.Attributes().Get("db.system.version")
+	assert.True(t, ok)
+	if ok {
+		assert.Equal(t, "db.system.version-val", dbSystemVersionAttrVal.Str())
+	}
 	serverAddressAttrVal, ok := res.Attributes().Get("server.address")
 	assert.True(t, ok)
 	if ok {

--- a/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
@@ -133,6 +133,8 @@ all_set:
     db.server.top_query:
       enabled: true
   resource_attributes:
+    db.system.version:
+      enabled: true
     server.address:
       enabled: true
     server.port:
@@ -277,6 +279,8 @@ reaggregate_set:
     db.server.top_query:
       enabled: true
   resource_attributes:
+    db.system.version:
+      enabled: true
     server.address:
       enabled: true
     server.port:
@@ -421,6 +425,8 @@ none_set:
     db.server.top_query:
       enabled: false
   resource_attributes:
+    db.system.version:
+      enabled: false
     server.address:
       enabled: false
     server.port:
@@ -433,6 +439,9 @@ none_set:
       enabled: false
 override_set:
   resource_attributes:
+    db.system.version:
+      enabled: true
+      override_value: "override-db.system.version"
     server.address:
       enabled: true
       override_value: "override-server.address"
@@ -450,6 +459,12 @@ override_set:
       override_value: "override-service.namespace"
 filter_set_include:
   resource_attributes:
+    db.system.version:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+      events_include:
+        - regexp: ".*"
     server.address:
       enabled: true
       metrics_include:
@@ -482,6 +497,12 @@ filter_set_include:
         - regexp: ".*"
 filter_set_exclude:
   resource_attributes:
+    db.system.version:
+      enabled: true
+      metrics_exclude:
+        - strict: "db.system.version-val"
+      events_exclude:
+        - strict: "db.system.version-val"
     server.address:
       enabled: true
       metrics_exclude:

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -19,6 +19,10 @@ status:
 override_value_enabled: true
 
 resource_attributes:
+  db.system.version:
+    description: The database version of the instance. Examples include "5.0.0", "6.0.4".
+    enabled: false
+    type: string
   server.address:
     description: The address of the MongoDB host.
     enabled: true

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -223,7 +223,7 @@ func (s *mongodbScraper) scrapeLogsFromClient(ctx context.Context, c client, now
 	s.processCurrentOp(ctx, operations, now)
 
 	rb := s.lb.NewResourceBuilder()
-	setResourceAttributes(rb, serverAddress, serverPort)
+	setResourceAttributes(rb, serverAddress, serverPort, s.mongoVersion)
 	s.lb.EmitForResource(metadata.WithLogsResource(rb.Emit()))
 }
 
@@ -535,12 +535,15 @@ func clientAddressAndPort(clientAddr string) (string, int64) {
 	return host, parsedPort
 }
 
-func setResourceAttributes(rb *metadata.ResourceBuilder, serverAddress string, serverPort int64) {
+func setResourceAttributes(rb *metadata.ResourceBuilder, serverAddress string, serverPort int64, mongoVersion *version.Version) {
 	rb.SetServerAddress(serverAddress)
 	rb.SetServerPort(serverPort)
 	rb.SetServiceInstanceID(generateInstanceID(serverAddress, serverPort))
 	rb.SetServiceName(defaultServiceName)
 	rb.SetServiceNamespace("")
+	if mongoVersion != nil && !mongoVersion.Equal(unknownVersion()) {
+		rb.SetDbSystemVersion(mongoVersion.String())
+	}
 }
 
 func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.ScrapeErrors) {
@@ -583,7 +586,7 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.
 
 	// Emit single resource for the server
 	rb := s.mb.NewResourceBuilder()
-	setResourceAttributes(rb, serverAddress, serverPort)
+	setResourceAttributes(rb, serverAddress, serverPort, s.mongoVersion)
 	s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 }
 

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -1695,12 +1695,10 @@ func TestCollectIndexStatsSkipsViews(t *testing.T) {
 
 func TestResourceAttributeDbSystemVersion(t *testing.T) {
 	// Test the setResourceAttributes function directly
-	rb := metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())
-
 	// Test with enabled db.system.version
 	cfg := metadata.DefaultResourceAttributesConfig()
 	cfg.DbSystemVersion.Enabled = true
-	rb = metadata.NewResourceBuilder(cfg)
+	rb := metadata.NewResourceBuilder(cfg)
 
 	mongo50, err := version.NewVersion("5.0.0")
 	require.NoError(t, err)

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -1692,3 +1692,45 @@ func TestCollectIndexStatsSkipsViews(t *testing.T) {
 	scraper.collectIndexStats(t.Context(), pcommon.NewTimestampFromTime(time.Now()), "fakedatabase", "someview", errs)
 	require.NoError(t, errs.Combine())
 }
+
+func TestResourceAttributeDbSystemVersion(t *testing.T) {
+	// Test the setResourceAttributes function directly
+	rb := metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())
+
+	// Test with enabled db.system.version
+	cfg := metadata.DefaultResourceAttributesConfig()
+	cfg.DbSystemVersion.Enabled = true
+	rb = metadata.NewResourceBuilder(cfg)
+
+	mongo50, err := version.NewVersion("5.0.0")
+	require.NoError(t, err)
+
+	setResourceAttributes(rb, "localhost", 27017, mongo50)
+	res := rb.Emit()
+
+	dbSystemVersion, ok := res.Attributes().Get("db.system.version")
+	require.True(t, ok, "db.system.version should be present when enabled")
+	require.Equal(t, "5.0.0", dbSystemVersion.Str())
+
+	// Test with disabled db.system.version
+	cfg2 := metadata.DefaultResourceAttributesConfig()
+	cfg2.DbSystemVersion.Enabled = false
+	rb2 := metadata.NewResourceBuilder(cfg2)
+
+	setResourceAttributes(rb2, "localhost", 27017, mongo50)
+	res2 := rb2.Emit()
+
+	_, ok = res2.Attributes().Get("db.system.version")
+	require.False(t, ok, "db.system.version should not be present when disabled")
+
+	// Test with unknown version
+	cfg3 := metadata.DefaultResourceAttributesConfig()
+	cfg3.DbSystemVersion.Enabled = true
+	rb3 := metadata.NewResourceBuilder(cfg3)
+
+	setResourceAttributes(rb3, "localhost", 27017, nil)
+	res3 := rb3.Emit()
+
+	_, ok = res3.Attributes().Get("db.system.version")
+	require.False(t, ok, "db.system.version should not be present when version is unknown")
+}

--- a/receiver/mongodbreceiver/top_query_scraper.go
+++ b/receiver/mongodbreceiver/top_query_scraper.go
@@ -175,7 +175,7 @@ func (s *mongodbScraper) scrapeTopQueryLogs(ctx context.Context) (plog.Logs, err
 	}
 
 	rb := s.lb.NewResourceBuilder()
-	setResourceAttributes(rb, serverAddress, serverPort)
+	setResourceAttributes(rb, serverAddress, serverPort, s.mongoVersion)
 	s.lb.EmitForResource(metadata.WithLogsResource(rb.Emit()))
 
 	s.lastScrapeTime = serverNow

--- a/receiver/mongodbreceiver/top_query_scraper_test.go
+++ b/receiver/mongodbreceiver/top_query_scraper_test.go
@@ -485,7 +485,7 @@ func TestProcessTopQueryEntries_EmitsTopQueryEvent(t *testing.T) {
 	s.processTopQueryEntries(t.Context(), entries, now, defaultMaxExplainEachInterval)
 
 	rb := s.lb.NewResourceBuilder()
-	setResourceAttributes(rb, "localhost", 27017)
+	setResourceAttributes(rb, "localhost", 27017, nil)
 	s.lb.EmitForResource(metadata.WithLogsResource(rb.Emit()))
 
 	logs := s.lb.Emit()
@@ -541,7 +541,7 @@ func TestProcessTopQueryEntries_EmitsCommentAndTruncated(t *testing.T) {
 	s.processTopQueryEntries(t.Context(), entries, pcommon.NewTimestampFromTime(time.Now()), defaultMaxExplainEachInterval)
 
 	rb := s.lb.NewResourceBuilder()
-	setResourceAttributes(rb, "localhost", 27017)
+	setResourceAttributes(rb, "localhost", 27017, nil)
 	s.lb.EmitForResource(metadata.WithLogsResource(rb.Emit()))
 
 	logs := s.lb.Emit()
@@ -577,7 +577,7 @@ func TestProcessTopQueryEntries_EmitsCursorAndOriginatingCommand(t *testing.T) {
 	s.processTopQueryEntries(t.Context(), entries, pcommon.NewTimestampFromTime(time.Now()), defaultMaxExplainEachInterval)
 
 	rb := s.lb.NewResourceBuilder()
-	setResourceAttributes(rb, "localhost", 27017)
+	setResourceAttributes(rb, "localhost", 27017, nil)
 	s.lb.EmitForResource(metadata.WithLogsResource(rb.Emit()))
 
 	logs := s.lb.Emit()


### PR DESCRIPTION
The mongodbreceiver now exposes the MongoDB version as a resource attribute (db.version). This follows the OpenTelemetry semantic conventions and can be disabled by default to match other server.* attributes. The version is already fetched during connection initialization and is now included in resource attributes.

Fixes #50710

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
