### PR TITLE
[pkg/pdatatest] Add pmetricassert double_value precision operator

### DIFF
--- a/.chloggen/pmetricassert-precision-operator.yaml
+++ b/.chloggen/pmetricassert-precision-operator.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+component: pkg/pdatatest
+note: Add a `double_value/precision<n>` operator to `pmetricassert`, comparing double datapoint values rounded to n decimal places
+issues: [48441]
+subtext: |
+  Mirrors `pmetrictest`'s `IgnoreMetricFloatPrecision` for assertion snapshots.
+  `n` must be between 0 and 15, and the operator cannot be combined with an
+  exact `double_value` on the same datapoint.
+change_logs: [user]

--- a/pkg/pdatatest/pmetricassert/README.md
+++ b/pkg/pdatatest/pmetricassert/README.md
@@ -153,6 +153,25 @@ Use at most one of `version:`, `version/exists:`, or `version/regex:` per
 scope. `version/exists` accepts only `true`; any other value is a schema
 error.
 
+### Datapoint value precision matcher
+
+A `double_value` key can use the `/precision<n>` suffix when the value is a
+float whose trailing digits are not stable. Both sides are rounded to `n`
+decimal places before they are compared, matching `pmetrictest`'s
+`IgnoreMetricFloatPrecision`:
+
+```yaml
+datapoints:
+  - attributes:
+      state: user
+    double_value/precision3: 1.235
+```
+
+`n` must be between 0 and 15; beyond that a `float64` cannot distinguish the
+values. Use at most one of `double_value:` or `double_value/precision<n>:` per
+datapoint. The operator applies only to `double_value`, since integer values
+have no float precision to ignore.
+
 ### Shorthand: single empty-attribute datapoint
 
 A metric with exactly one datapoint that has no attributes can omit

--- a/pkg/pdatatest/pmetricassert/assert.go
+++ b/pkg/pdatatest/pmetricassert/assert.go
@@ -6,6 +6,7 @@ package pmetricassert // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"slices"
 	"sort"
@@ -224,6 +225,12 @@ func compareDatapoints(expected, actual []datapointAssertion) error {
 	return errors.Join(errs...)
 }
 
+// roundTo matches how pmetrictest's IgnoreMetricFloatPrecision rounds.
+func roundTo(v float64, n int) float64 {
+	factor := math.Pow(10, float64(n))
+	return math.Round(v*factor) / factor
+}
+
 func compareDatapointValues(expected, actual datapointAssertion) error {
 	var errs []error
 	if expected.IntValue != nil {
@@ -234,9 +241,15 @@ func compareDatapointValues(expected, actual datapointAssertion) error {
 		}
 	}
 	if expected.DoubleValue != nil {
-		if actual.DoubleValue == nil {
+		switch {
+		case actual.DoubleValue == nil:
 			errs = append(errs, errors.New("missing expected double_value"))
-		} else if *expected.DoubleValue != *actual.DoubleValue {
+		case expected.DoublePrecision != nil:
+			digits := *expected.DoublePrecision
+			if roundTo(*expected.DoubleValue, digits) != roundTo(*actual.DoubleValue, digits) {
+				errs = append(errs, fmt.Errorf("double_value mismatch at %d decimal places: expected %v, got %v", digits, *expected.DoubleValue, *actual.DoubleValue))
+			}
+		case *expected.DoubleValue != *actual.DoubleValue:
 			errs = append(errs, fmt.Errorf("double_value mismatch: expected %v, got %v", *expected.DoubleValue, *actual.DoubleValue))
 		}
 	}

--- a/pkg/pdatatest/pmetricassert/assert_test.go
+++ b/pkg/pdatatest/pmetricassert/assert_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"gopkg.in/yaml.v3"
 )
 
 func TestAssertMetrics_RoundTrip(t *testing.T) {
@@ -540,6 +541,94 @@ func TestAssertMetrics_SingleEmptyDatapointShorthand(t *testing.T) {
 		"single empty-attribute datapoint should be compacted to no `datapoints:` key")
 
 	require.NoError(t, AssertMetrics(path, m))
+}
+
+func TestAssertMetrics_DoublePrecisionOperator(t *testing.T) {
+	m := buildSampleMetrics()
+	gauge := m.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+	dp := gauge.Gauge().DataPoints().At(0)
+	dp.SetDoubleValue(1.23456)
+
+	path := filepath.Join(t.TempDir(), "metrics.assert.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`version: 1
+signal: metrics
+resources:
+    - attributes:
+        service.name: svc
+      scopes:
+        - name: github.com/example/receiver
+          version: v0.0.1
+          metrics:
+            - name: svc.active
+              type: gauge
+              unit: "1"
+              datapoints:
+                - attributes: {}
+                  double_value/precision3: 1.235
+            - name: svc.requests
+              type: sum
+              unit: "{requests}"
+              temporality: cumulative
+              monotonic: true
+              datapoints:
+                - attributes:
+                    method: GET
+                - attributes:
+                    method: POST
+`), 0o600))
+
+	require.NoError(t, AssertMetrics(path, m))
+
+	// Drift below the asserted precision is tolerated.
+	dp.SetDoubleValue(1.23549)
+	require.NoError(t, AssertMetrics(path, m))
+
+	// Drift at the asserted precision is not.
+	dp.SetDoubleValue(1.24)
+	err := AssertMetrics(path, m)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "double_value mismatch at 3 decimal places")
+}
+
+func TestDatapointAssertion_PrecisionOperatorSchemaErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{
+			name: "count is not a number",
+			doc:  "double_value/precisionX: 1.0",
+			want: "must end in a decimal place count",
+		},
+		{
+			name: "count is negative",
+			doc:  "double_value/precision-1: 1.0",
+			want: "out of range",
+		},
+		{
+			name: "count exceeds float64 precision",
+			doc:  "double_value/precision99: 1.0",
+			want: "out of range",
+		},
+		{
+			name: "conflicts with an exact double_value",
+			doc:  "double_value: 1.0\ndouble_value/precision2: 1.0",
+			want: "cannot specify both",
+		},
+		{
+			name: "more than one precision operator",
+			doc:  "double_value/precision2: 1.0\ndouble_value/precision3: 1.0",
+			want: "more than one precision operator",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var dp datapointAssertion
+			err := yaml.Unmarshal([]byte(tc.doc), &dp)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
 }
 
 func buildSampleMetrics() pmetric.Metrics {

--- a/pkg/pdatatest/pmetricassert/doc.go
+++ b/pkg/pdatatest/pmetricassert/doc.go
@@ -14,6 +14,8 @@
 // regular expression. The scope version field supports the same operators.
 // Attribute maps may use attributes/include instead of attributes to assert a
 // subset of the map while allowing extra keys.
+// A double_value key may use the /precision<n> suffix to compare rounded to n
+// decimal places, mirroring pmetrictest's IgnoreMetricFloatPrecision.
 //
 // See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48079
 // for the design discussion and roadmap of operator-suffix grammar

--- a/pkg/pdatatest/pmetricassert/document.go
+++ b/pkg/pdatatest/pmetricassert/document.go
@@ -8,9 +8,18 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// The decimal-place count is part of the key, so it is matched by prefix.
+const doubleValuePrecisionPrefix = "double_value/precision"
+
+// A float64 cannot distinguish more than ~15 decimal places.
+const maxDoublePrecision = 15
 
 // documentVersion is the schema version emitted by WriteAssertionFile.
 // Readers accept this exact value; bumps must be backwards compatible or
@@ -201,16 +210,18 @@ type metricAssertion struct {
 }
 
 type datapointAssertion struct {
-	Attributes     map[string]any `yaml:"attributes,omitempty"`
-	AttributeMode  attributeMode  `yaml:"-"`
-	IntValue       *int64         `yaml:"int_value,omitempty"`
-	DoubleValue    *float64       `yaml:"double_value,omitempty"`
-	Count          *uint64        `yaml:"count,omitempty"`
-	Sum            *float64       `yaml:"sum,omitempty"`
-	ExplicitBounds *[]float64     `yaml:"explicit_bounds,omitempty"`
-	BucketCounts   []uint64       `yaml:"bucket_counts,omitempty"`
-	Min            *float64       `yaml:"min,omitempty"`
-	Max            *float64       `yaml:"max,omitempty"`
+	Attributes    map[string]any `yaml:"attributes,omitempty"`
+	AttributeMode attributeMode  `yaml:"-"`
+	IntValue      *int64         `yaml:"int_value,omitempty"`
+	DoubleValue   *float64       `yaml:"double_value,omitempty"`
+	// Set by `double_value/precision<n>`; nil compares exactly.
+	DoublePrecision *int       `yaml:"-"`
+	Count           *uint64    `yaml:"count,omitempty"`
+	Sum             *float64   `yaml:"sum,omitempty"`
+	ExplicitBounds  *[]float64 `yaml:"explicit_bounds,omitempty"`
+	BucketCounts    []uint64   `yaml:"bucket_counts,omitempty"`
+	Min             *float64   `yaml:"min,omitempty"`
+	Max             *float64   `yaml:"max,omitempty"`
 }
 
 // UnmarshalYAML implements custom unmarshaling to support `attributes/include`
@@ -252,6 +263,9 @@ func (d *datapointAssertion) UnmarshalYAML(node *yaml.Node) error {
 			return fmt.Errorf("datapoint assertion: decode double_value: %w", err)
 		}
 		d.DoubleValue = &dv
+	}
+	if err := d.decodeDoublePrecision(raw); err != nil {
+		return err
 	}
 	if v, ok := raw["count"]; ok {
 		var c uint64
@@ -295,6 +309,45 @@ func (d *datapointAssertion) UnmarshalYAML(node *yaml.Node) error {
 		}
 		d.Max = &maxVal
 	}
+	return nil
+}
+
+// decodeDoublePrecision resolves `double_value/precision<n>` into DoubleValue
+// plus DoublePrecision.
+func (d *datapointAssertion) decodeDoublePrecision(raw map[string]yaml.Node) error {
+	var keys []string
+	for key := range raw {
+		if strings.HasPrefix(key, doubleValuePrecisionPrefix) {
+			keys = append(keys, key)
+		}
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	sort.Strings(keys) // map order is random; keep the error stable
+	if len(keys) > 1 {
+		return fmt.Errorf("datapoint assertion: cannot specify more than one precision operator, got %v", keys)
+	}
+	key := keys[0]
+	if d.DoubleValue != nil {
+		return fmt.Errorf("datapoint assertion: cannot specify both %q and %q", "double_value", key)
+	}
+
+	digits, err := strconv.Atoi(strings.TrimPrefix(key, doubleValuePrecisionPrefix))
+	if err != nil {
+		return fmt.Errorf("datapoint assertion: %q must end in a decimal place count, e.g. %s3", key, doubleValuePrecisionPrefix)
+	}
+	if digits < 0 || digits > maxDoublePrecision {
+		return fmt.Errorf("datapoint assertion: %q is out of range, want 0 to %d", key, maxDoublePrecision)
+	}
+
+	var dv float64
+	node := raw[key]
+	if err := node.Decode(&dv); err != nil {
+		return fmt.Errorf("datapoint assertion: decode %s: %w", key, err)
+	}
+	d.DoubleValue = &dv
+	d.DoublePrecision = &digits
 	return nil
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48441

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/48441

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added tests to 1. assert a value that drifts below the stated precision still passes and one that drifts at it fails and 2. tests that cover schema errors

<!--Describe the documentation added.-->
#### Documentation
Added a section to `pmetricassert` README and a line to the package doc comment to match other newly added operators

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
