### PR TITLE
[receiver/kafkareceiver] Fix Shutdown hang when Start fails

### DIFF
--- a/.chloggen/issues_50631.yaml
+++ b/.chloggen/issues_50631.yaml
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/.chloggen/issues_50631.yaml
+++ b/.chloggen/issues_50631.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Shutdown() hanging indefinitely when Start() fails due to a misconfigured TLS certificate path.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50631]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/issues_50631.yaml
+++ b/.chloggen/issues_50631.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: receiver/kafka
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix Shutdown() hanging indefinitely when Start() fails due to a misconfigured TLS certificate path.
+note: Fix Shutdown() hanging indefinitely when Start() fails.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [50631]

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -138,7 +138,6 @@ func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 	case <-c.started:
 		return errors.New("franz kafka consumer already started")
 	default:
-		close(c.started)
 	}
 
 	// Report "Starting" as soon as Start() is called.
@@ -206,6 +205,9 @@ func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 		return err
 	}
 	c.consumeMessage = cm
+
+	// Signal that Start was successful only after all setup is complete.
+	close(c.started)
 
 	go c.consumeLoop(context.Background())
 	return nil

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -211,7 +211,6 @@ func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 
 	cm, err := c.newConsumeFn(host, c.obsrecv, c.telemetryBuilder)
 	if err != nil {
-		c.client = nil
 		clientToClose = client
 		return err
 	}

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -131,6 +131,15 @@ func (c *franzConsumer) reportRecoverable(err error) {
 
 func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 	c.mu.Lock()
+	// Declared before defer c.mu.Unlock() so this runs after the lock is released (LIFO).
+	// Closing the client under the lock risks a deadlock: Close() may invoke
+	// partition-assigned/lost callbacks that also acquire c.mu.
+	var clientToClose *kgo.Client
+	defer func() {
+		if clientToClose != nil {
+			clientToClose.Close()
+		}
+	}()
 	defer c.mu.Unlock()
 	select {
 	case <-c.closing:
@@ -202,6 +211,8 @@ func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 
 	cm, err := c.newConsumeFn(host, c.obsrecv, c.telemetryBuilder)
 	if err != nil {
+		c.client = nil
+		clientToClose = client
 		return err
 	}
 	c.consumeMessage = cm

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -56,7 +56,8 @@ type franzConsumer struct {
 	consumeMessage   consumeMessageFunc
 
 	mu             sync.RWMutex
-	started        chan struct{}
+	startAttempted bool        // set on first Start() call; prevents retry after failure
+	started        chan struct{} // closed when Start() succeeds; signals triggerShutdown
 	consumerClosed chan struct{}
 	closing        chan struct{}
 
@@ -144,10 +145,12 @@ func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 	select {
 	case <-c.closing:
 		return errors.New("franz kafka consumer already shut down")
-	case <-c.started:
-		return errors.New("franz kafka consumer already started")
 	default:
 	}
+	if c.startAttempted {
+		return errors.New("franz kafka consumer already started")
+	}
+	c.startAttempted = true
 
 	// Report "Starting" as soon as Start() is called.
 	c.host = host

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -56,7 +56,7 @@ type franzConsumer struct {
 	consumeMessage   consumeMessageFunc
 
 	mu             sync.RWMutex
-	startAttempted bool        // set on first Start() call; prevents retry after failure
+	startAttempted bool          // set on first Start() call; prevents retry after failure
 	started        chan struct{} // closed when Start() succeeds; signals triggerShutdown
 	consumerClosed chan struct{}
 	closing        chan struct{}

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -1369,7 +1369,7 @@ func TestFranzConsumerBrokerCacheEvictOnDisconnect(t *testing.T) {
 	require.Empty(t, c.brokerReadOpts)
 }
 
-func TestStartFailureShutdownNotBlocks(t *testing.T) {
+func TestStartFailureShutdownDoesNotBlock(t *testing.T) {
 	// Reproduces issue #50631: when Start() fails due to misconfigured TLS,
 	// Shutdown() should not block indefinitely.
 	const topic = "otlp_spans"
@@ -1380,7 +1380,7 @@ func TestStartFailureShutdownNotBlocks(t *testing.T) {
 	cfg.ConsumerConfig.InitialOffset = "earliest"
 	cfg.ConsumerConfig.GroupID = t.Name()
 
-	// Configure bad TLS cert path to trigger failure in NewFranzConsumerGroup
+	// Configure bad TLS cert path to trigger failure in NewFranzConsumerGroup.
 	cfg.ClientConfig.TLS = &configtls.ClientConfig{
 		Config: configtls.Config{
 			CAFile:   "/this/goes/nowhere.cert",
@@ -1393,12 +1393,13 @@ func TestStartFailureShutdownNotBlocks(t *testing.T) {
 	consumer, err := newFranzKafkaConsumer(cfg, settings, []string{topic}, nil, nil)
 	require.NoError(t, err)
 
-	// Start should fail due to bad TLS config
+	// Start should fail due to bad TLS config. Assert on the stable wrapper
+	// message produced by NewFranzConsumerGroup, not the OS-specific syscall text.
 	err = consumer.Start(t.Context(), componenttest.NewNopHost())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.Contains(t, err.Error(), "failed to load TLS config")
 
-	// Shutdown should not block, even though Start failed
+	// Shutdown should not block, even though Start failed.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	err = consumer.Shutdown(ctx)

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/testdata"
@@ -1366,4 +1367,41 @@ func TestFranzConsumerBrokerCacheEvictOnDisconnect(t *testing.T) {
 	// Disconnect should evict both entries.
 	c.OnBrokerDisconnect(meta, nil)
 	require.Empty(t, c.brokerReadOpts)
+}
+
+func TestStartFailureShutdownNotBlocks(t *testing.T) {
+	// Reproduces issue #50631: when Start() fails due to misconfigured TLS,
+	// Shutdown() should not block indefinitely.
+	const topic = "otlp_spans"
+	_, clientConfig := kafkatest.NewCluster(t, kfake.SeedTopics(int32(1), topic))
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.ClientConfig = clientConfig
+	cfg.ConsumerConfig.InitialOffset = "earliest"
+	cfg.ConsumerConfig.GroupID = t.Name()
+
+	// Configure bad TLS cert path to trigger failure in NewFranzConsumerGroup
+	cfg.ClientConfig.TLS = &configtls.ClientConfig{
+		Config: configtls.Config{
+			CAFile:   "/this/goes/nowhere.cert",
+			CertFile: "/this/goes/nowhere.cert",
+			KeyFile:  "bunk",
+		},
+	}
+
+	settings, _, _ := mustNewSettings(t)
+	consumer, err := newFranzKafkaConsumer(cfg, settings, []string{topic}, nil, nil)
+	require.NoError(t, err)
+
+	// Start should fail due to bad TLS config
+	err = consumer.Start(t.Context(), componenttest.NewNopHost())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no such file or directory")
+
+	// Shutdown should not block, even though Start failed
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err = consumer.Shutdown(ctx)
+	require.NoError(t, err)
+	require.NoError(t, ctx.Err(), "Shutdown should not timeout")
 }

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -1429,6 +1429,7 @@ func TestStartFailureShutdownDoesNotBlock(t *testing.T) {
 
 		ctx2, cancel2 := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel2()
+		require.ErrorIs(t, consumer2.client.Ping(ctx2), kgo.ErrClientClosed)
 		err2 = consumer2.Shutdown(ctx2)
 		require.NoError(t, err2)
 		require.NoError(t, ctx2.Err(), "Shutdown should not timeout")

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -1400,7 +1400,7 @@ func TestStartFailureShutdownDoesNotBlock(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to load TLS config")
 
 	// Shutdown should not block, even though Start failed.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 	err = consumer.Shutdown(ctx)
 	require.NoError(t, err)

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -1370,8 +1370,10 @@ func TestFranzConsumerBrokerCacheEvictOnDisconnect(t *testing.T) {
 }
 
 func TestStartFailureShutdownDoesNotBlock(t *testing.T) {
-	// Reproduces issue #50631: when Start() fails due to misconfigured TLS,
-	// Shutdown() should not block indefinitely.
+	// Reproduces issue #50631: Shutdown() must not block when Start() fails.
+	// Two failure modes are covered:
+	//   1. Client creation fails (bad TLS) — clientToClose deferred close never fires.
+	//   2. Client created but newConsumeFn fails — exercises the deferred client close.
 	const topic = "otlp_spans"
 	_, clientConfig := kafkatest.NewCluster(t, kfake.SeedTopics(int32(1), topic))
 
@@ -1405,4 +1407,30 @@ func TestStartFailureShutdownDoesNotBlock(t *testing.T) {
 	err = consumer.Shutdown(ctx)
 	require.NoError(t, err)
 	require.NoError(t, ctx.Err(), "Shutdown should not timeout")
+
+	// Case 2: client created successfully but newConsumeFn fails.
+	// This exercises the deferred client.Close() path added to fix the leak.
+	t.Run("newConsumeFn failure closes client", func(t *testing.T) {
+		_, clientConfig2 := kafkatest.NewCluster(t, kfake.SeedTopics(int32(1), topic))
+		cfg2 := createDefaultConfig().(*Config)
+		cfg2.ClientConfig = clientConfig2
+		cfg2.ConsumerConfig.InitialOffset = "earliest"
+		cfg2.ConsumerConfig.GroupID = t.Name()
+
+		failConsumeFn := func(_ component.Host, _ *receiverhelper.ObsReport, _ *metadata.TelemetryBuilder) (consumeMessageFunc, error) {
+			return nil, errors.New("newConsumeFn failed")
+		}
+		settings2, _, _ := mustNewSettings(t)
+		consumer2, err2 := newFranzKafkaConsumer(cfg2, settings2, []string{topic}, nil, failConsumeFn)
+		require.NoError(t, err2)
+
+		err2 = consumer2.Start(t.Context(), componenttest.NewNopHost())
+		require.ErrorContains(t, err2, "newConsumeFn failed")
+
+		ctx2, cancel2 := context.WithTimeout(t.Context(), 2*time.Second)
+		defer cancel2()
+		err2 = consumer2.Shutdown(ctx2)
+		require.NoError(t, err2)
+		require.NoError(t, ctx2.Err(), "Shutdown should not timeout")
+	})
 }


### PR DESCRIPTION
Hello folks!

I've tried to reproduce issue #50631. So far I've noticed:

- Start() fails after closing the 'started' channel but before successfully creating the consume loop (e.g., due to TLS config errors), Shutdown() would block indefinitely waiting for the consume loop to exit.

- 'started' channel was closed too early, signaling that the consumer was started even when the setup failed. Shutdown() would then wait for consumerClosed, which never closed since the consumeLoop was never started.

This proposes to move close(c.started) to after all setup is complete, ensuring that Shutdown() only waits if the consume loop was actually started.

Address issue #50631.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
