### PR TITLE
[receiver/macosunifiedlogging] Stop re-emitting records in live mode

### DIFF
--- a/.chloggen/macosunifiedlogging-live-read-cursor.yaml
+++ b/.chloggen/macosunifiedlogging-live-read-cursor.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/macos_unified_logging
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Stop re-emitting already sent records in live mode by resuming each poll from the last emitted record
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50625]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Live mode previously recomputed `--start` as `now - max_log_age` on every poll and reset the poll interval
+  whenever the re-read window returned records, so each record was emitted up to `max_log_age / 100ms` times.
+  Text formats (`default`, `syslog`, `compact`) now also set the log record timestamp from the line.
+  The `json` format has no per-line timestamp and is not de-duplicated.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/macosunifiedloggingreceiver/README.md
+++ b/receiver/macosunifiedloggingreceiver/README.md
@@ -32,10 +32,10 @@ supports both live system logs and archived log files (`.logarchive`).
 |--------|------|---------|-------------|
 | `archive_path` | string | "" | Path or glob pattern to `.logarchive` directory(ies). If empty, reads live system logs. Supports glob patterns (e.g., `*.logarchive`, `**/logs/*.logarchive`) which will match multiple archives |
 | `predicate` | string | "" | Filter predicate (e.g., `"subsystem == 'com.apple.example'"`) |
-| `start_time` | string | "" | Start time in format "2006-01-02 15:04:05" |
+| `start_time` | string | "" | Start time in format "2006-01-02 15:04:05". In live mode it only applies to the first poll |
 | `end_time` | string | "" | End time in format "2006-01-02 15:04:05" (archive mode only) |
 | `max_poll_interval` | duration | 30s | Maximum interval between polling for new logs (live mode only). Uses exponential backoff starting at 100ms |
-| `max_log_age` | duration | 24h | Maximum age of logs to read on startup (live mode only) |
+| `max_log_age` | duration | 24h | Maximum age of logs to read on startup (live mode only). Later polls resume from the last emitted record |
 | `format` | string | "default" | Output format: `default`, `ndjson`, `json`, `syslog`, or `compact` |
 
 ### Exponential Backoff Behavior
@@ -44,7 +44,12 @@ In live mode, the receiver uses exponential backoff to optimize polling based on
 
 - **Active Logging**: When logs are actively being written, the receiver polls frequently (starting at 100ms) to minimize latency and catch logs written immediately after the previous poll
 - **Idle Period**: When no logs are found, the polling interval increases exponentially (doubling each time) up to `max_poll_interval`
-- **Automatic Reset**: As soon as logs are detected again, the interval resets to the minimum (100ms)
+- **Automatic Reset**: As soon as new logs are detected again, the interval resets to the minimum (100ms)
+
+Each poll resumes from the timestamp of the newest record emitted by the previous poll, so with the `ndjson`,
+`default`, `syslog` and `compact` formats a record is only emitted once. The `json` format prints each record
+across several lines, so no per-line timestamp is available and those records are still emitted on every poll
+that returns them; the same applies to any line without a parseable timestamp.
 
 This approach minimizes both latency during active logging and resource usage during idle periods.
 
@@ -153,7 +158,7 @@ When using JSON formats, each log line is captured as a complete JSON string in 
 
 When using plain text formats, each log line is captured as plain text in the body:
 
-- **Timestamp**: Set to observed time (when the log was received)
+- **Timestamp**: Parsed from the leading timestamp column of the line
 - **Severity**: Not set
 
 ## Example

--- a/receiver/macosunifiedloggingreceiver/receiver_darwin.go
+++ b/receiver/macosunifiedloggingreceiver/receiver_darwin.go
@@ -28,6 +28,10 @@ type unifiedLoggingReceiver struct {
 	logger   *zap.Logger
 	consumer consumer.Logs
 	cancel   context.CancelFunc
+
+	// lastTimestamp is the timestamp of the newest record emitted in live mode. It is the read
+	// cursor for the next poll and is only accessed from the readFromLive goroutine
+	lastTimestamp time.Time
 }
 
 func newUnifiedLoggingReceiver(
@@ -174,6 +178,10 @@ func (r *unifiedLoggingReceiver) runLogCommand(ctx context.Context, archivePath 
 
 	var processedCount int
 	isFirstLine := true
+	// In live mode, --start is second-granular, so a poll re-reads the records of the cursor's
+	// second. Skip everything up to and including the cursor since it was already emitted
+	live := archivePath == ""
+	since := r.lastTimestamp
 	// Skip the header line in text-based formats (default, syslog, compact)
 	isTextFormat := r.config.Format == "default" || r.config.Format == "syslog" || r.config.Format == "compact"
 	for scanner.Scan() {
@@ -201,13 +209,21 @@ func (r *unifiedLoggingReceiver) runLogCommand(ctx context.Context, archivePath 
 				continue
 			}
 
-			// Parse and send the log entry
-			if err := r.processLogLine(ctx, line); err != nil {
+			entry := r.parseLogLine(line)
+			if live && !entry.timestamp.IsZero() && !entry.timestamp.After(since) {
+				continue
+			}
+
+			// Send the log entry
+			if err := r.processLogLine(ctx, line, entry); err != nil {
 				r.logger.Warn("Failed to process log line",
 					zap.Error(err))
 				continue
 			}
 			processedCount++
+			if live && entry.timestamp.After(r.lastTimestamp) {
+				r.lastTimestamp = entry.timestamp
+			}
 		}
 	}
 
@@ -235,9 +251,13 @@ func (r *unifiedLoggingReceiver) buildLogCommandArgs(archivePath string) []strin
 	}
 
 	// Add start time
-	if r.config.StartTime != "" {
+	switch {
+	case archivePath == "" && !r.lastTimestamp.IsZero():
+		// For live mode, resume from the newest record emitted by the previous poll
+		args = append(args, "--start", r.lastTimestamp.Local().Format("2006-01-02 15:04:05"))
+	case r.config.StartTime != "":
 		args = append(args, "--start", r.config.StartTime)
-	} else if r.config.MaxLogAge > 0 && archivePath == "" {
+	case r.config.MaxLogAge > 0 && archivePath == "":
 		// For live mode, calculate start time from max_log_age
 		startTime := time.Now().Add(-r.config.MaxLogAge)
 		args = append(args, "--start", startTime.Format("2006-01-02 15:04:05"))
@@ -256,8 +276,48 @@ func (r *unifiedLoggingReceiver) buildLogCommandArgs(archivePath string) []strin
 	return args
 }
 
-// processLogLine processes a log line and sends it to the consumer
-func (r *unifiedLoggingReceiver) processLogLine(ctx context.Context, line []byte) error {
+// logEntry holds the fields parsed from a single log line
+type logEntry struct {
+	timestamp   time.Time
+	messageType string
+}
+
+// parseLogLine extracts the timestamp and message type from a log line
+// The timestamp comes from the "timestamp" field for JSON formats and from the leading
+// timestamp column for text formats; it is zero when the line does not carry one
+func (r *unifiedLoggingReceiver) parseLogLine(line []byte) logEntry {
+	var entry logEntry
+	if r.config.Format == "ndjson" || r.config.Format == "json" {
+		var fields map[string]any
+		if err := json.Unmarshal(line, &fields); err != nil {
+			return entry
+		}
+		if ts, ok := fields["timestamp"].(string); ok {
+			if t, err := time.Parse("2006-01-02 15:04:05.000000-0700", ts); err == nil {
+				entry.timestamp = t
+			}
+		}
+		if msgType, ok := fields["messageType"].(string); ok {
+			entry.messageType = msgType
+		}
+		return entry
+	}
+
+	// default and syslog lines start with "2006-01-02 15:04:05.000000-0700 ", compact lines with "2006-01-02 15:04:05.000 "
+	for _, layout := range []string{"2006-01-02 15:04:05.000000-0700", "2006-01-02 15:04:05.000"} {
+		if len(line) <= len(layout) || line[len(layout)] != ' ' {
+			continue
+		}
+		if t, err := time.ParseInLocation(layout, string(line[:len(layout)]), time.Local); err == nil {
+			entry.timestamp = t
+			break
+		}
+	}
+	return entry
+}
+
+// processLogLine sends a log line to the consumer using the fields parsed from it
+func (r *unifiedLoggingReceiver) processLogLine(ctx context.Context, line []byte, entry logEntry) error {
 	// Convert to OTel plog
 	logs := plog.NewLogs()
 	resourceLogs := logs.ResourceLogs().AppendEmpty()
@@ -268,23 +328,14 @@ func (r *unifiedLoggingReceiver) processLogLine(ctx context.Context, line []byte
 	logRecord.Body().SetStr(string(line))
 	logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 
-	// Parse timestamp and severity when using JSON formats
-	if r.config.Format == "ndjson" || r.config.Format == "json" {
-		var logEntry map[string]any
-		if err := json.Unmarshal(line, &logEntry); err == nil {
-			// Parse and set timestamp
-			if ts, ok := logEntry["timestamp"].(string); ok {
-				if t, err := time.Parse("2006-01-02 15:04:05.000000-0700", ts); err == nil {
-					logRecord.SetTimestamp(pcommon.NewTimestampFromTime(t))
-				}
-			}
+	if !entry.timestamp.IsZero() {
+		logRecord.SetTimestamp(pcommon.NewTimestampFromTime(entry.timestamp))
+	}
 
-			// Set severity from messageType
-			if msgType, ok := logEntry["messageType"].(string); ok {
-				logRecord.SetSeverityText(msgType)
-				logRecord.SetSeverityNumber(mapMessageTypeToSeverity(msgType))
-			}
-		}
+	// Set severity from messageType
+	if entry.messageType != "" {
+		logRecord.SetSeverityText(entry.messageType)
+		logRecord.SetSeverityNumber(mapMessageTypeToSeverity(entry.messageType))
 	}
 
 	// Send to consumer

--- a/receiver/macosunifiedloggingreceiver/receiver_test.go
+++ b/receiver/macosunifiedloggingreceiver/receiver_test.go
@@ -132,6 +132,26 @@ func TestBuildLogCommandArgs(t *testing.T) {
 		require.Contains(t, args, "--style")
 		require.Contains(t, args, "json")
 	})
+
+	t.Run("live mode resumes from last emitted record", func(t *testing.T) {
+		cursor := time.Date(2024, 1, 1, 12, 0, 3, 250000000, time.Local)
+		receiver := &unifiedLoggingReceiver{
+			config: &Config{
+				StartTime: "2024-01-01 00:00:00",
+				MaxLogAge: 24 * time.Hour,
+				Format:    "ndjson",
+			},
+			lastTimestamp: cursor,
+		}
+
+		args := receiver.buildLogCommandArgs("")
+		require.Equal(t, []string{"show", "--style", "ndjson", "--start", "2024-01-01 12:00:03"}, args)
+
+		// Archive mode does not use the live cursor
+		args = receiver.buildLogCommandArgs("./testdata/system_logs.logarchive")
+		require.Contains(t, args, "2024-01-01 00:00:00")
+		require.NotContains(t, args, "2024-01-01 12:00:03")
+	})
 }
 
 func TestProcessLogLine(t *testing.T) {
@@ -146,7 +166,7 @@ func TestProcessLogLine(t *testing.T) {
 		}
 
 		rawLine := []byte("2024-01-01 12:00:00.123456-0700  localhost kernel[0]: (AppleACPIPlatform) AppleACPICPU: ProcessorId=0 LocalApicId=0 Enabled")
-		err := receiver.processLogLine(t.Context(), rawLine)
+		err := receiver.processLogLine(t.Context(), rawLine, receiver.parseLogLine(rawLine))
 		require.NoError(t, err)
 
 		// Verify the log was consumed
@@ -158,9 +178,10 @@ func TestProcessLogLine(t *testing.T) {
 		logRecord := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 		require.Equal(t, string(rawLine), logRecord.Body().Str())
 
-		// In default format, timestamp should only be observed (not parsed)
+		// In default format, timestamp is parsed from the leading timestamp column
 		require.NotZero(t, logRecord.ObservedTimestamp())
-		require.Zero(t, logRecord.Timestamp())
+		expectedTime, _ := time.Parse("2006-01-02 15:04:05.000000-0700", "2024-01-01 12:00:00.123456-0700")
+		require.Equal(t, expectedTime.UnixNano(), logRecord.Timestamp().AsTime().UnixNano())
 
 		// In default format, severity should not be set
 		require.Empty(t, logRecord.SeverityText())
@@ -178,7 +199,7 @@ func TestProcessLogLine(t *testing.T) {
 		}
 
 		jsonLine := []byte(`{"timestamp":"2024-01-01 12:00:00.123456-0700","eventMessage":"Test message","messageType":"Error","subsystem":"com.test"}`)
-		err := receiver.processLogLine(t.Context(), jsonLine)
+		err := receiver.processLogLine(t.Context(), jsonLine, receiver.parseLogLine(jsonLine))
 		require.NoError(t, err)
 
 		// Verify the log was consumed
@@ -211,7 +232,7 @@ func TestProcessLogLine(t *testing.T) {
 		}
 
 		invalidJSON := []byte(`{invalid json}`)
-		err := receiver.processLogLine(t.Context(), invalidJSON)
+		err := receiver.processLogLine(t.Context(), invalidJSON, receiver.parseLogLine(invalidJSON))
 		require.NoError(t, err)
 
 		// Verify the log was still consumed (with just the body)
@@ -239,7 +260,7 @@ func TestProcessLogLine(t *testing.T) {
 		}
 
 		jsonLine := []byte(`{"timestamp":"2024-01-01 12:00:00.123456-0700","eventMessage":"Test message","messageType":"Debug","subsystem":"com.test"}`)
-		err := receiver.processLogLine(t.Context(), jsonLine)
+		err := receiver.processLogLine(t.Context(), jsonLine, receiver.parseLogLine(jsonLine))
 		require.NoError(t, err)
 
 		// Verify the log was consumed
@@ -270,7 +291,7 @@ func TestProcessLogLine(t *testing.T) {
 		}
 
 		jsonLine := []byte(`{"eventMessage":"Test message","subsystem":"com.test"}`)
-		err := receiver.processLogLine(t.Context(), jsonLine)
+		err := receiver.processLogLine(t.Context(), jsonLine, receiver.parseLogLine(jsonLine))
 		require.NoError(t, err)
 
 		// Verify the log was consumed
@@ -623,5 +644,114 @@ func TestReadFromLiveUsesBackoffLoop(t *testing.T) {
 	require.GreaterOrEqual(t, len(calls), 2, "expected initial run plus at least one ticker iteration")
 
 	allLogs := sink.AllLogs()
-	require.GreaterOrEqual(t, len(allLogs), 2)
+	require.Len(t, allLogs, 1, "the same record must not be emitted again by later polls")
+}
+
+func TestRunLogCommandLiveModeDoesNotReemitRecords(t *testing.T) {
+	setupFakeLogBinary(t)
+	// The fake binary returns the same window on every poll, like `log show --start` does
+	// when the window has not moved past these records yet
+	outputPath := writeFakeLogOutput(t,
+		`{"timestamp":"2024-01-01 12:00:00.000000-0700","eventMessage":"first","messageType":"Info"}`,
+		`{"timestamp":"2024-01-01 12:00:00.500000-0700","eventMessage":"second","messageType":"Info"}`,
+	)
+	t.Setenv("FAKE_LOG_OUTPUT_PATH", outputPath)
+
+	sink := &consumertest.LogsSink{}
+	receiver := newUnifiedLoggingReceiver(&Config{Format: "ndjson", MaxLogAge: 24 * time.Hour}, zap.NewNop(), sink)
+
+	count, err := receiver.runLogCommand(t.Context(), "")
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	count, err = receiver.runLogCommand(t.Context(), "")
+	require.NoError(t, err)
+	require.Equal(t, 0, count, "second poll must not count records that were already emitted")
+	require.Equal(t, 2, sink.LogRecordCount(), "records must be emitted exactly once across polls")
+}
+
+func TestRunLogCommandLiveModeStartsFromLastEmittedRecord(t *testing.T) {
+	setupFakeLogBinary(t)
+	outputPath := writeFakeLogOutput(t,
+		`{"timestamp":"2024-01-01 12:00:00.000000-0700","eventMessage":"first","messageType":"Info"}`,
+		`{"timestamp":"2024-01-01 12:00:03.250000-0700","eventMessage":"second","messageType":"Info"}`,
+	)
+	t.Setenv("FAKE_LOG_OUTPUT_PATH", outputPath)
+	callsFile := filepath.Join(t.TempDir(), "calls.txt")
+	t.Setenv("FAKE_LOG_CALLS_FILE", callsFile)
+
+	receiver := newUnifiedLoggingReceiver(&Config{Format: "ndjson", MaxLogAge: 24 * time.Hour}, zap.NewNop(), &consumertest.LogsSink{})
+
+	_, err := receiver.runLogCommand(t.Context(), "")
+	require.NoError(t, err)
+	_, err = receiver.runLogCommand(t.Context(), "")
+	require.NoError(t, err)
+
+	calls := readRecordedCalls(t, callsFile)
+	require.Len(t, calls, 2)
+	last, err := time.Parse("2006-01-02 15:04:05.000000-0700", "2024-01-01 12:00:03.250000-0700")
+	require.NoError(t, err)
+	require.Contains(t, calls[1], "--start "+last.Local().Format("2006-01-02 15:04:05"),
+		"second poll must start from the last emitted record, not from now-max_log_age")
+}
+
+func TestParseLogLineTimestamp(t *testing.T) {
+	local := func(year int, month time.Month, day, hour, minute, sec, nsec int) time.Time {
+		return time.Date(year, month, day, hour, minute, sec, nsec, time.Local)
+	}
+	fixed := func(value string) time.Time {
+		ts, err := time.Parse("2006-01-02 15:04:05.000000-0700", value)
+		require.NoError(t, err)
+		return ts
+	}
+	tests := []struct {
+		name     string
+		format   string
+		line     string
+		expected time.Time
+	}{
+		{
+			name:     "ndjson",
+			format:   "ndjson",
+			line:     `{"timestamp":"2024-01-01 12:00:00.123456-0700","eventMessage":"m","messageType":"Info"}`,
+			expected: fixed("2024-01-01 12:00:00.123456-0700"),
+		},
+		{
+			name:     "ndjson without timestamp",
+			format:   "ndjson",
+			line:     `{"eventMessage":"m"}`,
+			expected: time.Time{},
+		},
+		{
+			name:     "default",
+			format:   "default",
+			line:     "2024-01-01 12:00:00.123456-0700 0xc31f3    Activity    0x1f96ea             421    0    runningboardd: message",
+			expected: fixed("2024-01-01 12:00:00.123456-0700"),
+		},
+		{
+			name:     "syslog",
+			format:   "syslog",
+			line:     "2024-01-01 12:00:00.123456-0700  localhost app[123]: message",
+			expected: fixed("2024-01-01 12:00:00.123456-0700"),
+		},
+		{
+			name:     "compact",
+			format:   "compact",
+			line:     "2024-01-01 12:00:00.123 Df app[123:1a2b] [subsystem:category] message",
+			expected: local(2024, time.January, 1, 12, 0, 0, 123000000),
+		},
+		{
+			name:     "text without timestamp",
+			format:   "default",
+			line:     "Timestamp               Thread     Type        Activity             PID",
+			expected: time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receiver := &unifiedLoggingReceiver{config: &Config{Format: tt.format}}
+			require.WithinDuration(t, tt.expected, receiver.parseLogLine([]byte(tt.line)).timestamp, 0)
+		})
+	}
 }


### PR DESCRIPTION
#### Description

In live mode the receiver emits the same record on every poll until the record ages out of the `max_log_age` window. With `max_log_age: 1m` that is a duplication factor of roughly 600x (one poll every 100 ms for 60 s); with the default 24h it is far larger. Because the re-read window always returns records, the exponential backoff never engages and the receiver stays at the 100 ms minimum interval.

**Root cause** (`receiver/macosunifiedloggingreceiver/receiver_darwin.go` at 9e2ba3f1f5c):

- `buildLogCommandArgs`, lines 240-243: `--start` is recomputed as `time.Now().Add(-MaxLogAge)` on every poll, so each `log show` re-reads the whole window. With `start_time` configured, every poll re-reads from that fixed point instead.
- `readFromLive`, lines 125-127: the interval resets to `minInterval` whenever `count > 0`, and `runLogCommand` counts re-read records, so the backoff never grows.

**Fix:**

- Track the timestamp of the newest record emitted in live mode on the receiver (`lastTimestamp`) and use it as the next `--start`. `max_log_age` / `start_time` only bound the first poll, matching their documented "on startup" meaning.
- `--start` is second-granular, so the next poll re-reads the records of the cursor's second. Records whose timestamp is not after the cursor are skipped and not counted, which also lets the existing backoff engage naturally when nothing new arrived.
- Split the JSON parsing out of `processLogLine` into `parseLogLine` so the timestamp is known before the record is emitted without parsing twice. For text formats (`default`, `syslog`, `compact`) the timestamp is taken from the leading timestamp column; as a consequence those records now carry a `Timestamp` instead of only `ObservedTimestamp`.
- Archive mode is unchanged (no cursor, no dedupe).

**Trade-offs for reviewers:**

- A record that lands in the log store late, with a timestamp at or before the cursor, is now dropped instead of being emitted (the previous behaviour never dropped such records, it duplicated everything instead). On this Mac `log show` ndjson output was sorted in all 7857 sampled records, and two polls 4 s apart over the same `--start` produced 3132 new records with 0 late arrivals, so this was not observed in practice, but it is a behaviour change worth stating.
- The cursor is not clamped to `now - max_log_age`; after a long idle or blocked period the next poll reads everything since the last emitted record rather than dropping the gap.
- The `json` format (`log show --style json`) is a pretty-printed array with one field per line, so `parseLogLine` never finds a timestamp for it and those records are still re-emitted every poll, as before. `ndjson` and the text formats are de-duplicated. The README says so.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50625

#### Testing

New tests (darwin build tag, run on macOS with Go 1.26):

- `TestRunLogCommandLiveModeDoesNotReemitRecords`: two live polls over the same fake `log` output emit each record once and the second poll counts 0.
- `TestRunLogCommandLiveModeStartsFromLastEmittedRecord`: the second poll's `--start` is the last emitted record's second, not `now - max_log_age`.
- `TestBuildLogCommandArgs/live mode resumes from last emitted record`: cursor takes precedence over `start_time`/`max_log_age` in live mode and is ignored in archive mode.
- `TestParseLogLineTimestamp`: table test for ndjson, default, syslog, compact and lines without a timestamp.
- `TestReadFromLiveUsesBackoffLoop` now asserts the repeated record is emitted once; `TestProcessLogLine` default-format case asserts the parsed timestamp.

Before the fix:

```
--- FAIL: TestRunLogCommandLiveModeDoesNotReemitRecords (0.20s)
    receiver_test.go:648:
        	Error:      	Not equal:
        	            	expected: 0
        	            	actual  : 2
        	Messages:   	second poll must not count records that were already emitted
--- FAIL: TestRunLogCommandLiveModeStartsFromLastEmittedRecord (0.18s)
    receiver_test.go:673:
        	Error:      	"show --style ndjson --start 2026-09-06 19:31:38" does not contain "--start 2024-01-01 11:00:03"
        	Messages:   	second poll must start from the last emitted record, not from now-max_log_age
FAIL
```

After the fix (`go test -race -count=2 ./...`):

```
--- PASS: TestBuildLogCommandArgs (0.00s)
--- PASS: TestProcessLogLine (0.00s)
--- PASS: TestReadFromLiveUsesBackoffLoop (0.26s)
--- PASS: TestRunLogCommandLiveModeDoesNotReemitRecords (0.19s)
--- PASS: TestRunLogCommandLiveModeStartsFromLastEmittedRecord (0.18s)
--- PASS: TestParseLogLineTimestamp (0.00s)
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver	2.847s
```

Disabling the cursor (`live := false` and the cursor case removed from `buildLogCommandArgs`) makes `TestBuildLogCommandArgs`, `TestReadFromLiveUsesBackoffLoop`, `TestRunLogCommandLiveModeDoesNotReemitRecords` and `TestRunLogCommandLiveModeStartsFromLastEmittedRecord` fail, so the tests exercise the change.

Also verified against the real `/usr/bin/log` on macOS: `--start "YYYY-MM-DD HH:MM:SS"` is inclusive from the start of that second, ndjson `timestamp` values are microsecond precision with a zone offset, output is sorted by timestamp, and the text styles begin with the timestamp column in the layouts the parser expects. `golangci-lint`, `go vet` and `chloggen validate` pass.

#### Documentation

- README: `start_time` and `max_log_age` notes, the live-mode cursor paragraph (including which formats are de-duplicated), and the text-format `Timestamp`.
- Changelog: `.chloggen/macosunifiedlogging-live-read-cursor.yaml` (`bug_fix`, `receiver/macos_unified_logging`, issue 50625).

#### Authorship

- [x] I, a human, wrote this pull request description myself.

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
