### PR TITLE
[pkg/semconvtest] Fix Weaver v0.26 compatibility

### DIFF
--- a/.chloggen/semconvtest-weaver-v026.yaml
+++ b/.chloggen/semconvtest-weaver-v026.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/semconvtest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix compatibility with Weaver v0.26 by binding the container listeners to all interfaces and waiting on the /health endpoint for readiness
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50674]
+
+# (Optional) One or more lines of additional information about the change.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/semconvtest/semconvtest.go
+++ b/pkg/semconvtest/semconvtest.go
@@ -287,10 +287,12 @@ func (s *weaverSession) shutdown(ctx context.Context) error {
 func (opts *weaverOptions) testContainerOptions() []testcontainers.ContainerCustomizer {
 	containerOpts := []testcontainers.ContainerCustomizer{
 		testcontainers.WithCmdArgs(opts.cmdArgs()...),
-		// Expose the required ports on the container and wait for the OTLP
-		// listener to be ready before returning.
+		// Expose the required ports on the container and wait for Weaver's
+		// /health endpoint before returning. A plain port check is not
+		// reliable here: Docker's port proxy accepts connections on the host
+		// side before the process inside the container listens.
 		testcontainers.WithExposedPorts(weaverOTLPListenerPort, weaverStopPort),
-		testcontainers.WithWaitStrategy(wait.ForListeningPort(weaverOTLPListenerPort)),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/health").WithPort(weaverStopPort)),
 	}
 	return containerOpts
 }
@@ -303,7 +305,11 @@ func (opts *weaverOptions) cmdArgs() []string {
 	if opts.registry != "" {
 		args = append(args, "--registry", opts.registry)
 	}
-	args = append(args, "--output", "http", "--format", "json")
+	// Weaver v0.26.0 changed the default bind address of the OTLP and admin
+	// listeners to 127.0.0.1, which makes the container's mapped ports
+	// unreachable. Bind all interfaces instead; the flag exists in all
+	// supported versions (v0.22.1+), where this was also the default.
+	args = append(args, "--output", "http", "--format", "json", "--otlp-grpc-address", "0.0.0.0")
 	return args
 }
 

--- a/pkg/semconvtest/semconvtest.go
+++ b/pkg/semconvtest/semconvtest.go
@@ -309,6 +309,9 @@ func (opts *weaverOptions) cmdArgs() []string {
 	// listeners to 127.0.0.1, which makes the container's mapped ports
 	// unreachable. Bind all interfaces instead; the flag exists in all
 	// supported versions (v0.22.1+), where this was also the default.
+	// The bind applies inside the container's network namespace only, so it
+	// does not reintroduce the host-level exposure that the v0.26.0 change
+	// addressed.
 	args = append(args, "--output", "http", "--format", "json", "--otlp-grpc-address", "0.0.0.0")
 	return args
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Because of a breaking change in Weaver v0.26.0 (live-check now binds to 127.0.0.1 by default), the mapped container ports reject connections. The fix passes --otlp-grpc-address 0.0.0.0 (the flag exists in all supported versions, v0.22.1 and later, where this was also the default behavior). It also replaces the port-based readiness wait with a wait on Weaver's /health endpoint, because Docker's port proxy accepts connections before the process inside listens.
Note on security: the bind applies inside the container's network namespace only, so it does not reintroduce the host-level exposure that the v0.26.0 change addressed.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to #50674

<!--Describe what testing was performed and which tests were added.-->
#### Testing
All the package tests pass locally against Weaver v0.26.1. I also verified that, with this fix applied, the k8sattributes tests from #50665 pass, using the same make command that CI runs.

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
