### PR TITLE
[cmd/opampsupervisor] Include Supervisor instance ID in agent attributes

### DIFF
--- a/.chloggen/supervisor-instance-id-in-agent.yaml
+++ b/.chloggen/supervisor-instance-id-in-agent.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an opt-in setting to include the Supervisor instance ID in Collector telemetry
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50760]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Set `agent.description.include_supervisor_instance_id` to `true` to add the 
+  Supervisor's `service.instance.id` as `supervisor.service.instance.id`. 
+  The setting defaults to `false`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/specification/README.md
+++ b/cmd/opampsupervisor/specification/README.md
@@ -180,6 +180,9 @@ agent:
     # Passed to the Supervisor-injected OpAMP extension to copy the collector's 
     # resource attributes into the non-identifying attributes.
     include_resource_attributes: true
+    # Adds the Supervisor's service.instance.id to the Collector's own telemetry
+    # as `supervisor.service.instance.id`. Defaults to false.
+    include_supervisor_instance_id: true
     identifying_attributes:
       client.id: "01HWWSK84BMT7J45663MBJMTPJ"
     non_identifying_attributes:

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -359,9 +359,10 @@ var SpecialConfigFiles = []SpecialConfigFile{
 }
 
 type AgentDescription struct {
-	IdentifyingAttributes     map[string]string `mapstructure:"identifying_attributes"`
-	NonIdentifyingAttributes  map[string]string `mapstructure:"non_identifying_attributes"`
-	IncludeResourceAttributes bool              `mapstructure:"include_resource_attributes"`
+	IdentifyingAttributes       map[string]string `mapstructure:"identifying_attributes"`
+	NonIdentifyingAttributes    map[string]string `mapstructure:"non_identifying_attributes"`
+	IncludeResourceAttributes   bool              `mapstructure:"include_resource_attributes"`
+	IncludeSupervisorInstanceID bool              `mapstructure:"include_supervisor_instance_id"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -1096,6 +1096,7 @@ agent:
   executable: %s
   description:
     include_resource_attributes: true
+    include_supervisor_instance_id: true
     identifying_attributes:
       "service.name": "io.opentelemetry.collector"
     non_identifying_attributes:
@@ -1144,7 +1145,8 @@ telemetry:
 					Agent: Agent{
 						Executable: executablePath,
 						Description: AgentDescription{
-							IncludeResourceAttributes: true,
+							IncludeResourceAttributes:   true,
+							IncludeSupervisorInstanceID: true,
 							IdentifyingAttributes: map[string]string{
 								"service.name": "io.opentelemetry.collector",
 							},

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1287,6 +1287,11 @@ func (s *Supervisor) composeExtraTelemetryConfig() []byte {
 	for _, attr := range ad.NonIdentifyingAttributes {
 		resourceAttrs[attr.Key] = attr.Value.GetStringValue()
 	}
+	if s.config.Agent.Description.IncludeSupervisorInstanceID {
+		if instanceID, ok := s.supervisorServiceInstanceID(); ok {
+			resourceAttrs["supervisor.service.instance.id"] = instanceID
+		}
+	}
 	attrNames := make([]string, 0, len(resourceAttrs))
 	for name := range resourceAttrs {
 		attrNames = append(attrNames, name)
@@ -1316,17 +1321,34 @@ func (s *Supervisor) composeExtraTelemetryConfig() []byte {
 	return cfg.Bytes()
 }
 
+func (s *Supervisor) supervisorServiceInstanceID() (string, bool) {
+	instanceID, ok := s.telemetrySettings.Resource.Attributes().Get("service.instance.id")
+	if !ok {
+		return "", false
+	}
+	return instanceID.AsString(), true
+}
+
 func (s *Supervisor) composeRequiredResourceAttributesConfig() []byte {
+	attributes := []map[string]any{
+		{
+			"name":  "service.instance.id",
+			"value": s.persistentState.InstanceID.String(),
+		},
+	}
+	if s.config.Agent.Description.IncludeSupervisorInstanceID {
+		if instanceID, ok := s.supervisorServiceInstanceID(); ok {
+			attributes = append(attributes, map[string]any{
+				"name":  "supervisor.service.instance.id",
+				"value": instanceID,
+			})
+		}
+	}
 	cfg, err := gyaml.Marshal(map[string]any{
 		"service": map[string]any{
 			"telemetry": map[string]any{
 				"resource": map[string]any{
-					"attributes": []map[string]any{
-						{
-							"name":  "service.instance.id",
-							"value": s.persistentState.InstanceID.String(),
-						},
-					},
+					"attributes": attributes,
 				},
 			},
 		},

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -858,10 +858,10 @@ service:
 			},
 		})
 
-		telemetrySettings := newNopTelemetrySettings()
-		telemetrySettings.Resource.Attributes().PutStr("service.instance.id", "supervisor-instance")
+		supervisorTelemetrySettings := newNopTelemetrySettings()
+		supervisorTelemetrySettings.Resource.Attributes().PutStr("service.instance.id", "supervisor-instance")
 		s := Supervisor{
-			telemetrySettings: telemetrySettings,
+			telemetrySettings: supervisorTelemetrySettings,
 			config: config.Supervisor{
 				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
 				Agent: config.Agent{
@@ -1042,10 +1042,10 @@ func TestComposeExtraTelemetryConfigUsesDeclarativeResourceAttributes(t *testing
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			telemetrySettings := newNopTelemetrySettings()
-			telemetrySettings.Resource.Attributes().PutStr("service.instance.id", "supervisor-instance")
+			supervisorTelemetrySettings := newNopTelemetrySettings()
+			supervisorTelemetrySettings.Resource.Attributes().PutStr("service.instance.id", "supervisor-instance")
 			s := Supervisor{
-				telemetrySettings: telemetrySettings,
+				telemetrySettings: supervisorTelemetrySettings,
 				config: config.Supervisor{Agent: config.Agent{
 					Description: config.AgentDescription{IncludeSupervisorInstanceID: tc.includeSupervisorInstanceID},
 				}},

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -147,6 +148,7 @@ func newNopTelemetrySettings() telemetrySettings {
 		TelemetrySettings: component.TelemetrySettings{
 			Logger:         zap.NewNop(),
 			TracerProvider: noop.NewTracerProvider(),
+			Resource:       pcommon.NewResource(),
 		},
 	}
 }
@@ -856,13 +858,18 @@ service:
 			},
 		})
 
+		telemetrySettings := newNopTelemetrySettings()
+		telemetrySettings.Resource.Attributes().PutStr("service.instance.id", "supervisor-instance")
 		s := Supervisor{
-			telemetrySettings: newNopTelemetrySettings(),
+			telemetrySettings: telemetrySettings,
 			config: config.Supervisor{
 				Capabilities: config.Capabilities{AcceptsRemoteConfig: true},
-				Agent: config.Agent{ConfigFiles: []string{
-					string(config.SpecialConfigFileRemoteConfig),
-				}},
+				Agent: config.Agent{
+					ConfigFiles: []string{
+						string(config.SpecialConfigFileRemoteConfig),
+					},
+					Description: config.AgentDescription{IncludeSupervisorInstanceID: true},
+				},
 			},
 			agentDescription: agentDesc,
 			persistentState:  &persistentState{InstanceID: uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb")},
@@ -909,6 +916,7 @@ service:
 		assert.Equal(t, "remote-version", attrValues["service.version"])
 		assert.Equal(t, "remote-env", attrValues["deployment.environment"])
 		assert.Equal(t, "018fee23-4a51-7303-a441-73faed7d9deb", attrValues["service.instance.id"])
+		assert.Equal(t, "supervisor-instance", attrValues["supervisor.service.instance.id"])
 	})
 
 	t.Run("remote legacy attributes override stale agent description attributes", func(t *testing.T) {
@@ -1011,25 +1019,51 @@ func TestComposeExtraTelemetryConfigUsesDeclarativeResourceAttributes(t *testing
 		},
 	})
 
-	s := Supervisor{
-		telemetrySettings: newNopTelemetrySettings(),
-		agentDescription:  agentDesc,
+	for _, tc := range []struct {
+		name                        string
+		includeSupervisorInstanceID bool
+		expected                    []any
+	}{
+		{
+			name: "disabled",
+			expected: []any{
+				map[string]any{"name": "service.name", "value": "otelcol"},
+				map[string]any{"name": "service.version", "value": "0.152.0"},
+			},
+		},
+		{
+			name:                        "enabled",
+			includeSupervisorInstanceID: true,
+			expected: []any{
+				map[string]any{"name": "service.name", "value": "otelcol"},
+				map[string]any{"name": "service.version", "value": "0.152.0"},
+				map[string]any{"name": "supervisor.service.instance.id", "value": "supervisor-instance"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			telemetrySettings := newNopTelemetrySettings()
+			telemetrySettings.Resource.Attributes().PutStr("service.instance.id", "supervisor-instance")
+			s := Supervisor{
+				telemetrySettings: telemetrySettings,
+				config: config.Supervisor{Agent: config.Agent{
+					Description: config.AgentDescription{IncludeSupervisorInstanceID: tc.includeSupervisorInstanceID},
+				}},
+				agentDescription: agentDesc,
+			}
+			require.NoError(t, s.createTemplates())
+
+			conf, err := config.NewConfFromYAML(s.composeExtraTelemetryConfig())
+			require.NoError(t, err)
+
+			assert.False(t, conf.IsSet("service::telemetry::resource::service.name"))
+			assert.False(t, conf.IsSet("service::telemetry::resource::service.version"))
+
+			attrs, ok := conf.Get("service::telemetry::resource::attributes").([]any)
+			require.True(t, ok)
+			assert.Equal(t, tc.expected, attrs)
+		})
 	}
-	require.NoError(t, s.createTemplates())
-
-	conf, err := config.NewConfFromYAML(s.composeExtraTelemetryConfig())
-	require.NoError(t, err)
-
-	assert.False(t, conf.IsSet("service::telemetry::resource::service.name"))
-	assert.False(t, conf.IsSet("service::telemetry::resource::service.version"))
-
-	attrs, ok := conf.Get("service::telemetry::resource::attributes").([]any)
-	require.True(t, ok)
-	require.Len(t, attrs, 2)
-	assert.Equal(t, []any{
-		map[string]any{"name": "service.name", "value": "otelcol"},
-		map[string]any{"name": "service.version", "value": "0.152.0"},
-	}, attrs)
 }
 
 func TestComposeExtraTelemetryConfigTemplateError(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds a small configuration in the Supervisor to automatically inject its `service.instance.id` into the agent's resource attributes, effectively also including it in the agent's own telemetry.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50759.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Automated tests updated and smoke tests ran locally.

<!--Describe the documentation added.-->
#### Documentation

Small update to the Supervisor spec file to explain the new configuration option.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
