### PR TITLE
Include token in checkout step

### DIFF
--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ steps.otelbot-token.outputs.token }}
           # Keep token so the `go mod tidy` step can push.
           persist-credentials: true # zizmor: ignore[artipacked]
       - uses: ./.github/actions/setup-go-tools


### PR DESCRIPTION
#### Description

Recently it was added that an app token is generated for the tidy workflow however it was missed that the checkout should use this token. See example in https://github.com/open-telemetry/opentelemetry-lambda/blob/main/.github/workflows/renovate-go.yml

it was noticed as renovate pr’s which were tidied still needed approval to run. This should eliminate the need to be merging main into renovate pr’s.


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
