### PR TITLE
[processor/resourcedetection] Honor the configured timeout in the gcp detector

### DIFF
--- a/.chloggen/resourcedetection-gcp-timeout.yaml
+++ b/.chloggen/resourcedetection-gcp-timeout.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resource_detection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Honor the configured `timeout` in the `gcp` detector when the metadata server is unreachable.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50754]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `gcp` detector did not honor the configured `timeout`. It now checks the metadata
+  server with a context that carries the deadline.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -46,6 +46,7 @@ func NewDetector(set processor.Settings, dcfg internal.DetectorConfig, failOnMis
 	return &detector{
 		logger:                set.Logger,
 		detector:              gcp.NewDetector(),
+		onGCE:                 metadata.OnGCEWithContext,
 		rb:                    localMetadata.NewResourceBuilder(cfg.ResourceAttributes),
 		labelKeyRegexes:       labelKeyRegexes,
 		gceClientBuilder:      &instancesRESTBuilder{},
@@ -57,6 +58,7 @@ func NewDetector(set processor.Settings, dcfg internal.DetectorConfig, failOnMis
 type detector struct {
 	logger                *zap.Logger
 	detector              gcpDetector
+	onGCE                 func(context.Context) bool
 	rb                    *localMetadata.ResourceBuilder
 	labelKeyRegexes       []*regexp.Regexp
 	gceClientBuilder      instancesBuilder
@@ -65,7 +67,8 @@ type detector struct {
 }
 
 func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schemaURL string, err error) {
-	if d.detector.CloudPlatform() == gcp.BareMetalSolution {
+	// BMS has no metadata server, so it must be detected before the OnGCE probe.
+	if d.onBareMetalSolution() {
 		d.rb.SetCloudProvider(conventions.CloudProviderGCP.Value.AsString())
 		errs := d.rb.SetFromCallable(d.rb.SetCloudAccountID, d.detector.BareMetalSolutionProjectID)
 
@@ -80,7 +83,8 @@ func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		return d.rb.Emit(), conventions.SchemaURL, nil
 	}
 
-	if !metadata.OnGCE() {
+	// Pass the context to the metadata server probe to honor the configured timeout.
+	if !d.onGCE(ctx) {
 		return pcommon.NewResource(), "", nil
 	}
 
@@ -214,6 +218,14 @@ func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		return pcommon.NewResource(), "", errs
 	}
 	return d.rb.Emit(), conventions.SchemaURL, nil
+}
+
+func (d *detector) onBareMetalSolution() bool {
+	projectID, projectErr := d.detector.BareMetalSolutionProjectID()
+	region, regionErr := d.detector.BareMetalSolutionCloudRegion()
+	instanceID, instanceErr := d.detector.BareMetalSolutionInstanceID()
+	return projectErr == nil && regionErr == nil && instanceErr == nil &&
+		projectID != "" && region != "" && instanceID != ""
 }
 
 type instancesAPI interface {

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
@@ -51,9 +51,6 @@ func mustRe(p string) *regexp.Regexp {
 }
 
 func TestDetect(t *testing.T) {
-	// Set this before all tests to ensure metadata.onGCE() returns true
-	t.Setenv("GCE_METADATA_HOST", "169.254.169.254")
-
 	for _, tc := range []struct {
 		desc             string
 		detector         internal.Detector
@@ -398,6 +395,35 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
+			desc: "Bare Metal Solution with unknown cloud platform",
+			detector: newTestDetector(&fakeGCPDetector{
+				projectID:                       "my-project",
+				cloudPlatform:                   gcp.UnknownPlatform,
+				gcpBareMetalSolutionCloudRegion: "us-central1",
+				gcpBareMetalSolutionInstanceID:  "1472385723456792345",
+				gcpBareMetalSolutionProjectID:   "my-project",
+			}),
+			expectedResource: map[string]any{
+				"cloud.provider":   "gcp",
+				"cloud.account.id": "my-project",
+				"cloud.platform":   "gcp_bare_metal_solution",
+				"cloud.region":     "us-central1",
+				"host.name":        "1472385723456792345",
+			},
+		},
+		{
+			desc: "Bare Metal Solution with incomplete environment",
+			detector: newTestDetector(&fakeGCPDetector{
+				projectID:                     "my-project",
+				cloudPlatform:                 gcp.UnknownPlatform,
+				gcpBareMetalSolutionProjectID: "my-project",
+			}),
+			expectedResource: map[string]any{
+				"cloud.provider":   "gcp",
+				"cloud.account.id": "my-project",
+			},
+		},
+		{
 			desc: "Unknown Platform",
 			detector: newTestDetector(&fakeGCPDetector{
 				projectID:     "my-project",
@@ -433,6 +459,26 @@ func TestDetect(t *testing.T) {
 	}
 }
 
+func TestDetectSkipsPlatformWhenContextIsDone(t *testing.T) {
+	fake := &fakeGCPDetector{
+		projectID:     "my-project",
+		cloudPlatform: gcp.GCE,
+	}
+	d := newTestDetector(fake)
+	d.onGCE = func(ctx context.Context) bool {
+		return ctx.Err() == nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	res, schema, err := d.Detect(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, schema)
+	assert.Equal(t, 0, res.Attributes().Len())
+	assert.False(t, fake.cloudPlatformCalled)
+}
+
 func TestDetectFailOnMissingMetadata(t *testing.T) {
 	d := newTestDetector(&fakeGCPDetector{
 		err: errors.New("failed to get metadata"),
@@ -454,6 +500,7 @@ func newTestDetector(gcpDetector *fakeGCPDetector, opts ...func(*localMetadata.R
 	return &detector{
 		logger:          zap.NewNop(),
 		detector:        gcpDetector,
+		onGCE:           func(context.Context) bool { return true },
 		rb:              localMetadata.NewResourceBuilder(cfg),
 		hostTypeEnabled: cfg.HostType.Enabled,
 	}
@@ -464,6 +511,7 @@ type fakeGCPDetector struct {
 	err                             error
 	projectID                       string
 	cloudPlatform                   gcp.Platform
+	cloudPlatformCalled             bool
 	gkeAvailabilityZone             string
 	gkeRegion                       string
 	gkeClusterName                  string
@@ -561,9 +609,6 @@ func TestGCELabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Force metadata.OnGCE() to return true without a real metadata server.
-			t.Setenv("GCE_METADATA_HOST", "169.254.169.254")
-
 			d := newTestDetector(&fakeGCPDetector{
 				projectID:           "test-proj",
 				cloudPlatform:       gcp.GCE,
@@ -609,6 +654,7 @@ func (f *fakeGCPDetector) ProjectID() (string, error) {
 }
 
 func (f *fakeGCPDetector) CloudPlatform() gcp.Platform {
+	f.cloudPlatformCalled = true
 	return f.cloudPlatform
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `gcp` detector did not honor the configured `timeout`. If the host cannot reach the metadata server, each attempt took much longer than the timeout. On Kubernetes the startup probe killed the container before detection finished.

The detector now checks the metadata server with the timeout and it stops there if the server does not answer.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #50754

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Three unit tests. Two of them fail without the fix:

- `TestDetect/Bare Metal Solution with unknown cloud platform`: BMS is still detected when the platform check finds nothing.
-  `TestDetect/Bare Metal Solution with incomplete environment`: a host with only some of the BMS variables set is not detected as BMS.
- `TestDetectSkipsPlatformWhenContextIsDone`: detection stops and returns no attributes after the timeout ends.

<!--Describe the documentation added.-->
#### Documentation

N/A

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.
