### PR TITLE
[chore][receiver/postgresql] Trim changelog subtext for #50669

### DIFF
--- a/.chloggen/50670-postgresql-explain-extract-syntax-error.yaml
+++ b/.chloggen/50670-postgresql-explain-extract-syntax-error.yaml
@@ -15,20 +15,7 @@ issues: [50670]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: |
-  `pg_stat_statements` produces its normalized query text by substituting `$N` over the byte
-  ranges of the constants it recorded, without re-parsing the result, so it can place a parameter
-  where PostgreSQL does not accept one. `EXTRACT(YEAR FROM col)` becomes `EXTRACT($1 FROM col)`
-  and `interval '1 day'` becomes `interval $1`, both of which fail to `PREPARE` with a syntax
-  error. Affected queries were emitted with an empty `postgresql.query_plan`, and because the
-  empty result was cached the query stayed unexplainable for the lifetime of the cache entry.
-  These forms are now rewritten to `pg_catalog.extract($1, col)` and `CAST($1 AS interval)` before
-  the plan is requested. The typed-literal rewrite covers the built-in type names, including
-  multi-word spellings such as `timestamp with time zone` and interval field qualifiers such as
-  `interval $1 day`. Both rewrites are skipped inside string literals, quoted identifiers,
-  dollar-quoted strings and comments, so queries that already explained successfully are
-  unaffected. The `EXTRACT` rewrite requires PostgreSQL 14 or later, which is where
-  `pg_catalog.extract` was added.
+subtext: The `EXTRACT` case requires PostgreSQL 14 or later.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.


### PR DESCRIPTION
#### Description

Follow-up to #50669. A review comment on the changelog entry asked to reduce the subtext so the changelog stays clean, since the full detail already lives in the tracking issue. That feedback came in just before the PR was merged and wasn't applied in time, so this retrofits it ahead of the next build.

Trims `.chloggen/50670-postgresql-explain-extract-syntax-error.yaml` down to the single user-relevant caveat (the `EXTRACT` rewrite requires PostgreSQL 14+). No code changes.

Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/50669#discussion_r3935896822

#### Link to tracking issue

N/A (chore follow-up to #50669, tracking issue #50670)

#### Testing

N/A — changelog-only change.

#### Documentation

N/A