### PR TITLE
Skip metric queries when all their fed metrics are disabled

### DIFF
--- a/.chloggen/mysqlreceiver-skip-disabled-metric-queries.yaml
+++ b/.chloggen/mysqlreceiver-skip-disabled-metric-queries.yaml
@@ -1,0 +1,16 @@
+change_type: bug_fix
+component: receiver/mysql
+note: Skip metric queries when all their fed metrics are disabled
+issues: [50702]
+subtext: |-
+  The mysqlreceiver now checks if any metrics fed by a query are enabled before executing that query.
+  This prevents unnecessary database load when metrics are disabled by default.
+  Affected queries:
+  - scrapeTableStats (mysql.table.rows, mysql.table.average_row_length, mysql.table.size)
+  - scrapeStatementEventsStats (mysql.statement_event.count, mysql.statement_event.wait.time)
+  - scrapeTableLockWaitEventStats (mysql.table.lock_wait.*)
+  - scrapeReplicaStatusStats (mysql.replica.*)
+  - scrapeTableIoWaitsStats (mysql.table.io.wait.*)
+  - scrapeIndexIoWaitsStats (mysql.index.io.wait.*)
+  - InnoDB stats queries (mysql.buffer_pool.limit, mysql.innodb.*)
+change_logs: [user]

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -181,39 +181,60 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 
 	now := pcommon.NewTimestampFromTime(time.Now())
 
-	// collect innodb metrics.
-	innodbStats, innoErr := m.sqlclient.getInnodbStats()
-	if innoErr != nil {
-		m.logger.Error("Failed to fetch InnoDB stats", zap.Error(innoErr))
-	}
-
 	errs := &scrapererror.ScrapeErrors{}
-	for k, v := range innodbStats {
-		if k != "buffer_pool_size" {
-			continue
+
+	// collect innodb metrics.
+	metrics := m.config.MetricsBuilderConfig.Metrics
+	if metrics.MysqlBufferPoolLimit.Enabled || 
+		(metrics.MysqlInnodbHistoryListLength.Enabled || 
+		 metrics.MysqlInnodbTransactionActiveCount.Enabled || 
+		 metrics.MysqlInnodbTransactionActiveDurationMax.Enabled) {
+		innodbStats, innoErr := m.sqlclient.getInnodbStats()
+		if innoErr != nil {
+			m.logger.Error("Failed to fetch InnoDB stats", zap.Error(innoErr))
 		}
-		addPartialIfError(errs, m.mb.RecordMysqlBufferPoolLimitDataPoint(now, v))
+
+		for k, v := range innodbStats {
+			if k != "buffer_pool_size" {
+				continue
+			}
+			addPartialIfError(errs, m.mb.RecordMysqlBufferPoolLimitDataPoint(now, v))
+		}
+		m.scrapeInnodbTransactionStats(now, errs)
 	}
-	m.scrapeInnodbTransactionStats(now, errs)
 
 	// collect io_waits metrics.
-	m.scrapeTableIoWaitsStats(now, errs)
-	m.scrapeIndexIoWaitsStats(now, errs)
+	metrics := m.config.MetricsBuilderConfig.Metrics
+	if metrics.MysqlTableIoWaitCount.Enabled || metrics.MysqlTableIoWaitTime.Enabled {
+		m.scrapeTableIoWaitsStats(now, errs)
+	}
+	if metrics.MysqlIndexIoWaitCount.Enabled || metrics.MysqlIndexIoWaitTime.Enabled {
+		m.scrapeIndexIoWaitsStats(now, errs)
+	}
 
 	// collect table size metrics.
-
-	m.scrapeTableStats(now, errs)
+	if metrics.MysqlTableRows.Enabled || metrics.MysqlTableAverageRowLength.Enabled || metrics.MysqlTableSize.Enabled {
+		m.scrapeTableStats(now, errs)
+	}
 
 	// collect performance event statements metrics.
-	m.scrapeStatementEventsStats(now, errs)
+	if metrics.MysqlStatementEventCount.Enabled || metrics.MysqlStatementEventWaitTime.Enabled {
+		m.scrapeStatementEventsStats(now, errs)
+	}
 	// collect lock table events metrics
-	m.scrapeTableLockWaitEventStats(now, errs)
+	if metrics.MysqlTableLockWaitReadCount.Enabled || metrics.MysqlTableLockWaitReadTime.Enabled ||
+		metrics.MysqlTableLockWaitWriteCount.Enabled || metrics.MysqlTableLockWaitWriteTime.Enabled {
+		m.scrapeTableLockWaitEventStats(now, errs)
+	}
 
 	// collect global status metrics.
 	m.scrapeGlobalStats(now, errs)
 
 	// collect replicas status metrics.
-	m.scrapeReplicaStatusStats(now)
+	if metrics.MysqlReplicaTimeBehindSource.Enabled || metrics.MysqlReplicaSQLDelay.Enabled || 
+		metrics.MysqlReplicaThreadRunning.Enabled {
+		m.scrapeReplicaStatusStats(now)
+	}
 
 	rb := m.mb.NewResourceBuilder()
 	m.setResourceAttributes(rb)
@@ -823,17 +844,25 @@ func (m *mySQLScraper) scrapeReplicaStatusStats(now pcommon.Timestamp) {
 		return
 	}
 
+	metrics := m.config.MetricsBuilderConfig.Metrics
 	for i := range replicaStatusStats {
 		s := replicaStatusStats[i]
 
-		val, _ := s.secondsBehindSource.Value()
-		if val != nil {
-			m.mb.RecordMysqlReplicaTimeBehindSourceDataPoint(now, val.(int64))
+		if metrics.MysqlReplicaTimeBehindSource.Enabled {
+			val, _ := s.secondsBehindSource.Value()
+			if val != nil {
+				m.mb.RecordMysqlReplicaTimeBehindSourceDataPoint(now, val.(int64))
+			}
 		}
 
-		m.mb.RecordMysqlReplicaSQLDelayDataPoint(now, s.sqlDelay)
-		m.mb.RecordMysqlReplicaThreadRunningDataPoint(now, replicaThreadRunningValue(s.replicaIORunning), metadata.AttributeMysqlReplicaThreadTypeIo, s.channelName)
-		m.mb.RecordMysqlReplicaThreadRunningDataPoint(now, replicaThreadRunningValue(s.replicaSQLRunning), metadata.AttributeMysqlReplicaThreadTypeSQL, s.channelName)
+		if metrics.MysqlReplicaSQLDelay.Enabled {
+			m.mb.RecordMysqlReplicaSQLDelayDataPoint(now, s.sqlDelay)
+		}
+
+		if metrics.MysqlReplicaThreadRunning.Enabled {
+			m.mb.RecordMysqlReplicaThreadRunningDataPoint(now, replicaThreadRunningValue(s.replicaIORunning), metadata.AttributeMysqlReplicaThreadTypeIo, s.channelName)
+			m.mb.RecordMysqlReplicaThreadRunningDataPoint(now, replicaThreadRunningValue(s.replicaSQLRunning), metadata.AttributeMysqlReplicaThreadTypeSQL, s.channelName)
+		}
 	}
 }
 


### PR DESCRIPTION
The mysqlreceiver now checks if any metrics fed by a query are enabled before executing that query. This prevents unnecessary database load when metrics are disabled by default.

Affected queries:
- scrapeTableStats (mysql.table.rows, mysql.table.average_row_length, mysql.table.size)
- scrapeStatementEventsStats (mysql.statement_event.count, mysql.statement_event.wait.time)
- scrapeTableLockWaitEventStats (mysql.table.lock_wait.*)
- scrapeReplicaStatusStats (mysql.replica.*)
- scrapeTableIoWaitsStats (mysql.table.io.wait.*)
- scrapeIndexIoWaitsStats (mysql.index.io.wait.*)
- InnoDB stats queries (mysql.buffer_pool.limit, mysql.innodb.*)

Fixes #50702

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
