### PR TITLE
[receiver/awsecscontainermetrics] fix storage read/write bytes always 0 on cgroup v2 hosts

### DIFF
--- a/.chloggen/50791.yaml
+++ b/.chloggen/50791.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awsecscontainermetrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix `container.storage.read_bytes`/`container.storage.write_bytes` (and the task-level equivalents) always reporting 0 on cgroup v2 hosts, where the ECS Task Metadata Endpoint v4 `/stats` response reports the blkio `Op` field in lowercase (`read`/`write`) instead of the capitalized form (`Read`/`Write`) used on cgroup v1 hosts."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50791]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -4,6 +4,8 @@
 package awsecscontainermetrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics"
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.uber.org/zap"
 )
@@ -108,10 +110,12 @@ func extractStorageUsage(stats *DiskStats) (uint64, uint64) {
 	}
 
 	for _, blockStat := range stats.IoServiceBytesRecursives {
-		switch op := blockStat.Op; op {
-		case "Read":
+		// The Op value is capitalized ("Read"/"Write") on cgroup v1 hosts but
+		// lowercase ("read"/"write") on cgroup v2 hosts, so match case-insensitively.
+		switch {
+		case strings.EqualFold(blockStat.Op, "Read"):
 			readBytes += aws.ToUint64(blockStat.Value)
-		case "Write":
+		case strings.EqualFold(blockStat.Op, "Write"):
 			writeBytes += aws.ToUint64(blockStat.Value)
 
 		default:

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -413,6 +413,30 @@ func TestExtractStorageUsage(t *testing.T) {
 	require.Equal(t, v, write)
 }
 
+func TestExtractStorageUsageLowercaseOp(t *testing.T) {
+	// On cgroup v2 hosts, the ECS Task Metadata Endpoint v4 /stats response
+	// reports blkio_stats.io_service_bytes_recursive Op values in lowercase
+	// ("read"/"write") instead of the capitalized form ("Read"/"Write") seen
+	// on cgroup v1 hosts.
+	v := uint64(100)
+	v2 := uint64(200)
+	disk := &DiskStats{
+		IoServiceBytesRecursives: []IoServiceBytesRecursive{
+			{Op: "read", Value: &v},
+			{Op: "write", Value: &v},
+			{Op: "total", Value: &v},
+
+			{Op: "read", Value: &v2},
+			{Op: "write", Value: &v2},
+			{Op: "total", Value: &v2},
+		},
+	}
+	read, write := extractStorageUsage(disk)
+
+	require.Equal(t, v+v2, read)
+	require.Equal(t, v+v2, write)
+}
+
 func TestExtractStorageUsageDereferenceCheck(t *testing.T) {
 	disk := &DiskStats{
 		IoServiceBytesRecursives: []IoServiceBytesRecursive{


### PR DESCRIPTION
#### Description

extractStorageUsage() matched blkio_stats.io_service_bytes_recursive Op
values case-sensitively against "Read"/"Write". On cgroup v2 hosts the ECS
Task Metadata Endpoint v4 /stats response reports these values in lowercase
("read"/"write"), so every entry fell through to the default case and
container.storage.read_bytes/write_bytes (and the task-level equivalents)
were always reported as 0, silently, with no error or log line.

Match case-insensitively via strings.EqualFold instead.

#### Link to tracking issue
Fixes #50791

#### Testing

- Existing test, unmodified, still passes: `TestExtractStorageUsage` — capitalized `"Read"`/`"Write"` (cgroup v1 style), confirms no regression.
- `TestExtractStorageUsageDereferenceCheck` — nil-value entries, still passes.
- New test added: `TestExtractStorageUsageLowercaseOp` — lowercase `"read"`/`"write"` entries (cgroup v2 style), fails on the old code, passes on the fix.
- Manual verification (not part of the diff): replayed the actual raw `/stats` JSON captured live from a cgroup v2 ECS EC2 host (Amazon Linux 2023, kernel 6.1.174) — the fix correctly extracted `read=67620864`, `write=73465856`, matching the real byte counters exactly. Before the fix, this same payload produced `0, 0`.
- `go build ./... && go vet ./... && go test ./...` for the full `awsecscontainermetricsreceiver` module — all green.

#### Documentation

none

#### Authorship

- [x] I, a human, wrote this pull request description myself.
