### PR TITLE
fix(receiver/nsxtreceiver): guard against nil interface stats

### DIFF
--- a/.chloggen/nsxtreceiver-nil-interface-stats-panic.yaml
+++ b/.chloggen/nsxtreceiver-nil-interface-stats-panic.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/nsxt
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a panic when interface status retrieval fails for one interface during a scrape.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50768]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/nsxtreceiver/scraper.go
+++ b/receiver/nsxtreceiver/scraper.go
@@ -184,6 +184,10 @@ func (s *nsxtScraper) process(
 }
 
 func (s *nsxtScraper) recordNodeInterface(colTime pcommon.Timestamp, nodeProps dm.NodeProperties, i interfaceInformation) {
+	if i.stats == nil {
+		return
+	}
+
 	s.mb.RecordNsxtNodeNetworkPacketCountDataPoint(colTime, i.stats.RxDropped, metadata.AttributeDirectionReceived, metadata.AttributePacketTypeDropped)
 	s.mb.RecordNsxtNodeNetworkPacketCountDataPoint(colTime, i.stats.RxErrors, metadata.AttributeDirectionReceived, metadata.AttributePacketTypeErrored)
 	successRxPackets := i.stats.RxPackets - i.stats.RxDropped - i.stats.RxErrors

--- a/receiver/nsxtreceiver/scraper_test.go
+++ b/receiver/nsxtreceiver/scraper_test.go
@@ -158,6 +158,24 @@ func TestScraperRecordNoStat(_ *testing.T) {
 	scraper.recordNode(pcommon.NewTimestampFromTime(time.Now()), &nodeInfo{stats: nil})
 }
 
+func TestScraperRecordInterfaceNoStat(_ *testing.T) {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	// TODO: See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/49316.
+	clientConfig.MaxIdleConns = 0    //nolint:staticcheck // SA1019: see TODO above
+	clientConfig.IdleConnTimeout = 0 //nolint:staticcheck // SA1019: see TODO above
+	clientConfig.ForceAttemptHTTP2 = false
+	clientConfig.Endpoint = "http://localhost"
+	scraper := newScraper(
+		&Config{
+			ClientConfig:         clientConfig,
+			MetricsBuilderConfig: metadata.NewDefaultMetricsBuilderConfig(),
+		},
+		receivertest.NewNopSettings(metadata.Type),
+	)
+	scraper.host = componenttest.NewNopHost()
+	scraper.recordNodeInterface(pcommon.NewTimestampFromTime(time.Now()), dm.NodeProperties{}, interfaceInformation{stats: nil})
+}
+
 func loadTestNodeStatus(t *testing.T, nodeID string, class nodeClass) (*dm.NodeStatus, error) {
 	classType := "cluster"
 	if class == transportClass {


### PR DESCRIPTION
#### Description

In `nsxtreceiver`, when the stats call for a single interface fails, `interfaceInformation.stats` remains nil. `recordNodeInterface` then accesses fields such as `i.stats.RxDropped` without checking whether `stats` is nil, which can cause the receiver to panic.

The sibling `recordNode` function already handles the same situation by returning early when `info.stats == nil`. This change adds the equivalent guard to `recordNodeInterface`, allowing the scrape to continue safely when stats are unavailable for an individual interface.

#### Link to tracking issue

N/A - no tracking issue. This was found while reviewing the existing code.

#### Testing

Added `TestScraperRecordInterfaceNoStat` to verify that `recordNodeInterface` does not panic when interface stats are nil.

The test was also verified by temporarily removing the guard and confirming that it reproduces the panic.

#### Documentation

N/A - no documentation changes are required.

#### Authorship

- [x] I, a human, wrote this pull request description myself.