### PR TITLE
[exporter/syslog] Add support for datagram sockets in the syslog exporter

### DIFF
--- a/.chloggen/syslog-unixgram.yaml
+++ b/.chloggen/syslog-unixgram.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/syslog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for exporting to Unix datagram sockets such as `/dev/log`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues:
+- 50867
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/syslogexporter/README.md
+++ b/exporter/syslogexporter/README.md
@@ -22,7 +22,7 @@ This means that syslog messages received via the Syslog receiver and exported vi
 **The following configuration options are available**:
 
 - `endpoint` - (required) syslog endpoint
-- `network` - (default = `tcp`) tcp/udp/unix
+- `network` - (default = `tcp`) tcp/udp/unix/unixgram
 - `port` - (default = `514`) A syslog port, ignored when `network` is set to `unix`
 - `protocol` - (default = `rfc5424`) rfc5424/rfc3164
   - `rfc5424` - Expects the syslog messages to be rfc5424 compliant
@@ -164,6 +164,9 @@ Output:
 ```console
 <34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8
 ```
+
+When used with `/dev/log`, the `hostname` attribute must be set to an empty
+string for `systemd-journald` to parse the message correctly.
 
 Please see [example configurations](./examples/).
 

--- a/exporter/syslogexporter/config.go
+++ b/exporter/syslogexporter/config.go
@@ -17,7 +17,7 @@ import (
 var (
 	errUnsupportedPort     = errors.New("unsupported port: port is required, must be in the range 1-65535")
 	errInvalidEndpoint     = errors.New("invalid endpoint: endpoint is required but it is not configured")
-	errUnsupportedNetwork  = errors.New("unsupported network: network is required, only tcp/udp/unix supported")
+	errUnsupportedNetwork  = errors.New("unsupported network: network is required, only tcp/udp/unix/unixgram supported")
 	errUnsupportedProtocol = errors.New("unsupported protocol: Only rfc5424 and rfc3164 supported")
 	errOctetCounting       = errors.New("octet counting is only supported for rfc5424 protocol")
 )
@@ -29,7 +29,7 @@ type Config struct {
 	// Syslog server port (ignored for Unix sockets)
 	Port int `mapstructure:"port"`
 	// Network for syslog communication
-	// options: tcp, udp, unix
+	// options: tcp, udp, unix, unixgram
 	Network string `mapstructure:"network"`
 	// Protocol of syslog messages
 	// options: rfc5424, rfc3164
@@ -56,7 +56,7 @@ func (cfg *Config) Validate() error {
 		if cfg.Port < 1 || cfg.Port > 65535 {
 			invalidFields = append(invalidFields, errUnsupportedPort)
 		}
-	case string(confignet.TransportTypeUnix):
+	case string(confignet.TransportTypeUnix), string(confignet.TransportTypeUnixgram):
 	default:
 		invalidFields = append(invalidFields, errUnsupportedNetwork)
 	}

--- a/exporter/syslogexporter/config.schema.yaml
+++ b/exporter/syslogexporter/config.schema.yaml
@@ -8,7 +8,7 @@ properties:
     description: Syslog server address
     type: string
   network:
-    description: 'Network for syslog communication options: tcp, udp, unix'
+    description: 'Network for syslog communication options: tcp, udp, unix, unixgram'
     type: string
   port:
     description: Syslog server port (ignored for Unix sockets)

--- a/exporter/syslogexporter/config_test.go
+++ b/exporter/syslogexporter/config_test.go
@@ -44,7 +44,7 @@ func TestValidate(t *testing.T) {
 				Protocol: "rfc5424",
 				Network:  "ftp",
 			},
-			err: "unsupported network: network is required, only tcp/udp/unix supported",
+			err: "unsupported network: network is required, only tcp/udp/unix/unixgram supported",
 		},
 		{
 			name: "Unsupported Protocol",

--- a/exporter/syslogexporter/examples/config_with_devlog.yaml
+++ b/exporter/syslogexporter/examples/config_with_devlog.yaml
@@ -1,0 +1,34 @@
+exporters:
+  syslog:
+    network: unixgram
+    endpoint: /dev/log
+    protocol: rfc3164
+
+processors:
+  transform:
+    log_statements:
+      # /dev/log requires an empty hostname.
+      - set(log.attributes["hostname"], "")
+      # The `appname` attribute becomes the syslog identifier.
+      - set(log.attributes["appname"], "app")
+      # syslogexporter uses the `message` attribute and ignores the log body.
+      - set(log.attributes["message"], log.body)
+
+receivers:
+  file_log:
+    start_at: beginning
+    include:
+    - /other/path/**/*.txt
+
+service:
+  telemetry:
+      logs:
+        level: "debug"
+  pipelines:
+    logs:
+      receivers:
+        - file_log
+      processors:
+        - transform
+      exporters:
+        - syslog

--- a/exporter/syslogexporter/exporter_test.go
+++ b/exporter/syslogexporter/exporter_test.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	expectedForm = "<165>1 2003-08-24T12:14:15Z 192.0.2.1 myproc 8710 - - It's time to make the do-nuts.\n"
-	originalForm = "<165>1 2003-08-24T05:14:15-07:00 192.0.2.1 myproc 8710 - - It's time to make the do-nuts."
+	expectedForm       = "<165>1 2003-08-24T12:14:15Z 192.0.2.1 myproc 8710 - - It's time to make the do-nuts.\n"
+	expectedDevLogForm = "<165>Aug 24 12:14:15  myproc: It's time to make the do-nuts.\n"
+	originalForm       = "<165>1 2003-08-24T05:14:15-07:00 192.0.2.1 myproc 8710 - - It's time to make the do-nuts."
 )
 
 type exporterTCPTest struct {
@@ -313,6 +314,43 @@ func TestUnixSocketExporterFail(t *testing.T) {
 	require.Nil(t, conn)
 	assert.ErrorContains(t, consumerErr, "dial unix invalid.sock: connect: no such file or directory")
 	assert.Equal(t, droppedLog, originalForm)
+}
+
+func TestUnixgramSocketExporterDevLog(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows (functionality Unix specific)")
+	}
+
+	// This test verifies that the exporter is capable of sending messages to a /dev/log socket.
+	cfg := createUnixSocketTestConfig(t)
+	cfg.Network = "unixgram"
+	cfg.Protocol = "rfc3164"
+
+	var err error
+
+	srv, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: cfg.Endpoint, Net: "unixgram"})
+	require.NoError(t, err, "failed to start test syslog server")
+	defer srv.Close()
+
+	exp, err := initExporter(cfg, createExporterCreateSettings())
+	require.NoError(t, err, "Error building exporter")
+	require.NotNil(t, exp)
+
+	buffer := exampleLog(t)
+	// /dev/log messages do not have a hostname field.
+	buffer.Attributes().PutStr("hostname", "")
+	logs := logRecordsToLogs(buffer)
+	err = exp.pushLogsData(t.Context(), logs)
+
+	assert.NoError(t, err, "could not send message")
+	err = srv.SetDeadline(time.Now().Add(time.Second * 1))
+	require.NoError(t, err, "cannot set deadline")
+	// Call read once to verify the message was sent in a single datagram
+	b := make([]byte, 1024)
+	n, err := srv.Read(b)
+	require.NoError(t, err, "could not read message")
+	b = b[:n]
+	assert.Equal(t, expectedDevLogForm, string(b))
 }
 
 func TestTLSConfig(t *testing.T) {

--- a/exporter/syslogexporter/sender.go
+++ b/exporter/syslogexporter/sender.go
@@ -53,7 +53,7 @@ type sender struct {
 
 func connect(ctx context.Context, logger *zap.Logger, cfg *Config, tlsConfig *tls.Config) (*sender, error) {
 	var addr string
-	if cfg.Network == string(confignet.TransportTypeUnix) {
+	if cfg.Network == string(confignet.TransportTypeUnix) || cfg.Network == string(confignet.TransportTypeUnixgram) {
 		addr = cfg.Endpoint
 	} else {
 		addr = fmt.Sprintf("%s:%d", cfg.Endpoint, cfg.Port)


### PR DESCRIPTION
This allows the `syslogexporter` to be used to write to `/dev/log`

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`/dev/log` is a standard interface that accepts RFC 3164-format messages. The `syslogexporter` was previously unable to write to `/dev/log` because `/dev/log` is a datagram socket, not a stream socket.

This PR just changes the config validation to allow `unixgram` as a connection type. The rest of the code was already set up to handle datagram sockets correctly.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
I added a new example showing how to send logs to `/dev/log`, and tested this example with `systemd-journald`. I also added a unit test that verifies it can send to a datagram socket.

<!--Describe the documentation added.-->
#### Documentation
I updated `README.txt` with the new configuration option, and added an example.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
