### PR TITLE
[exporter/rabbitmq] address regression introduced by dep update

### DIFF
--- a/exporter/rabbitmqexporter/rabbitmq_exporter.go
+++ b/exporter/rabbitmqexporter/rabbitmq_exporter.go
@@ -58,9 +58,11 @@ func (e *rabbitmqExporter) start(ctx context.Context, host component.Host) error
 		DialConfig: rabbitmq.DialConfig{
 			URL:   e.config.Connection.Endpoint,
 			Vhost: e.config.Connection.VHost,
-			Auth: &amqp.PlainAuth{
-				Username: e.config.Connection.Auth.Plain.Username,
-				Password: e.config.Connection.Auth.Plain.Password,
+			Auth: func() amqp.Authentication {
+				return &amqp.PlainAuth{
+					Username: e.config.Connection.Auth.Plain.Username,
+					Password: e.config.Connection.Auth.Plain.Password,
+				}
 			},
 			ConnectionName:    e.connectionName,
 			ConnectionTimeout: e.config.Connection.ConnectionTimeout,

--- a/internal/rabbitmq/client.go
+++ b/internal/rabbitmq/client.go
@@ -41,6 +41,7 @@ type DeferredConfirmation interface {
 type connectionHolder struct {
 	url              string
 	config           amqp.Config
+	authFactory      func() amqp.Authentication
 	connection       *amqp.Connection
 	logger           *zap.Logger
 	connLock         *sync.Mutex
@@ -56,9 +57,13 @@ type deferredConfirmationHolder struct {
 }
 
 type DialConfig struct {
-	URL               string
-	Vhost             string
-	Auth              amqp.Authentication
+	URL   string
+	Vhost string
+	// Auth builds a fresh Authentication value for every dial attempt. amqp091-go
+	// zeroes out a PlainAuth/AMQPlainAuth's password in place after a successful
+	// connection, so reusing a single Authentication instance across reconnects
+	// would send an empty password on the second attempt.
+	Auth              func() amqp.Authentication
 	ConnectionTimeout time.Duration
 	Heartbeat         time.Duration
 	TLS               *tls.Config
@@ -79,13 +84,13 @@ func (c *client) DialConfig(config DialConfig) (Connection, error) {
 	ch := &connectionHolder{
 		url: config.URL,
 		config: amqp.Config{
-			SASL:            []amqp.Authentication{config.Auth},
 			Vhost:           config.Vhost,
 			TLSClientConfig: config.TLS,
 			Heartbeat:       config.Heartbeat,
 			Dial:            amqp.DefaultDial(config.ConnectionTimeout),
 			Properties:      properties,
 		},
+		authFactory:      config.Auth,
 		logger:           c.logger,
 		connLock:         &sync.Mutex{},
 		connectionErrors: make(chan *amqp.Error, 1),
@@ -131,6 +136,11 @@ func (c *connectionHolder) ReconnectIfUnhealthy() error {
 func (c *connectionHolder) connect() error {
 	c.logger.Debug("Connecting to rabbitmq")
 
+	// Rebuild SASL from scratch on every dial attempt: amqp091-go zeroes out a
+	// PlainAuth/AMQPlainAuth's password in place once a connection is opened
+	// successfully, so a stale amqp.Config reused across reconnects would send
+	// an empty password.
+	c.config.SASL = []amqp.Authentication{c.authFactory()}
 	connection, err := amqp.DialConfig(c.url, c.config)
 	if connection != nil {
 		c.connection = connection

--- a/internal/rabbitmq/client_test.go
+++ b/internal/rabbitmq/client_test.go
@@ -91,7 +91,7 @@ func TestDialConfig(t *testing.T) {
 	config := DialConfig{
 		URL:               "amqp://guest:guest@localhost:5672/",
 		Vhost:             "/",
-		Auth:              &amqp.PlainAuth{Username: "guest", Password: "guest"},
+		Auth:              func() amqp.Authentication { return &amqp.PlainAuth{Username: "guest", Password: "guest"} },
 		ConnectionTimeout: 10 * time.Second,
 		Heartbeat:         10 * time.Second,
 		TLS:               &tls.Config{},
@@ -116,6 +116,7 @@ func TestReconnectIfUnhealthy(t *testing.T) {
 		config: amqp.Config{
 			Vhost: "/",
 		},
+		authFactory: func() amqp.Authentication { return &amqp.PlainAuth{Username: "guest", Password: "guest"} },
 	}
 
 	connection.connectionErrors <- &amqp.Error{


### PR DESCRIPTION
#### Description

The change in the dependency (https://github.com/rabbitmq/amqp091-go/pull/350) caused the credentials to be zero'd out. As a result, needed to use a factory func instead.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Integration/unit tests

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
