### PR TITLE
[receiver/awsxray] fix panic when segment cause exception id is missing

### DIFF
--- a/.chloggen/awsxrayreceiver-nil-exception-id.yaml
+++ b/.chloggen/awsxrayreceiver-nil-exception-id.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awsxray
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix panic when a segment's `cause.exceptions[].id` field is missing, since it is not guaranteed to be present.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37414]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awsxrayreceiver/internal/translator/cause.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause.go
@@ -57,9 +57,7 @@ func addCause(seg *awsxray.Segment, span ptrace.Span) {
 			attrs := evt.Attributes()
 			attrs.EnsureCapacity(8)
 
-			// ID is documented as required by X-Ray, but AWS's own documentation
-			// (https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-errors)
-			// shows it as optional, and some agents omit it, so fall back gracefully instead of panicking.
+			// The exception id is optional in X-Ray segment documents, so it may be nil.
 			addString(excp.ID, awsxray.AWSXrayExceptionIDAttribute, attrs)
 			addString(excp.Message, string(conventions.ExceptionMessageKey), attrs)
 			addString(excp.Type, string(conventions.ExceptionTypeKey), attrs)

--- a/receiver/awsxrayreceiver/internal/translator/cause.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause.go
@@ -57,8 +57,10 @@ func addCause(seg *awsxray.Segment, span ptrace.Span) {
 			attrs := evt.Attributes()
 			attrs.EnsureCapacity(8)
 
-			// ID is a required field
-			attrs.PutStr(awsxray.AWSXrayExceptionIDAttribute, *excp.ID)
+			// ID is documented as required by X-Ray, but AWS's own documentation
+			// (https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-errors)
+			// shows it as optional, and some agents omit it, so fall back gracefully instead of panicking.
+			addString(excp.ID, awsxray.AWSXrayExceptionIDAttribute, attrs)
 			addString(excp.Message, string(conventions.ExceptionMessageKey), attrs)
 			addString(excp.Type, string(conventions.ExceptionTypeKey), attrs)
 			addBool(excp.Remote, awsxray.AWSXrayExceptionRemoteAttribute, attrs)

--- a/receiver/awsxrayreceiver/internal/translator/cause_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause_test.go
@@ -113,8 +113,6 @@ func TestConvertStackFramesToStackTraceStrNoErrorMessage(t *testing.T) {
 }
 
 func TestAddCauseExceptionWithoutID(t *testing.T) {
-	// Per https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-errors
-	// the exception `id` is not guaranteed to be present, so addCause must not panic when it's missing.
 	seg := &awsxray.Segment{
 		Cause: &awsxray.CauseData{
 			Type: awsxray.CauseTypeObject,

--- a/receiver/awsxrayreceiver/internal/translator/cause_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -109,4 +110,34 @@ func TestConvertStackFramesToStackTraceStrNoErrorMessage(t *testing.T) {
 	}
 	actual := convertStackFramesToStackTraceStr(excp)
 	assert.Equal(t, ": \n\tat label0(path0: 10)\n\tat (path1: 11)\n", actual)
+}
+
+func TestAddCauseExceptionWithoutID(t *testing.T) {
+	// Per https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-errors
+	// the exception `id` is not guaranteed to be present, so addCause must not panic when it's missing.
+	seg := &awsxray.Segment{
+		Cause: &awsxray.CauseData{
+			Type: awsxray.CauseTypeObject,
+			CauseObject: awsxray.CauseObject{
+				Exceptions: []awsxray.Exception{
+					{
+						Message: awsxray.String("exceptionMessage"),
+						Type:    awsxray.String("exceptionType"),
+					},
+				},
+			},
+		},
+	}
+	span := ptrace.NewSpan()
+
+	assert.NotPanics(t, func() { addCause(seg, span) })
+
+	assert.Equal(t, 1, span.Events().Len())
+	attrs := span.Events().At(0).Attributes()
+	_, ok := attrs.Get(awsxray.AWSXrayExceptionIDAttribute)
+	assert.False(t, ok, "exception.id attribute should not be set when the id is missing")
+
+	msg, ok := attrs.Get("exception.message")
+	assert.True(t, ok)
+	assert.Equal(t, "exceptionMessage", msg.Str())
 }


### PR DESCRIPTION
#### Description

`cause.exceptions[].id` is optional in X-Ray segment documents, but `addCause` assumed it was always set. When an agent omitted the field, segment translation panicked with a nil pointer dereference

Fixes #37414 

#### Testing

added `TestAddCauseExceptionWithoutID` to verify that `addCause` no longer panics when the exception id field is missing

#### Documentation


#### Authorship

- [x] I, a human, wrote this pull request description myself.

