### PR TITLE
[receiver/awsfirehose] Fix cwlogs double-decompressing gzipped records

### DIFF
--- a/.chloggen/fix-awsfirehose-cwlogs-double-gunzip.yaml
+++ b/.chloggen/fix-awsfirehose-cwlogs-double-gunzip.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/awsfirehose
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the built-in `cwlogs` encoding double-decompressing gzipped CloudWatch Logs records
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50783]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Since v0.152.0 the receiver gunzips each record before handing it to the unmarshaler, but the
+  `cwlogs` unmarshaler still decompressed it a second time. CloudWatch Logs subscription filters
+  deliver exactly one gzip layer, so every record failed with `gzip: invalid header` and was
+  rejected with HTTP 400. The `cwlogs` unmarshaler now expects an already-decompressed record.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awsfirehosereceiver/go.mod
+++ b/receiver/awsfirehosereceiver/go.mod
@@ -4,7 +4,6 @@ go 1.26.0
 
 require (
 	github.com/json-iterator/go v1.1.12
-	github.com/klauspost/compress v1.20.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension v0.160.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.160.0
 	github.com/stretchr/testify v1.12.1
@@ -43,6 +42,7 @@ require (
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
+	github.com/klauspost/compress v1.20.0 // indirect
 	github.com/knadh/koanf/maps v0.1.3 // indirect
 	github.com/knadh/koanf/providers/confmap v1.0.1 // indirect
 	github.com/knadh/koanf/v2 v2.3.6 // indirect

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler.go
@@ -4,15 +4,11 @@
 package cwlog // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog"
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"sync"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/klauspost/compress/gzip"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -40,7 +36,6 @@ var (
 type Unmarshaler struct {
 	logger    *zap.Logger
 	buildInfo component.BuildInfo
-	gzipPool  sync.Pool
 }
 
 var _ plog.Unmarshaler = (*Unmarshaler)(nil)
@@ -52,28 +47,14 @@ func NewUnmarshaler(logger *zap.Logger, buildInfo component.BuildInfo) *Unmarsha
 
 // UnmarshalLogs deserializes the given record as CloudWatch Logs events
 // into a plog.Logs, grouping logs by owner (account ID), log group, and
-// log stream. Logs are assumed to be gzip-compressed as specified at
-// https://docs.aws.amazon.com/firehose/latest/dev/writing-with-cloudwatch-logs.html.
-func (u *Unmarshaler) UnmarshalLogs(compressedRecord []byte) (plog.Logs, error) {
-	var err error
-	r, ok := u.gzipPool.Get().(*gzip.Reader)
-	if !ok {
-		r, err = gzip.NewReader(bytes.NewReader(compressedRecord))
-	} else {
-		err = r.Reset(bytes.NewReader(compressedRecord))
-	}
-	if err != nil {
-		return plog.Logs{}, fmt.Errorf("failed to decompress record: %w", err)
-	}
-	defer u.gzipPool.Put(r)
-
-	data, err := io.ReadAll(r)
-	if err != nil {
-		u.logger.Error("Error reading log data", zap.Error(err))
-		return plog.Logs{}, fmt.Errorf("error reading log data: %w", err)
-	}
-
-	cwLog, control, err := parseLog(data)
+// log stream.
+//
+// The record is expected to be decompressed already: CloudWatch Logs
+// subscription records arrive gzip-compressed as described at
+// https://docs.aws.amazon.com/firehose/latest/dev/writing-with-cloudwatch-logs.html,
+// and the receiver decompresses them before unmarshaling.
+func (u *Unmarshaler) UnmarshalLogs(record []byte) (plog.Logs, error) {
+	cwLog, control, err := parseLog(record)
 	if err != nil {
 		u.logger.Error("Error unmarshalling log message", zap.Error(err))
 		return plog.Logs{}, fmt.Errorf("%w: %w", errInvalidRecords, err)

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler_test.go
@@ -5,7 +5,6 @@ package cwlog
 
 import (
 	"bytes"
-	"compress/gzip"
 	"os"
 	"path/filepath"
 	"testing"
@@ -58,10 +57,7 @@ func TestUnmarshal(t *testing.T) {
 			record, err := os.ReadFile(filepath.Join(".", "testdata", testCase.filename))
 			require.NoError(t, err)
 
-			compressedRecord, err := gzipData(record)
-			require.NoError(t, err)
-
-			got, err := unmarshaler.UnmarshalLogs(compressedRecord)
+			got, err := unmarshaler.UnmarshalLogs(record)
 			if testCase.wantErr != nil {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, testCase.wantErr.Error())
@@ -98,10 +94,7 @@ func TestLogTimestamp(t *testing.T) {
 	record, err := os.ReadFile(filepath.Join(".", "testdata", "single_record"))
 	require.NoError(t, err)
 
-	compressedRecord, err := gzipData(record)
-	require.NoError(t, err)
-
-	got, err := unmarshaler.UnmarshalLogs(compressedRecord)
+	got, err := unmarshaler.UnmarshalLogs(record)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, 1, got.ResourceLogs().Len())
@@ -125,24 +118,8 @@ func TestUnmarshalLargePayload(t *testing.T) {
 	}
 	largePayload.WriteString(`"}]}`)
 
-	compressedRecord, err := gzipData(largePayload.Bytes())
+	_, err := unmarshaler.UnmarshalLogs(largePayload.Bytes())
 	require.NoError(t, err)
-
-	_, err = unmarshaler.UnmarshalLogs(compressedRecord)
-	require.NoError(t, err)
-}
-
-func gzipData(data []byte) ([]byte, error) {
-	var b bytes.Buffer
-	w := gzip.NewWriter(&b)
-
-	if _, err := w.Write(data); err != nil {
-		return nil, err
-	}
-	if err := w.Close(); err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
 }
 
 func assertString(t *testing.T, m pcommon.Map, key, expected string) {

--- a/receiver/awsfirehosereceiver/logs_receiver_test.go
+++ b/receiver/awsfirehosereceiver/logs_receiver_test.go
@@ -5,13 +5,18 @@ package awsfirehosereceiver
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -228,4 +233,43 @@ type unmarshalLogsFunc func([]byte) (plog.Logs, error)
 
 func (f unmarshalLogsFunc) UnmarshalLogs(data []byte) (plog.Logs, error) {
 	return f(data)
+}
+
+// TestLogsConsumer_CWLogsSingleGzipLayer verifies that a CloudWatch Logs
+// subscription record delivered by Firehose is ingested.
+//
+// CloudWatch Logs subscription filters deliver records as
+// base64(gzip(<subscription JSON>)) -- exactly one gzip layer. The receiver
+// gunzips the record after base64-decoding it, so the unmarshaler must accept
+// the already-decompressed payload.
+func TestLogsConsumer_CWLogsSingleGzipLayer(t *testing.T) {
+	subscriptionRecord, err := os.ReadFile(
+		filepath.Join("internal", "unmarshaler", "cwlog", "testdata", "single_record"),
+	)
+	require.NoError(t, err)
+
+	cfg := createDefaultConfig().(*Config)
+	sink := new(consumertest.LogsSink)
+	r, err := newLogsReceiver(cfg, receivertest.NewNopSettings(metadata.Type), sink)
+	require.NoError(t, err)
+	require.NoError(t, r.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, r.Shutdown(t.Context()))
+	})
+
+	body, err := json.Marshal(testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{
+		testFirehoseRecordFromBytes(newGzipRecord(t, subscriptionRecord)),
+	}))
+	require.NoError(t, err)
+
+	got := httptest.NewRecorder()
+	r.(*firehoseReceiver).ServeHTTP(got, newTestRequest(body))
+
+	var gotResponse firehoseResponse
+	require.NoError(t, json.Unmarshal(got.Body.Bytes(), &gotResponse))
+	require.Empty(t, gotResponse.ErrorMessage)
+	require.Equal(t, http.StatusOK, got.Code)
+
+	require.Len(t, sink.AllLogs(), 1)
+	require.Equal(t, 2, sink.AllLogs()[0].LogRecordCount())
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The default `cwlogs` encoding fails to ingest CloudWatch Logs records. Requests return HTTP 400 with this error:

```text
failed to decompress record: gzip: invalid header
```

CloudWatch Logs subscription filters deliver records as `base64(gzip(json))`. The AWS Firehose receiver base64-decodes each record and conditionally decompresses gzip data before passing it to the configured unmarshaler. The legacy `cwlogs` unmarshaler then tries to decompress the record again. Because it receives plain JSON rather than gzip data, this second attempt fails with `gzip: invalid header`.

This PR removes gzip decompression from `cwlog.UnmarshalLogs`. Callers must now pass decompressed records, matching the contract documented by the successor `aws_logs_encoding` extension.

The gzip reader pool and its related imports are no longer needed, so they have been removed.

Receiver-level gzip decompression was added in #47848, introducing this regression in v0.152.0. Every release since then has been affected.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #50783

<!--Describe what testing was performed and which tests were added.-->
#### Testing

`TestLogsConsumer_CWLogsSingleGzipLayer` covers the full path through the receiver, `logsConsumer`, and the `cwlogs` unmarshaler. It sends a `base64(gzip(<CloudWatch Logs subscription JSON>))` payload with one gzip layer, then checks for an HTTP 200 response and two log events at the downstream consumer.

Before this fix, the test failed with the same `gzip: invalid header` error reported in the issue. It now passes.

The existing `cwlog` unmarshaler tests now pass decompressed records as required by the updated contract.

The following checks pass:

```text
go test ./receiver/awsfirehosereceiver/...
make lint
make chlog-validate
```

<!--Describe the documentation added.-->
#### Documentation

This fix does not change configuration or emitted telemetry, so no user-facing documentation changes are needed. The `UnmarshalLogs` documentation comment now says that the record must already be decompressed.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
