### PR TITLE
Do not panic on AIX

### DIFF
--- a/.chloggen/aix_panic.yaml
+++ b/.chloggen/aix_panic.yaml
@@ -1,0 +1,36 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not panic on AIX
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50764]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  These components do not work on AIX. However, they panic if incorporated in a distribution running on AIX, even if not used.
+  The fix is to return an error instead of a panic when trying to run on this OS. 
+  The components affected are:
+  - connector/datadogconnector
+  - exporter/datadogexporter
+  - exporter/pulsarexporter
+  - extension/datadogextension
+  - extension/tailstorage/pebbletailstorageextension
+  - receiver/pulsarreceiver
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/datadogconnector/factory_aix.go
+++ b/connector/datadogconnector/factory_aix.go
@@ -4,8 +4,32 @@
 //go:build aix
 
 package datadogconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector"
-import "go.opentelemetry.io/collector/connector"
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/connector"
+	"go.opentelemetry.io/collector/consumer"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector/internal/metadata"
+)
 
 func NewFactory() connector.Factory {
-	panic("aix is not supported")
+	return connector.NewFactory(
+		metadata.Type,
+		func() component.Config {
+			return nil
+		},
+		connector.WithTracesToMetrics(createTracesToMetricsConnector, metadata.TracesToMetricsStability),
+		connector.WithTracesToTraces(createTracesToTracesConnector, metadata.TracesToTracesStability),
+	)
+}
+
+func createTracesToTracesConnector(context.Context, connector.Settings, component.Config, consumer.Traces) (connector.Traces, error) {
+	return nil, errors.New("datadogconnector is not supported on aix")
+}
+
+func createTracesToMetricsConnector(context.Context, connector.Settings, component.Config, consumer.Metrics) (connector.Traces, error) {
+	return nil, errors.New("datadogconnector is not supported on aix")
 }

--- a/exporter/datadogexporter/factory_aix.go
+++ b/exporter/datadogexporter/factory_aix.go
@@ -5,8 +5,36 @@
 
 package datadogexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
 
-import "go.opentelemetry.io/collector/exporter"
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
+)
 
 func NewFactory() exporter.Factory {
-	panic("aix is not supported")
+	return exporter.NewFactory(
+		metadata.Type,
+		func() component.Config {
+			return nil
+		},
+		exporter.WithMetrics(createMetrics, metadata.MetricsStability),
+		exporter.WithTraces(createTraces, metadata.TracesStability),
+		exporter.WithLogs(createLogs, metadata.LogsStability),
+	)
+}
+
+func createMetrics(context.Context, exporter.Settings, component.Config) (exporter.Metrics, error) {
+	return nil, errors.New("datadogexporter is not supported on aix")
+}
+
+func createTraces(context.Context, exporter.Settings, component.Config) (exporter.Traces, error) {
+	return nil, errors.New("datadogexporter is not supported on aix")
+}
+
+func createLogs(context.Context, exporter.Settings, component.Config) (exporter.Logs, error) {
+	return nil, errors.New("datadogexporter is not supported on aix")
 }

--- a/exporter/pulsarexporter/factory_aix.go
+++ b/exporter/pulsarexporter/factory_aix.go
@@ -6,9 +6,36 @@
 //go:build aix
 
 package pulsarexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter"
-import "go.opentelemetry.io/collector/exporter"
+import (
+	"context"
+	"errors"
 
-// NewFactory creates Pulsar exporter factory.
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter/internal/metadata"
+)
+
 func NewFactory() exporter.Factory {
-	panic("AIX is not supported")
+	return exporter.NewFactory(
+		metadata.Type,
+		func() component.Config {
+			return nil
+		},
+		exporter.WithMetrics(createMetrics, metadata.MetricsStability),
+		exporter.WithTraces(createTraces, metadata.TracesStability),
+		exporter.WithLogs(createLogs, metadata.LogsStability),
+	)
+}
+
+func createMetrics(context.Context, exporter.Settings, component.Config) (exporter.Metrics, error) {
+	return nil, errors.New("pulsarexporter is not supported on aix")
+}
+
+func createTraces(context.Context, exporter.Settings, component.Config) (exporter.Traces, error) {
+	return nil, errors.New("pulsarexporter is not supported on aix")
+}
+
+func createLogs(context.Context, exporter.Settings, component.Config) (exporter.Logs, error) {
+	return nil, errors.New("pulsarexporter is not supported on aix")
 }

--- a/extension/datadogextension/factory_aix.go
+++ b/extension/datadogextension/factory_aix.go
@@ -4,8 +4,28 @@
 //go:build aix
 
 package datadogextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension"
-import "go.opentelemetry.io/collector/extension"
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/metadata"
+)
 
 func NewFactory() extension.Factory {
-	panic("aix is not supported")
+	return extension.NewFactory(
+		metadata.Type,
+		func() component.Config {
+			return nil
+		},
+		createAix,
+		metadata.ExtensionStability,
+	)
+}
+
+func createAix(context.Context, extension.Settings, component.Config) (extension.Extension, error) {
+	return nil, errors.New("datadogextension is not supported on aix")
 }

--- a/extension/tailstorage/pebbletailstorageextension/factory_aix.go
+++ b/extension/tailstorage/pebbletailstorageextension/factory_aix.go
@@ -5,8 +5,27 @@
 
 package pebbletailstorageextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension"
 
-import "go.opentelemetry.io/collector/extension"
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/tailstorage/pebbletailstorageextension/internal/metadata"
+)
 
 func NewFactory() extension.Factory {
-	panic("aix is not supported")
+	return extension.NewFactory(
+		metadata.Type,
+		func() component.Config {
+			return nil
+		},
+		createAix,
+		metadata.ExtensionStability,
+	)
+}
+
+func createAix(context.Context, extension.Settings, component.Config) (extension.Extension, error) {
+	return nil, errors.New("pebbletailstorageextension is not supported on aix")
 }

--- a/receiver/pulsarreceiver/factory_aix.go
+++ b/receiver/pulsarreceiver/factory_aix.go
@@ -5,10 +5,33 @@
 
 package pulsarreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver"
 import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver/internal/metadata"
 )
 
 // NewFactory creates Pulsar exporter factory.
 func NewFactory() receiver.Factory {
-	panic("AIX is not supported")
+	return receiver.NewFactory(metadata.Type, func() component.Config {
+		return nil
+	}, receiver.WithLogs(createLogs, metadata.LogsStability),
+		receiver.WithMetrics(createMetrics, metadata.MetricsStability),
+		receiver.WithTraces(createTraces, metadata.TracesStability))
+}
+
+func createTraces(context.Context, receiver.Settings, component.Config, consumer.Traces) (receiver.Traces, error) {
+	return nil, errors.New("pulsarreceiver is not supported on AIX")
+}
+
+func createMetrics(context.Context, receiver.Settings, component.Config, consumer.Metrics) (receiver.Metrics, error) {
+	return nil, errors.New("pulsarreceiver is not supported on AIX")
+}
+
+func createLogs(context.Context, receiver.Settings, component.Config, consumer.Logs) (receiver.Logs, error) {
+	return nil, errors.New("pulsarreceiver is not supported on AIX")
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

These components do not work on AIX. However, they panic if incorporated in a distribution running on AIX, even if not used.
  The fix is to return an error instead of a panic when trying to run on this OS. 
  The components affected are:
  - connector/datadogconnector
  - exporter/datadogexporter
  - exporter/pulsarexporter
  - extension/datadogextension
  - extension/tailstorage/pebbletailstorageextension
  - receiver/pulsarreceiver

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
