### PR TITLE
[chore][k8sattributesprocessor] Fix flaky E2E attribute checks

### DIFF
--- a/processor/k8sattributesprocessor/e2e_scan_test.go
+++ b/processor/k8sattributesprocessor/e2e_scan_test.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package k8sattributesprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+const scanTestService = "scan-test-service"
+
+func TestScanTracesForAttributesSkipsIncompleteResource(t *testing.T) {
+	sink := new(consumertest.TracesSink)
+	require.NoError(t, sink.ConsumeTraces(context.Background(), tracesWithResource(true)))
+	require.NoError(t, sink.ConsumeTraces(context.Background(), tracesWithResource(false)))
+
+	scanTracesForAttributes(t, sink, scanTestService, scanTestAttributes())
+}
+
+func TestScanMetricsForAttributesSkipsIncompleteResource(t *testing.T) {
+	sink := new(consumertest.MetricsSink)
+	require.NoError(t, sink.ConsumeMetrics(context.Background(), metricsWithResource(true)))
+	require.NoError(t, sink.ConsumeMetrics(context.Background(), metricsWithResource(false)))
+
+	scanMetricsForAttributes(t, sink, scanTestService, scanTestAttributes())
+}
+
+func TestScanLogsForAttributesSkipsIncompleteResource(t *testing.T) {
+	sink := new(consumertest.LogsSink)
+	require.NoError(t, sink.ConsumeLogs(context.Background(), logsWithResource(true)))
+	require.NoError(t, sink.ConsumeLogs(context.Background(), logsWithResource(false)))
+
+	scanLogsForAttributes(t, sink, scanTestService, scanTestAttributes())
+}
+
+func scanTestAttributes() map[string]*expectedValue {
+	return map[string]*expectedValue{
+		"k8s.pod.name": newExpectedValue(exist, ""),
+	}
+}
+
+func tracesWithResource(complete bool) ptrace.Traces {
+	traces := ptrace.NewTraces()
+	resource := traces.ResourceSpans().AppendEmpty().Resource()
+	resource.Attributes().PutStr("service.name", scanTestService)
+	if complete {
+		resource.Attributes().PutStr("k8s.pod.name", "pod")
+	}
+	return traces
+}
+
+func metricsWithResource(complete bool) pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	resource := metrics.ResourceMetrics().AppendEmpty().Resource()
+	resource.Attributes().PutStr("service.name", scanTestService)
+	if complete {
+		resource.Attributes().PutStr("k8s.pod.name", "pod")
+	}
+	return metrics
+}
+
+func logsWithResource(complete bool) plog.Logs {
+	logs := plog.NewLogs()
+	resource := logs.ResourceLogs().AppendEmpty().Resource()
+	resource.Attributes().PutStr("service.name", scanTestService)
+	if complete {
+		resource.Attributes().PutStr("k8s.pod.name", "pod")
+	}
+	return logs
+}

--- a/processor/k8sattributesprocessor/e2e_test.go
+++ b/processor/k8sattributesprocessor/e2e_test.go
@@ -2039,6 +2039,7 @@ func scanTracesForAttributes(t *testing.T, ts *consumertest.TracesSink, expected
 	// Iterate over the received set of traces starting from the most recent entries due to a bug in the processor:
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18892
 	// TODO: Remove the reverse loop once it's fixed. All the metrics should be properly annotated.
+	var lastErr error
 	for i := len(ts.AllTraces()) - 1; i >= 0; i-- {
 		traces := ts.AllTraces()[i]
 		for i := 0; i < traces.ResourceSpans().Len(); i++ {
@@ -2048,9 +2049,18 @@ func scanTracesForAttributes(t *testing.T, ts *consumertest.TracesSink, expected
 			if service.AsString() != expectedService {
 				continue
 			}
-			assert.NoError(t, resourceHasAttributes(resource, kvs))
-			return
+			err := resourceHasAttributes(resource, kvs)
+			if err == nil {
+				return
+			}
+			if lastErr == nil {
+				lastErr = err
+			}
 		}
+	}
+	if lastErr != nil {
+		assert.NoError(t, lastErr)
+		return
 	}
 	t.Fatalf("no spans found for service %s", expectedService)
 }
@@ -2061,6 +2071,7 @@ func scanMetricsForAttributes(t *testing.T, ms *consumertest.MetricsSink, expect
 	// Iterate over the received set of metrics starting from the most recent entries due to a bug in the processor:
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18892
 	// TODO: Remove the reverse loop once it's fixed. All the metrics should be properly annotated.
+	var lastErr error
 	for i := len(ms.AllMetrics()) - 1; i >= 0; i-- {
 		metrics := ms.AllMetrics()[i]
 		for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
@@ -2070,9 +2081,18 @@ func scanMetricsForAttributes(t *testing.T, ms *consumertest.MetricsSink, expect
 			if service.AsString() != expectedService {
 				continue
 			}
-			assert.NoError(t, resourceHasAttributes(resource, kvs))
-			return
+			err := resourceHasAttributes(resource, kvs)
+			if err == nil {
+				return
+			}
+			if lastErr == nil {
+				lastErr = err
+			}
 		}
+	}
+	if lastErr != nil {
+		assert.NoError(t, lastErr)
+		return
 	}
 	t.Fatalf("no metric found for service %s", expectedService)
 }
@@ -2083,6 +2103,7 @@ func scanLogsForAttributes(t *testing.T, ls *consumertest.LogsSink, expectedServ
 	// Iterate over the received set of logs starting from the most recent entries due to a bug in the processor:
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18892
 	// TODO: Remove the reverse loop once it's fixed. All the metrics should be properly annotated.
+	var lastErr error
 	for i := len(ls.AllLogs()) - 1; i >= 0; i-- {
 		logs := ls.AllLogs()[i]
 		for i := 0; i < logs.ResourceLogs().Len(); i++ {
@@ -2092,9 +2113,18 @@ func scanLogsForAttributes(t *testing.T, ls *consumertest.LogsSink, expectedServ
 			if service.AsString() != expectedService {
 				continue
 			}
-			assert.NoError(t, resourceHasAttributes(resource, kvs))
-			return
+			err := resourceHasAttributes(resource, kvs)
+			if err == nil {
+				return
+			}
+			if lastErr == nil {
+				lastErr = err
+			}
 		}
+	}
+	if lastErr != nil {
+		assert.NoError(t, lastErr)
+		return
 	}
 	t.Fatalf("no logs found for service %s", expectedService)
 }
@@ -2110,6 +2140,7 @@ func scanProfilesForAttributes(t *testing.T, ps *consumertest.ProfilesSink, expe
 	// Iterate over the received set of profiles starting from the most recent entries due to a bug in the processor:
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18892
 	// TODO: Remove the reverse loop once it's fixed. All the metrics should be properly annotated.
+	var lastErr error
 	for i := len(ps.AllProfiles()) - 1; i >= 0; i-- {
 		profiles := ps.AllProfiles()[i]
 		for i := 0; i < profiles.ResourceProfiles().Len(); i++ {
@@ -2119,9 +2150,18 @@ func scanProfilesForAttributes(t *testing.T, ps *consumertest.ProfilesSink, expe
 			if service.AsString() != expectedService {
 				continue
 			}
-			assert.NoError(t, resourceHasAttributes(resource, kvs))
-			return
+			err := resourceHasAttributes(resource, kvs)
+			if err == nil {
+				return
+			}
+			if lastErr == nil {
+				lastErr = err
+			}
 		}
+	}
+	if lastErr != nil {
+		assert.NoError(t, lastErr)
+		return
 	}
 	t.Fatalf("no profiles found for service %s", expectedService)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
  Ex. Adding a feature - Explain what this achieves.-->
  #### Description
  Some telemetry arrives before the Kubernetes informer cache contains the pod metadata. The test sink then has both early unenriched resources and later enriched resources for the same service. The scan helpers failed on the first matching resource instead of checking the remaining resources.

  The k8sattributesprocessor E2E tests intermittently failed on Kubernetes 1.34 and 1.35. The failures affected ClusterRBAC and ClusterRBACHeuristic checks for traces, metrics, and logs.

  The failed jobs: [Sep 6](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/34013555604/job/101434463421), [Aug 31](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/33368715136/job/99415455168), [Aug 26](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/32969533577/job/98183510472), [Aug 25](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/32814416144/job/97702350545), [Aug 24](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/32736441459/job/97465222730)

  ```mermaid
  flowchart LR
      A["Early telemetry<br/>Missing Kubernetes attributes"] --> C["Test sink"]
      B["Later telemetry<br/>Contains Kubernetes attributes"] --> C

      C --> D["Old: Check first matching resource"]
      D --> E["❌ Fail if it is incomplete"]

      C --> F["Fixed: Keep scanning matching resources"]
      F --> G["✅ Pass when a complete resource is found"]
  ```

  <!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
  #### Link to tracking issue
  Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50630

  Keep scanning resources for the service until one contains all expected Kubernetes attributes. If no resource is complete, report the error from the most recent matching resource. Apply this behavior to every signal scanner and add regression tests for incomplete resources.

  <!--Describe what testing was performed and which tests were added.-->
  #### Testing
  I reproduced the failure locally with TestE2E_ClusterRBAC on a Kind cluster running Kubernetes 1.35. With the original scan helpers, all 5 consecutive runs failed. After applying this fix, the same test passed all 5 consecutive runs.

  <!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
  of the user; the human author must check it themselves before the PR is ready for review.-->
  #### Authorship
  - [x] I, a human, wrote this pull request description myself.
  
  **Note**: I’m open to moving the new file into e2e_test.go if that better matches the maintainers’ preference.