### PR TITLE
[processor/redaction] Keep all summary attributes when data re-enters the processor

### DIFF
--- a/.chloggen/50770-redaction-allowlist-diagnostics.yaml
+++ b/.chloggen/50770-redaction-allowlist-diagnostics.yaml
@@ -16,8 +16,8 @@ issues: [50770]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  The auto-allowlist only covered five of the summary attributes the processor writes. When data passed
-  through a second redaction processor, `redaction.allowed.keys`, `redaction.allowed.count` and the six
+  The auto-allowlist only covered five of the fourteen summary attributes the processor writes. When data passed
+  through a second redaction processor, `redaction.allowed.keys`, `redaction.allowed.count` and the seven
   `redaction.body.*` attributes were treated as unknown keys, deleted, and reported in
   `redaction.redacted.keys`. All summary attributes are now allowed through, so the summary accumulates
   across chained processors as intended.

--- a/.chloggen/50770-redaction-allowlist-diagnostics.yaml
+++ b/.chloggen/50770-redaction-allowlist-diagnostics.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/redaction
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Keep every redaction summary attribute when data re-enters the processor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50770]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The auto-allowlist only covered five of the summary attributes the processor writes. When data passed
+  through a second redaction processor, `redaction.allowed.keys`, `redaction.allowed.count` and the six
+  `redaction.body.*` attributes were treated as unknown keys, deleted, and reported in
+  `redaction.redacted.keys`. All summary attributes are now allowed through, so the summary accumulates
+  across chained processors as intended.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -615,7 +615,22 @@ func makeAllowList(c *Config) map[string]string {
 	// span attributes (e.g. `notes`, `description`), then it will those
 	// attribute keys in `redaction.masked.keys` and set the
 	// `redaction.masked.count` to 2
-	redactionKeys := []string{redactionRedactedKeys, redactionRedactedCount, redactionMaskedKeys, redactionMaskedCount, redactionIgnoredCount}
+	//
+	// Every attribute the processor writes is listed here so that it survives
+	// re-entry: when data passes through a second redaction processor, these
+	// keys must be allowed through rather than treated as unknown attributes and
+	// deleted. addMetaAttrs merges into any values it finds, so the summary
+	// accumulates across the chain.
+	redactionKeys := []string{
+		redactionRedactedKeys, redactionRedactedCount,
+		redactionMaskedKeys, redactionMaskedCount,
+		redactionAllowedKeys, redactionAllowedCount,
+		redactionIgnoredCount,
+		redactionBodyRedactedKeys, redactionBodyRedactedCount,
+		redactionBodyMaskedKeys, redactionBodyMaskedCount,
+		redactionBodyAllowedKeys, redactionBodyAllowedCount,
+		redactionBodyIgnoredCount,
+	}
 	// allowList consists of the keys explicitly allowed by the configuration
 	// as well as of the new span attributes that the processor creates to
 	// summarize its changes

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"sync"
@@ -1166,9 +1167,7 @@ func TestDiagnosticAttrsSurviveReentry(t *testing.T) {
 	}
 
 	raw := map[string]any{"id": 5, "redundant": 1.2}
-	for k, v := range diagnostics {
-		raw[k] = v
-	}
+	maps.Copy(raw, diagnostics)
 
 	attrs := pcommon.NewMap()
 	require.NoError(t, attrs.FromRaw(raw))

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -1135,6 +1135,64 @@ func TestProcessAttrsAppliedTwice(t *testing.T) {
 	assert.Equal(t, int64(2), val.Int())
 }
 
+// TestDiagnosticAttrsSurviveReentry validates that the summary attributes the
+// processor writes are allowed through a second redaction processor instead of
+// being treated as unknown attributes and deleted.
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50770
+func TestDiagnosticAttrsSurviveReentry(t *testing.T) {
+	config := &Config{
+		AllowedKeys: []string{"id"},
+		Summary:     "debug",
+	}
+	processor, err := newRedaction(t.Context(), config, zaptest.NewLogger(t))
+	require.NoError(t, err)
+
+	// The summary a previous redaction processor in the pipeline left behind.
+	diagnostics := map[string]any{
+		redactionRedactedKeys:      "dropped_attr",
+		redactionRedactedCount:     int64(1),
+		redactionMaskedKeys:        "mystery",
+		redactionMaskedCount:       int64(1),
+		redactionAllowedKeys:       "email",
+		redactionAllowedCount:      int64(1),
+		redactionIgnoredCount:      int64(1),
+		redactionBodyRedactedKeys:  "body_dropped_attr",
+		redactionBodyRedactedCount: int64(1),
+		redactionBodyMaskedKeys:    "body_mystery",
+		redactionBodyMaskedCount:   int64(1),
+		redactionBodyAllowedKeys:   "body",
+		redactionBodyAllowedCount:  int64(1),
+		redactionBodyIgnoredCount:  int64(1),
+	}
+
+	raw := map[string]any{"id": 5, "redundant": 1.2}
+	for k, v := range diagnostics {
+		raw[k] = v
+	}
+
+	attrs := pcommon.NewMap()
+	require.NoError(t, attrs.FromRaw(raw))
+	processor.processAttrs(t.Context(), attrs)
+
+	for key, want := range diagnostics {
+		val, found := attrs.Get(key)
+		require.Truef(t, found, "%s was deleted on re-entry", key)
+		// redaction.redacted.* is updated by this pass and asserted separately.
+		if key == redactionRedactedKeys || key == redactionRedactedCount {
+			continue
+		}
+		assert.Equalf(t, want, val.AsRaw(), "%s was modified on re-entry", key)
+	}
+
+	// Only the unknown attribute is redacted, and the running summary accumulates.
+	val, found := attrs.Get(redactionRedactedKeys)
+	require.True(t, found)
+	assert.Equal(t, "dropped_attr,redundant", val.Str())
+	val, found = attrs.Get(redactionRedactedCount)
+	require.True(t, found)
+	assert.Equal(t, int64(2), val.Int())
+}
+
 // TestRedactAllTypesFalse validates that not all types are redacted when the setting is false
 func TestRedactAllTypesFalse(t *testing.T) {
 	tc := testConfig{


### PR DESCRIPTION
Fixes #50770

#### Description
makeAllowList had only 5 summary attributes out of 14.When data passed through a second redaction processor, redaction.allowed.keys, redaction.allowed.count and the seven redaction.body.* attributes were treated as unknown keys and deleted, then reported in that processor's redaction.redacted.keys.

addMetaAttrs already merges into any pre-existing value, so surviving re-entry is the intended behaviour for these attributes.

#### Link to tracking issue
Fixes #50770

#### Testing
Added one test, TestDiagnosticAttrsSurviveReentry creates a map with summary attributes and an attribute which is not in the allowlist and calls processAttrs then the attribute which is not in the allowlist gets deleted while other summary attributes untouched

#### Authorship
Assisted-by: Claude Opus 5

- [x] I, a human, wrote this pull request description myself.