### PR TITLE
[pkg/ottl]: rename NewTransformContextPtr to NewTransformContext

### DIFF
--- a/.chloggen/ottl-rename-newtransformcontextptr.yaml
+++ b/.chloggen/ottl-rename-newtransformcontextptr.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename `NewTransformContextPtr` to `NewTransformContext` in all OTTL contexts.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/ottl-rename-newtransformcontextptr.yaml
+++ b/.chloggen/ottl-rename-newtransformcontextptr.yaml
@@ -10,7 +10,7 @@ component: pkg/ottl
 note: Rename `NewTransformContextPtr` to `NewTransformContext` in all OTTL contexts.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50869]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/connector/countconnector/connector.go
+++ b/connector/countconnector/connector.go
@@ -62,14 +62,14 @@ func (c *count) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 				span := scopeSpan.Spans().At(k)
 				spansCounter.updateTimestamp(span.StartTimestamp())
 				spansCounter.updateTimestamp(span.EndTimestamp())
-				sCtx := ottlspan.NewTransformContextPtr(resourceSpan, scopeSpan, span)
+				sCtx := ottlspan.NewTransformContext(resourceSpan, scopeSpan, span)
 				multiError = errors.Join(multiError, spansCounter.update(ctx, span.Attributes(), scopeAttrs, resourceAttrs, sCtx))
 				sCtx.Close()
 
 				for l := 0; l < span.Events().Len(); l++ {
 					event := span.Events().At(l)
 					spanEventsCounter.updateTimestamp(event.Timestamp())
-					eCtx := ottlspanevent.NewTransformContextPtr(resourceSpan, scopeSpan, span, event)
+					eCtx := ottlspanevent.NewTransformContext(resourceSpan, scopeSpan, span, event)
 					multiError = errors.Join(multiError, spanEventsCounter.update(ctx, event.Attributes(), scopeAttrs, resourceAttrs, eCtx))
 					eCtx.Close()
 				}
@@ -112,7 +112,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 
 			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
 				metric := scopeMetrics.Metrics().At(k)
-				mCtx := ottlmetric.NewTransformContextPtr(resourceMetric, scopeMetrics, metric)
+				mCtx := ottlmetric.NewTransformContext(resourceMetric, scopeMetrics, metric)
 				multiError = errors.Join(multiError, metricsCounter.update(ctx, pcommon.NewMap(), scopeAttrs, resourceAttrs, mCtx))
 				mCtx.Close()
 
@@ -123,7 +123,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}
@@ -132,7 +132,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}
@@ -141,7 +141,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}
@@ -150,7 +150,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}
@@ -159,7 +159,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}
@@ -205,7 +205,7 @@ func (c *count) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			for k := 0; k < scopeLogs.LogRecords().Len(); k++ {
 				logRecord := scopeLogs.LogRecords().At(k)
 				counter.updateTimestamp(logRecord.Timestamp())
-				lCtx := ottllog.NewTransformContextPtr(resourceLog, scopeLogs, logRecord)
+				lCtx := ottllog.NewTransformContext(resourceLog, scopeLogs, logRecord)
 				multiError = errors.Join(multiError, counter.update(ctx, logRecord.Attributes(), scopeAttrs, resourceAttrs, lCtx))
 				lCtx.Close()
 			}
@@ -246,7 +246,7 @@ func (c *count) ConsumeProfiles(ctx context.Context, ld pprofile.Profiles) error
 			for k := 0; k < scopeProfile.Profiles().Len(); k++ {
 				profile := scopeProfile.Profiles().At(k)
 				counter.updateTimestamp(profile.Time())
-				pCtx := ottlprofile.NewTransformContextPtr(resourceProfile, scopeProfile, profile, ld.Dictionary())
+				pCtx := ottlprofile.NewTransformContext(resourceProfile, scopeProfile, profile, ld.Dictionary())
 				attributes, attrErr := pprofile.FromAttributeIndices(ld.Dictionary().AttributeTable(), profile, ld.Dictionary())
 				if attrErr != nil {
 					multiError = errors.Join(multiError, attrErr)

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -79,7 +79,7 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 				}
 			}
 		case "otelcol":
-			otx := ottlotelcol.NewTransformContextPtr()
+			otx := ottlotelcol.NewTransformContext()
 			_, isMatch, err := route.otelcolStatement.Execute(ctx, otx)
 			otx.Close()
 			if err != nil {
@@ -97,7 +97,7 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			case Copy:
 				plogutil.CopyResourcesIf(ld, matched,
 					func(rl plog.ResourceLogs) bool {
-						rtx := ottlresource.NewTransformContextPtr(rl.Resource(), rl)
+						rtx := ottlresource.NewTransformContext(rl.Resource(), rl)
 						defer rtx.Close()
 						_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 						// If error during statement evaluation consider it as not a match.
@@ -111,7 +111,7 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			default:
 				plogutil.MoveResourcesIf(ld, matched,
 					func(rl plog.ResourceLogs) bool {
-						rtx := ottlresource.NewTransformContextPtr(rl.Resource(), rl)
+						rtx := ottlresource.NewTransformContext(rl.Resource(), rl)
 						defer rtx.Close()
 						_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 						// If error during statement evaluation consider it as not a match.
@@ -128,7 +128,7 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			case Copy:
 				plogutil.CopyRecordsWithContextIf(ld, matched,
 					func(rl plog.ResourceLogs, sl plog.ScopeLogs, lr plog.LogRecord) bool {
-						ltx := ottllog.NewTransformContextPtr(rl, sl, lr)
+						ltx := ottllog.NewTransformContext(rl, sl, lr)
 						defer ltx.Close()
 						_, isMatch, err := route.logStatement.Execute(ctx, ltx)
 						// If error during statement evaluation consider it as not a match.
@@ -142,7 +142,7 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			default:
 				plogutil.MoveRecordsWithContextIf(ld, matched,
 					func(rl plog.ResourceLogs, sl plog.ScopeLogs, lr plog.LogRecord) bool {
-						ltx := ottllog.NewTransformContextPtr(rl, sl, lr)
+						ltx := ottllog.NewTransformContext(rl, sl, lr)
 						defer ltx.Close()
 						_, isMatch, err := route.logStatement.Execute(ctx, ltx)
 						// If error during statement evaluation consider it as not a match.

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -80,7 +80,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 				}
 			}
 		case "otelcol":
-			otx := ottlotelcol.NewTransformContextPtr()
+			otx := ottlotelcol.NewTransformContext()
 			_, isMatch, err := route.otelcolStatement.Execute(ctx, otx)
 			otx.Close()
 			if err != nil {
@@ -98,7 +98,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 			case Copy:
 				pmetricutil.CopyResourcesIf(md, matched,
 					func(rs pmetric.ResourceMetrics) bool {
-						rtx := ottlresource.NewTransformContextPtr(rs.Resource(), rs)
+						rtx := ottlresource.NewTransformContext(rs.Resource(), rs)
 						defer rtx.Close()
 						_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 						// If error during statement evaluation consider it as not a match.
@@ -112,7 +112,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 			default:
 				pmetricutil.MoveResourcesIf(md, matched,
 					func(rs pmetric.ResourceMetrics) bool {
-						rtx := ottlresource.NewTransformContextPtr(rs.Resource(), rs)
+						rtx := ottlresource.NewTransformContext(rs.Resource(), rs)
 						defer rtx.Close()
 						_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 						// If error during statement evaluation consider it as not a match.
@@ -129,7 +129,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 			case Copy:
 				pmetricutil.CopyMetricsWithContextIf(md, matched,
 					func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric) bool {
-						mtx := ottlmetric.NewTransformContextPtr(rm, sm, m)
+						mtx := ottlmetric.NewTransformContext(rm, sm, m)
 						_, isMatch, err := route.metricStatement.Execute(ctx, mtx)
 						mtx.Close()
 						// If error during statement evaluation consider it as not a match.
@@ -143,7 +143,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 			default:
 				pmetricutil.MoveMetricsWithContextIf(md, matched,
 					func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric) bool {
-						mtx := ottlmetric.NewTransformContextPtr(rm, sm, m)
+						mtx := ottlmetric.NewTransformContext(rm, sm, m)
 						_, isMatch, err := route.metricStatement.Execute(ctx, mtx)
 						mtx.Close()
 						// If error during statement evaluation consider it as not a match.
@@ -160,7 +160,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 			case Copy:
 				pmetricutil.CopyDataPointsWithContextIf(md, matched,
 					func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dp any) bool {
-						dptx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+						dptx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 						_, isMatch, err := route.dataPointStatement.Execute(ctx, dptx)
 						dptx.Close()
 						// If error during statement evaluation consider it as not a match.
@@ -174,7 +174,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 			default:
 				pmetricutil.MoveDataPointsWithContextIf(md, matched,
 					func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dp any) bool {
-						dptx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+						dptx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 						_, isMatch, err := route.dataPointStatement.Execute(ctx, dptx)
 						dptx.Close()
 						// If error during statement evaluation consider it as not a match.

--- a/connector/routingconnector/traces.go
+++ b/connector/routingconnector/traces.go
@@ -79,7 +79,7 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 				}
 			}
 		case "otelcol":
-			otx := ottlotelcol.NewTransformContextPtr()
+			otx := ottlotelcol.NewTransformContext()
 			_, isMatch, err := route.otelcolStatement.Execute(ctx, otx)
 			otx.Close()
 			if err != nil {
@@ -97,7 +97,7 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 			case Copy:
 				ptraceutil.CopyResourcesIf(td, matched,
 					func(rs ptrace.ResourceSpans) bool {
-						rtx := ottlresource.NewTransformContextPtr(rs.Resource(), rs)
+						rtx := ottlresource.NewTransformContext(rs.Resource(), rs)
 						defer rtx.Close()
 						_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 						// If error during statement evaluation consider it as not a match.
@@ -111,7 +111,7 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 			default:
 				ptraceutil.MoveResourcesIf(td, matched,
 					func(rs ptrace.ResourceSpans) bool {
-						rtx := ottlresource.NewTransformContextPtr(rs.Resource(), rs)
+						rtx := ottlresource.NewTransformContext(rs.Resource(), rs)
 						defer rtx.Close()
 						_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 						// If error during statement evaluation consider it as not a match.
@@ -128,7 +128,7 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 			case Copy:
 				ptraceutil.CopySpansWithContextIf(td, matched,
 					func(rs ptrace.ResourceSpans, ss ptrace.ScopeSpans, s ptrace.Span) bool {
-						mtx := ottlspan.NewTransformContextPtr(rs, ss, s)
+						mtx := ottlspan.NewTransformContext(rs, ss, s)
 						defer mtx.Close()
 						_, isMatch, err := route.spanStatement.Execute(ctx, mtx)
 						// If error during statement evaluation consider it as not a match.
@@ -142,7 +142,7 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 			default:
 				ptraceutil.MoveSpansWithContextIf(td, matched,
 					func(rs ptrace.ResourceSpans, ss ptrace.ScopeSpans, s ptrace.Span) bool {
-						mtx := ottlspan.NewTransformContextPtr(rs, ss, s)
+						mtx := ottlspan.NewTransformContext(rs, ss, s)
 						defer mtx.Close()
 						_, isMatch, err := route.spanStatement.Execute(ctx, mtx)
 						// If error during statement evaluation consider it as not a match.

--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -74,7 +74,7 @@ func (sm *signalToMetrics) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 					if !md.MatchAttributes(spanAttrs) {
 						continue
 					}
-					tCtx := ottlspan.NewTransformContextPtr(resourceSpan, scopeSpan, span)
+					tCtx := ottlspan.NewTransformContext(resourceSpan, scopeSpan, span)
 					resolvedAttrs, err := md.ResolveAttributes(ctx, tCtx)
 					if err != nil {
 						tCtx.Close()
@@ -155,7 +155,7 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 						if !md.MatchAttributes(dpAttrs) {
 							return nil
 						}
-						tCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetric, metric, dp)
+						tCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetric, metric, dp)
 						defer tCtx.Close()
 						resolvedAttrs, err := md.ResolveAttributes(ctx, tCtx)
 						if err != nil {
@@ -270,7 +270,7 @@ func (sm *signalToMetrics) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 					if !md.MatchAttributes(logAttrs) {
 						continue
 					}
-					tCtx := ottllog.NewTransformContextPtr(resourceLog, scopeLog, log)
+					tCtx := ottllog.NewTransformContext(resourceLog, scopeLog, log)
 					resolvedAttrs, err := md.ResolveAttributes(ctx, tCtx)
 					if err != nil {
 						tCtx.Close()
@@ -354,7 +354,7 @@ func (sm *signalToMetrics) ConsumeProfiles(ctx context.Context, profiles pprofil
 					if !md.MatchAttributes(profileAttrs) {
 						continue
 					}
-					tCtx := ottlprofile.NewTransformContextPtr(resourceProfile, scopeProfile, profile, profiles.Dictionary())
+					tCtx := ottlprofile.NewTransformContext(resourceProfile, scopeProfile, profile, profiles.Dictionary())
 					resolvedAttrs, err := md.ResolveAttributes(ctx, tCtx)
 					if err != nil {
 						tCtx.Close()

--- a/connector/signaltometricsconnector/internal/customottl/adjustedcount_test.go
+++ b/connector/signaltometricsconnector/internal/customottl/adjustedcount_test.go
@@ -32,7 +32,7 @@ func Test_AdjustedCount(t *testing.T) {
 			require.NoError(t, err)
 			span := ptrace.NewSpan()
 			span.TraceState().FromRaw(tc.tracestate)
-			tCtx := ottlspan.NewTransformContextPtr(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), span)
+			tCtx := ottlspan.NewTransformContext(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), span)
 			defer tCtx.Close()
 			result, err := exprFunc(nil, tCtx)
 			if tc.errMsg != "" {

--- a/connector/sumconnector/connector.go
+++ b/connector/sumconnector/connector.go
@@ -54,13 +54,13 @@ func (c *sum) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 
 			for k := 0; k < scopeSpan.Spans().Len(); k++ {
 				span := scopeSpan.Spans().At(k)
-				sCtx := ottlspan.NewTransformContextPtr(resourceSpan, scopeSpan, span)
+				sCtx := ottlspan.NewTransformContext(resourceSpan, scopeSpan, span)
 				multiError = errors.Join(multiError, spansSummer.update(ctx, span.Attributes(), sCtx))
 				sCtx.Close()
 
 				for l := 0; l < span.Events().Len(); l++ {
 					event := span.Events().At(l)
-					eCtx := ottlspanevent.NewTransformContextPtr(resourceSpan, scopeSpan, span, event)
+					eCtx := ottlspanevent.NewTransformContext(resourceSpan, scopeSpan, span, event)
 					multiError = errors.Join(multiError, spanEventsSummer.update(ctx, event.Attributes(), eCtx))
 					eCtx.Close()
 				}
@@ -100,7 +100,7 @@ func (c *sum) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 
 			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
 				metric := scopeMetrics.Metrics().At(k)
-				mCtx := ottlmetric.NewTransformContextPtr(resourceMetric, scopeMetrics, metric)
+				mCtx := ottlmetric.NewTransformContext(resourceMetric, scopeMetrics, metric)
 				multiError = errors.Join(multiError, metricsSummer.update(ctx, pcommon.NewMap(), mCtx))
 				mCtx.Close()
 
@@ -111,35 +111,35 @@ func (c *sum) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 				case pmetric.MetricTypeGauge:
 					dps := metric.Gauge().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}
 				case pmetric.MetricTypeSum:
 					dps := metric.Sum().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}
 				case pmetric.MetricTypeSummary:
 					dps := metric.Summary().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}
 				case pmetric.MetricTypeHistogram:
 					dps := metric.Histogram().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}
 				case pmetric.MetricTypeExponentialHistogram:
 					dps := metric.ExponentialHistogram().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
+						dCtx := ottldatapoint.NewTransformContext(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}
@@ -182,7 +182,7 @@ func (c *sum) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			for k := 0; k < scopeLogs.LogRecords().Len(); k++ {
 				logRecord := scopeLogs.LogRecords().At(k)
 
-				lCtx := ottllog.NewTransformContextPtr(resourceLog, scopeLogs, logRecord)
+				lCtx := ottllog.NewTransformContext(resourceLog, scopeLogs, logRecord)
 				multiError = errors.Join(multiError, summer.update(ctx, logRecord.Attributes(), lCtx))
 				lCtx.Close()
 			}

--- a/exporter/honeycombmarkerexporter/logs_exporter.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter.go
@@ -83,7 +83,7 @@ func (e *honeycombLogsExporter) exportMarkers(ctx context.Context, ld plog.Logs)
 			logs := slogs.LogRecords()
 			for k := 0; k < logs.Len(); k++ {
 				logRecord := logs.At(k)
-				tCtx := ottllog.NewTransformContextPtr(rlogs, slogs, logRecord)
+				tCtx := ottllog.NewTransformContext(rlogs, slogs, logRecord)
 				for _, m := range e.markers {
 					match, err := m.logBoolExpr.Eval(ctx, tCtx)
 					if err != nil {

--- a/internal/filter/filterlog/filterlog_test.go
+++ b/internal/filter/filterlog/filterlog_test.go
@@ -148,13 +148,13 @@ func TestLogRecord_Matching_False(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, expr)
 
-			tCtx := ottllog.NewTransformContextPtr(plog.NewResourceLogs(), plog.NewScopeLogs(), lr)
+			tCtx := ottllog.NewTransformContext(plog.NewResourceLogs(), plog.NewScopeLogs(), lr)
 			defer tCtx.Close()
 			val, err := expr.Eval(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.False(t, val)
 
-			neCtx := ottllog.NewTransformContextPtr(plog.NewResourceLogs(), plog.NewScopeLogs(), lrm)
+			neCtx := ottllog.NewTransformContext(plog.NewResourceLogs(), plog.NewScopeLogs(), lrm)
 			defer neCtx.Close()
 			val, err = expr.Eval(t.Context(), neCtx)
 			require.NoError(t, err)
@@ -229,13 +229,13 @@ func TestLogRecord_Matching_True(t *testing.T) {
 			require.NotNil(t, expr)
 
 			assert.NotNil(t, lr)
-			tCtx := ottllog.NewTransformContextPtr(plog.NewResourceLogs(), plog.NewScopeLogs(), lr)
+			tCtx := ottllog.NewTransformContext(plog.NewResourceLogs(), plog.NewScopeLogs(), lr)
 			defer tCtx.Close()
 			val, err := expr.Eval(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.True(t, val)
 
-			neCtx := ottllog.NewTransformContextPtr(plog.NewResourceLogs(), plog.NewScopeLogs(), lrm)
+			neCtx := ottllog.NewTransformContext(plog.NewResourceLogs(), plog.NewScopeLogs(), lrm)
 			defer neCtx.Close()
 			assert.NotNil(t, lrm)
 			val, err = expr.Eval(t.Context(), neCtx)
@@ -1306,7 +1306,7 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 			log.SetSeverityText("severity text")
 			log.SetSeverityNumber(tt.logSeverity)
 
-			tCtx := ottllog.NewTransformContextPtr(rLogs, rLogs.ScopeLogs().At(0), log)
+			tCtx := ottllog.NewTransformContext(rLogs, rLogs.ScopeLogs().At(0), log)
 			defer tCtx.Close()
 
 			boolExpr, err := NewSkipExpr(tt.condition)
@@ -1378,7 +1378,7 @@ func BenchmarkFilterlog_NewSkipExpr(b *testing.B) {
 		log.Body().SetStr("body")
 		log.SetSeverityNumber(plog.SeverityNumberUnspecified)
 
-		tCtx := ottllog.NewTransformContextPtr(rLogs, rLogs.ScopeLogs().At(0), log)
+		tCtx := ottllog.NewTransformContext(rLogs, rLogs.ScopeLogs().At(0), log)
 		defer tCtx.Close()
 
 		b.Run(tt.name, func(b *testing.B) {

--- a/internal/filter/filtermetric/filtermetric_test.go
+++ b/internal/filter/filtermetric/filtermetric_test.go
@@ -81,7 +81,7 @@ func TestMatcherMatches(t *testing.T) {
 			assert.NotNil(t, matcher)
 			assert.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), test.metric)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), test.metric)
 			matches, err := matcher.Eval(t.Context(), tCtx)
 			tCtx.Close()
 			assert.NoError(t, err)
@@ -184,7 +184,7 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 			metric := pmetric.NewMetric()
 			metric.SetName("metricA")
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer tCtx.Close()
 
 			boolExpr, err := NewSkipExpr(tt.include, tt.exclude)

--- a/internal/filter/filterottl/functions_test.go
+++ b/internal/filter/filterottl/functions_test.go
@@ -124,7 +124,7 @@ func Test_HasAttrKeyOnDatapoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := hasAttributeKeyOnDatapoint(tt.key)
 			assert.NoError(t, err)
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input())
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input())
 			defer tCtx.Close()
 			result, err := exprFunc(t.Context(), tCtx)
 			assert.NoError(t, err)
@@ -351,7 +351,7 @@ func Test_HasAttrOnDatapoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := hasAttributeOnDatapoint(tt.key, tt.expectedVal)
 			assert.NoError(t, err)
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input())
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input())
 			defer tCtx.Close()
 			result, err := exprFunc(t.Context(), tCtx)
 			assert.NoError(t, err)

--- a/internal/filter/filterspan/filterspan_test.go
+++ b/internal/filter/filterspan/filterspan_test.go
@@ -174,7 +174,7 @@ func TestSpan_Matching_False(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotNil(t, expr)
 
-			tCtx := ottlspan.NewTransformContextPtr(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), span)
+			tCtx := ottlspan.NewTransformContext(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), span)
 			defer tCtx.Close()
 
 			val, err := expr.Eval(t.Context(), tCtx)
@@ -195,7 +195,7 @@ func TestSpan_MissingServiceName(t *testing.T) {
 	assert.NotNil(t, mp)
 
 	emptySpan := ptrace.NewSpan()
-	tCtx := ottlspan.NewTransformContextPtr(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), emptySpan)
+	tCtx := ottlspan.NewTransformContext(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), emptySpan)
 	defer tCtx.Close()
 	val, err := mp.Eval(t.Context(), tCtx)
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestSpan_Matching_True(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotNil(t, mp)
 
-			tCtx := ottlspan.NewTransformContextPtr(rs, rs.ScopeSpans().At(0), span)
+			tCtx := ottlspan.NewTransformContext(rs, rs.ScopeSpans().At(0), span)
 			defer tCtx.Close()
 			val, err := mp.Eval(t.Context(), tCtx)
 			require.NoError(t, err)
@@ -1208,7 +1208,7 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 			scope.SetName("scope")
 			scope.SetVersion("0.1.0")
 
-			tCtx := ottlspan.NewTransformContextPtr(rs, rs.ScopeSpans().At(0), span)
+			tCtx := ottlspan.NewTransformContext(rs, rs.ScopeSpans().At(0), span)
 			defer tCtx.Close()
 
 			boolExpr, err := NewSkipExpr(tt.condition)
@@ -1273,7 +1273,7 @@ func BenchmarkFilterspan_NewSkipExpr(b *testing.B) {
 		span.Attributes().PutStr("keyExists", "present")
 		span.SetKind(ptrace.SpanKindClient)
 
-		tCtx := ottlspan.NewTransformContextPtr(rs, rs.ScopeSpans().At(0), span)
+		tCtx := ottlspan.NewTransformContext(rs, rs.ScopeSpans().At(0), span)
 		defer tCtx.Close()
 
 		b.Run(tt.name, func(b *testing.B) {

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -74,9 +74,9 @@ func WithCache(cache *pcommon.Map) TransformContextOption {
 	}
 }
 
-// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// NewTransformContext returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dataPoint any, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dataPoint any, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.resourceMetrics = resourceMetrics
 	tCtx.scopeMetrics = scopeMetrics

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -21,7 +21,7 @@ import (
 
 func Test_MarshalLogObject_IncludesDataPoint(t *testing.T) {
 	numberDataPoint := createNumberDataPointTelemetry(pmetric.NumberDataPointValueTypeDouble)
-	ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), numberDataPoint)
+	ctx := NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), numberDataPoint)
 	defer ctx.Close()
 
 	encoder := zapcore.NewMapObjectEncoder()
@@ -97,7 +97,7 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 
 			numberDataPoint := createNumberDataPointTelemetry(tt.valueType)
 
-			ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), numberDataPoint)
+			ctx := NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), numberDataPoint)
 			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
@@ -529,7 +529,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 
 			numberDataPoint := createNumberDataPointTelemetry(tt.valueType)
 
-			ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), numberDataPoint)
+			ctx := NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), numberDataPoint)
 			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
@@ -977,7 +977,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 
 			histogramDataPoint := createHistogramDataPointTelemetry()
 
-			ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), histogramDataPoint)
+			ctx := NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), histogramDataPoint)
 			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
@@ -1509,7 +1509,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 
 			expoHistogramDataPoint := createExpoHistogramDataPointTelemetry()
 
-			ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), expoHistogramDataPoint)
+			ctx := NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), expoHistogramDataPoint)
 			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
@@ -1942,7 +1942,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 
 			summaryDataPoint := createSummaryDataPointTelemetry()
 
-			ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), summaryDataPoint)
+			ctx := NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), pmetric.NewMetric(), summaryDataPoint)
 			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
@@ -2124,7 +2124,7 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 
 			metric := createMetricTelemetry()
 
-			ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric, pmetric.NewNumberDataPoint())
+			ctx := NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric, pmetric.NewNumberDataPoint())
 			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
@@ -2253,7 +2253,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	metric := sm.Metrics().AppendEmpty()
 	metric.SetName("metric")
 
-	ctx := NewTransformContextPtr(rm, sm, metric, pmetric.NewNumberDataPoint())
+	ctx := NewTransformContext(rm, sm, metric, pmetric.NewNumberDataPoint())
 	defer ctx.Close()
 
 	tests := []struct {

--- a/pkg/ottl/contexts/ottlexemplar/exemplar.go
+++ b/pkg/ottl/contexts/ottlexemplar/exemplar.go
@@ -79,9 +79,9 @@ func WithCache(cache *pcommon.Map) TransformContextOption {
 	}
 }
 
-// NewTransformContextPtr returns a new TransformContext from a pool of contexts.
+// NewTransformContext returns a new TransformContext from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dataPoint any, exemplar pmetric.Exemplar, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dataPoint any, exemplar pmetric.Exemplar, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.resourceMetrics = resourceMetrics
 	tCtx.scopeMetrics = scopeMetrics

--- a/pkg/ottl/contexts/ottlexemplar/exemplar_test.go
+++ b/pkg/ottl/contexts/ottlexemplar/exemplar_test.go
@@ -235,7 +235,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			rm, sm, metric, dp, exemplar := createTelemetry()
 
-			tCtx := NewTransformContextPtr(rm, sm, metric, dp, exemplar)
+			tCtx := NewTransformContext(rm, sm, metric, dp, exemplar)
 			defer tCtx.Close()
 
 			got, err := accessor.Get(t.Context(), tCtx)
@@ -289,7 +289,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	exemplar := dp.Exemplars().AppendEmpty()
 	exemplar.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(100)))
 
-	ctx := NewTransformContextPtr(rm, sm, metric, dp, exemplar)
+	ctx := NewTransformContext(rm, sm, metric, dp, exemplar)
 	defer ctx.Close()
 
 	tests := []struct {
@@ -403,7 +403,7 @@ func TestHigherContextCacheAccessError(t *testing.T) {
 
 func TestMarshalLogObjectIncludesDataPoint(t *testing.T) {
 	rm, sm, metric, dp, exemplar := createTelemetry()
-	ctx := NewTransformContextPtr(rm, sm, metric, dp, exemplar)
+	ctx := NewTransformContext(rm, sm, metric, dp, exemplar)
 	defer ctx.Close()
 
 	encoder := zapcore.NewMapObjectEncoder()

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -93,9 +93,9 @@ func WithCache(cache *pcommon.Map) TransformContextOption {
 	}
 }
 
-// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// NewTransformContext returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(resourceLogs plog.ResourceLogs, scopeLogs plog.ScopeLogs, logRecord plog.LogRecord, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(resourceLogs plog.ResourceLogs, scopeLogs plog.ScopeLogs, logRecord plog.LogRecord, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.resourceLogs = resourceLogs
 	tCtx.scopeLogs = scopeLogs

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -617,13 +617,13 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			rLogs, sLogs, log := createTelemetry(tt.bodyType)
 
-			tCtx := NewTransformContextPtr(rLogs, sLogs, log)
+			tCtx := NewTransformContext(rLogs, sLogs, log)
 			defer tCtx.Close()
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
-			newCtx := NewTransformContextPtr(rLogs, sLogs, log)
+			newCtx := NewTransformContext(rLogs, sLogs, log)
 			defer newCtx.Close()
 			err = accessor.Set(t.Context(), tCtx, tt.newVal)
 			require.NoError(t, err)
@@ -640,7 +640,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	rLogs, sLogs, log := createTelemetry("string")
-	ctx := NewTransformContextPtr(rLogs, sLogs, log)
+	ctx := NewTransformContext(rLogs, sLogs, log)
 	defer ctx.Close()
 
 	tests := []struct {
@@ -786,12 +786,12 @@ func Test_InvalidBodyIndexing(t *testing.T) {
 
 	rLogs, sLogs, log := createTelemetry("string")
 
-	tCtx := NewTransformContextPtr(rLogs, sLogs, log)
+	tCtx := NewTransformContext(rLogs, sLogs, log)
 	defer tCtx.Close()
 	_, err = accessor.Get(t.Context(), tCtx)
 	assert.Error(t, err)
 
-	newCtx := NewTransformContextPtr(rLogs, sLogs, log)
+	newCtx := NewTransformContext(rLogs, sLogs, log)
 	defer newCtx.Close()
 	err = accessor.Set(t.Context(), tCtx, nil)
 	assert.Error(t, err)

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -72,9 +72,9 @@ func WithCache(cache *pcommon.Map) TransformContextOption {
 	}
 }
 
-// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// NewTransformContext returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.resourceMetrics = resourceMetrics
 	tCtx.scopeMetrics = scopeMetrics

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -194,7 +194,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			metric := createTelemetry()
 
-			ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			ctx := NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
@@ -221,7 +221,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	instrumentationScope := rm.ScopeMetrics().AppendEmpty().Scope()
 	instrumentationScope.SetName("instrumentation_scope")
 
-	ctx := NewTransformContextPtr(rm, rm.ScopeMetrics().At(0), pmetric.NewMetric())
+	ctx := NewTransformContext(rm, rm.ScopeMetrics().At(0), pmetric.NewMetric())
 	defer ctx.Close()
 
 	tests := []struct {
@@ -330,7 +330,7 @@ func Test_newPathGetSetter_RelaxedNames(t *testing.T) {
 			metric := pmetric.NewMetric()
 			metric.SetName("original")
 
-			ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			ctx := NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			err := accessor.Set(t.Context(), ctx, name)

--- a/pkg/ottl/contexts/ottlotelcol/otelcol.go
+++ b/pkg/ottl/contexts/ottlotelcol/otelcol.go
@@ -43,8 +43,8 @@ func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) er
 // TransformContextOption represents an option for configuring a TransformContext.
 type TransformContextOption func(*TransformContext)
 
-// NewTransformContextPtr creates a new TransformContext with the provided parameters.
-func NewTransformContextPtr(options ...TransformContextOption) *TransformContext {
+// NewTransformContext creates a new TransformContext with the provided parameters.
+func NewTransformContext(options ...TransformContextOption) *TransformContext {
 	tc := tcPool.Get().(*TransformContext)
 	for _, opt := range options {
 		opt(tc)

--- a/pkg/ottl/contexts/ottlotelcol/otelcol_test.go
+++ b/pkg/ottl/contexts/ottlotelcol/otelcol_test.go
@@ -172,7 +172,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
 			assert.NoError(t, err)
 
-			tCtx := NewTransformContextPtr()
+			tCtx := NewTransformContext()
 			defer tCtx.Close()
 			got, err := accessor.Get(t.Context(), tCtx)
 			assert.NoError(t, err)

--- a/pkg/ottl/contexts/ottlprofile/profile.go
+++ b/pkg/ottl/contexts/ottlprofile/profile.go
@@ -76,9 +76,9 @@ func WithCache(cache *pcommon.Map) TransformContextOption {
 	}
 }
 
-// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// NewTransformContext returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(resourceProfiles pprofile.ResourceProfiles, scopeProfiles pprofile.ScopeProfiles, profile pprofile.Profile, dictionary pprofile.ProfilesDictionary, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(resourceProfiles pprofile.ResourceProfiles, scopeProfiles pprofile.ScopeProfiles, profile pprofile.Profile, dictionary pprofile.ProfilesDictionary, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.profile = profile
 	tCtx.dictionary = dictionary

--- a/pkg/ottl/contexts/ottlprofile/profile_test.go
+++ b/pkg/ottl/contexts/ottlprofile/profile_test.go
@@ -119,13 +119,13 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			profile := createProfileTelemetry()
 
-			tCtx := NewTransformContextPtr(pprofile.NewResourceProfiles(), pprofile.NewScopeProfiles(), profile, pprofile.NewProfilesDictionary())
+			tCtx := NewTransformContext(pprofile.NewResourceProfiles(), pprofile.NewScopeProfiles(), profile, pprofile.NewProfilesDictionary())
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 			tCtx.Close()
 
-			tCtx = NewTransformContextPtr(pprofile.NewResourceProfiles(), pprofile.NewScopeProfiles(), profile, pprofile.NewProfilesDictionary())
+			tCtx = NewTransformContext(pprofile.NewResourceProfiles(), pprofile.NewScopeProfiles(), profile, pprofile.NewProfilesDictionary())
 			err = accessor.Set(t.Context(), tCtx, tt.newVal)
 			require.NoError(t, err)
 			tCtx.Close()
@@ -152,7 +152,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	scopeProfiles := pprofile.NewScopeProfiles()
 	instrumentationScope.CopyTo(scopeProfiles.Scope())
 
-	ctx := NewTransformContextPtr(resourceProfiles, scopeProfiles, pprofile.NewProfile(), pprofile.NewProfilesDictionary())
+	ctx := NewTransformContext(resourceProfiles, scopeProfiles, pprofile.NewProfile(), pprofile.NewProfilesDictionary())
 
 	tests := []struct {
 		name     string

--- a/pkg/ottl/contexts/ottlprofilesample/profilesample.go
+++ b/pkg/ottl/contexts/ottlprofilesample/profilesample.go
@@ -67,9 +67,9 @@ func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) er
 // TransformContextOption represents an option for configuring a TransformContext.
 type TransformContextOption func(*TransformContext)
 
-// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// NewTransformContext returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(resourceProfiles pprofile.ResourceProfiles, scopeProfiles pprofile.ScopeProfiles, profile pprofile.Profile, sample pprofile.Sample, dictionary pprofile.ProfilesDictionary, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(resourceProfiles pprofile.ResourceProfiles, scopeProfiles pprofile.ScopeProfiles, profile pprofile.Profile, sample pprofile.Sample, dictionary pprofile.ProfilesDictionary, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.sample = sample
 	tCtx.profile = profile

--- a/pkg/ottl/contexts/ottlprofilesample/profilesample_test.go
+++ b/pkg/ottl/contexts/ottlprofilesample/profilesample_test.go
@@ -89,13 +89,13 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 
 			profileSample, profile := createProfileSampleTelemetry()
 
-			tCtx := NewTransformContextPtr(pprofile.NewResourceProfiles(), pprofile.NewScopeProfiles(), profile, profileSample, pprofile.NewProfilesDictionary())
+			tCtx := NewTransformContext(pprofile.NewResourceProfiles(), pprofile.NewScopeProfiles(), profile, profileSample, pprofile.NewProfilesDictionary())
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 			tCtx.Close()
 
-			tCtx = NewTransformContextPtr(pprofile.NewResourceProfiles(), pprofile.NewScopeProfiles(), profile, profileSample, pprofile.NewProfilesDictionary())
+			tCtx = NewTransformContext(pprofile.NewResourceProfiles(), pprofile.NewScopeProfiles(), profile, profileSample, pprofile.NewProfilesDictionary())
 			err = accessor.Set(t.Context(), tCtx, tt.newVal)
 			require.NoError(t, err)
 			tCtx.Close()
@@ -121,7 +121,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	scopeProfile := pprofile.NewScopeProfiles()
 	scopeProfile.Scope().SetName("instrumentation_scope")
 
-	ctx := NewTransformContextPtr(resourceProfile, scopeProfile, profile, pprofile.NewSample(), pprofile.NewProfilesDictionary())
+	ctx := NewTransformContext(resourceProfile, scopeProfile, profile, pprofile.NewSample(), pprofile.NewProfilesDictionary())
 	defer ctx.Close()
 
 	tests := []struct {

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -63,9 +63,9 @@ func WithCache(cache *pcommon.Map) TransformContextOption {
 	}
 }
 
-// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// NewTransformContext returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(resource pcommon.Resource, schemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(resource pcommon.Resource, schemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.resource = resource
 	tCtx.schemaURLItem = schemaURLItem

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -381,7 +381,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			resource := createTelemetry()
 
-			tCtx := NewTransformContextPtr(resource, pmetric.NewResourceMetrics())
+			tCtx := NewTransformContext(resource, pmetric.NewResourceMetrics())
 			defer tCtx.Close()
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -68,9 +68,9 @@ func WithCache(cache *pcommon.Map) TransformContextOption {
 	}
 }
 
-// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// NewTransformContext returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeSchemaURLItem, resourceSchemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeSchemaURLItem, resourceSchemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.instrumentationScope = instrumentationScope
 	tCtx.resource = resource

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -415,7 +415,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			is, res := createTelemetry()
 
-			tCtx := NewTransformContextPtr(is, res, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := NewTransformContext(is, res, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
 			defer tCtx.Close()
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
@@ -448,7 +448,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl("resource_schema")
 
-	ctx := NewTransformContextPtr(scope, resource, sm, rm)
+	ctx := NewTransformContext(scope, resource, sm, rm)
 	defer ctx.Close()
 
 	tests := []struct {

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -67,9 +67,9 @@ func WithCache(cache *pcommon.Map) TransformContextOption {
 	}
 }
 
-// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// NewTransformContext returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(resourceSpans ptrace.ResourceSpans, scopeSpans ptrace.ScopeSpans, span ptrace.Span, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(resourceSpans ptrace.ResourceSpans, scopeSpans ptrace.ScopeSpans, span ptrace.Span, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.resourceSpans = resourceSpans
 	tCtx.scopeSpans = scopeSpans

--- a/pkg/ottl/contexts/ottlspan/span_test.go
+++ b/pkg/ottl/contexts/ottlspan/span_test.go
@@ -685,7 +685,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			require.NoError(t, err)
 
 			rs, ss, span := createTelemetry()
-			tCtx := NewTransformContextPtr(rs, ss, span)
+			tCtx := NewTransformContext(rs, ss, span)
 			defer tCtx.Close()
 
 			got, err := accessor.Get(t.Context(), tCtx)
@@ -712,7 +712,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	instrumentationScope := rs.ScopeSpans().AppendEmpty().Scope()
 	instrumentationScope.SetName("instrumentation_scope")
 
-	tCtx := NewTransformContextPtr(rs, rs.ScopeSpans().At(0), ptrace.NewSpan())
+	tCtx := NewTransformContext(rs, rs.ScopeSpans().At(0), ptrace.NewSpan())
 	defer tCtx.Close()
 
 	tests := []struct {

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -75,9 +75,9 @@ func WithCache(cache *pcommon.Map) TransformContextOption {
 	}
 }
 
-// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// NewTransformContext returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(resourceSpans ptrace.ResourceSpans, scopeSpans ptrace.ScopeSpans, span ptrace.Span, spanEvent ptrace.SpanEvent, options ...TransformContextOption) *TransformContext {
+func NewTransformContext(resourceSpans ptrace.ResourceSpans, scopeSpans ptrace.ScopeSpans, span ptrace.Span, spanEvent ptrace.SpanEvent, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.resourceSpans = resourceSpans
 	tCtx.scopeSpans = scopeSpans

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -443,7 +443,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			rs, ss, span, spanEvent := createTelemetry()
 
-			tCtx := NewTransformContextPtr(rs, ss, span, spanEvent, WithEventIndex(1))
+			tCtx := NewTransformContext(rs, ss, span, spanEvent, WithEventIndex(1))
 			defer tCtx.Close()
 
 			got, err := accessor.Get(t.Context(), tCtx)
@@ -479,7 +479,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	span := ss.Spans().AppendEmpty()
 	span.SetName("span")
 
-	ctx := NewTransformContextPtr(rs, ss, span, ptrace.NewSpanEvent())
+	ctx := NewTransformContext(rs, ss, span, ptrace.NewSpanEvent())
 	defer ctx.Close()
 
 	tests := []struct {
@@ -585,9 +585,9 @@ func Test_setAndGetEventIndex(t *testing.T) {
 
 			var tCtx *TransformContext
 			if tt.setEventIndex {
-				tCtx = NewTransformContextPtr(rs, ss, span, spanEvent, WithEventIndex(tt.eventIndexValue))
+				tCtx = NewTransformContext(rs, ss, span, spanEvent, WithEventIndex(tt.eventIndexValue))
 			} else {
-				tCtx = NewTransformContextPtr(rs, ss, span, spanEvent)
+				tCtx = NewTransformContext(rs, ss, span, spanEvent)
 			}
 			defer tCtx.Close()
 

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -2938,7 +2938,7 @@ func constructLogTransformContext() *ottllog.TransformContext {
 	s4.AppendEmpty().SetInt(42)
 	s4.AppendEmpty().SetBool(true)
 
-	return ottllog.NewTransformContextPtr(rLogs, rLogs.ScopeLogs().At(0), logRecord)
+	return ottllog.NewTransformContext(rLogs, rLogs.ScopeLogs().At(0), logRecord)
 }
 
 func constructLogTransformContextEditors() *ottllog.TransformContext {
@@ -2991,7 +2991,7 @@ func constructLogTransformContextEditors() *ottllog.TransformContext {
 	s3.AppendEmpty().SetStr("bar")
 	s3.AppendEmpty().SetStr("baz")
 
-	return ottllog.NewTransformContextPtr(rLogs, rLogs.ScopeLogs().At(0), logRecord)
+	return ottllog.NewTransformContext(rLogs, rLogs.ScopeLogs().At(0), logRecord)
 }
 
 func constructLogTransformContextValueExpressions() *ottllog.TransformContext {
@@ -3043,7 +3043,7 @@ func constructLogTransformContextValueExpressions() *ottllog.TransformContext {
 	thing2 := s2.AppendEmpty().SetEmptyMap()
 	thing2.PutStr("name", "bar")
 
-	return ottllog.NewTransformContextPtr(rLogs, rLogs.ScopeLogs().At(0), logRecord)
+	return ottllog.NewTransformContext(rLogs, rLogs.ScopeLogs().At(0), logRecord)
 }
 
 func constructSpanTransformContext() *ottlspan.TransformContext {
@@ -3055,7 +3055,7 @@ func constructSpanTransformContext() *ottlspan.TransformContext {
 	span := ss.Spans().AppendEmpty()
 	fillSpanOne(span)
 
-	return ottlspan.NewTransformContextPtr(rs, ss, span)
+	return ottlspan.NewTransformContext(rs, ss, span)
 }
 
 func constructSpanEventTransformContext() *ottlspanevent.TransformContext {
@@ -3070,7 +3070,7 @@ func constructSpanEventTransformContext() *ottlspanevent.TransformContext {
 	ev1 := span.Events().AppendEmpty()
 	ev1.SetName("event-1")
 
-	return ottlspanevent.NewTransformContextPtr(rs, ss, span, ev1, ottlspanevent.WithEventIndex(0))
+	return ottlspanevent.NewTransformContext(rs, ss, span, ev1, ottlspanevent.WithEventIndex(0))
 }
 
 func newResourceLogs(tCtx *ottllog.TransformContext) plog.ResourceLogs {
@@ -3111,7 +3111,7 @@ func Benchmark_XML_Functions(b *testing.B) {
 		rLogs := plog.NewResourceLogs()
 		logRecord := rLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
 		logRecord.Body().SetStr(testXML)
-		return ottllog.NewTransformContextPtr(rLogs, rLogs.ScopeLogs().At(0), logRecord)
+		return ottllog.NewTransformContext(rLogs, rLogs.ScopeLogs().At(0), logRecord)
 	}
 
 	settings := componenttest.NewNopTelemetrySettings()

--- a/pkg/ottl/e2e/profiles/e2e_test.go
+++ b/pkg/ottl/e2e/profiles/e2e_test.go
@@ -1654,7 +1654,7 @@ func constructProfileTransformContext() *ottlprofile.TransformContext {
 
 	dic := pprofile.NewProfilesDictionary()
 	scopeProfiles := pprofile.NewScopeProfiles()
-	return ottlprofile.NewTransformContextPtr(resourceProfiles, scopeProfiles, profile.Transform(dic, scopeProfiles), dic)
+	return ottlprofile.NewTransformContext(resourceProfiles, scopeProfiles, profile.Transform(dic, scopeProfiles), dic)
 }
 
 func constructProfileTransformContextEditors() *ottlprofile.TransformContext {
@@ -1688,7 +1688,7 @@ func constructProfileTransformContextEditors() *ottlprofile.TransformContext {
 
 	dic := pprofile.NewProfilesDictionary()
 	scopeProfiles := pprofile.NewScopeProfiles()
-	return ottlprofile.NewTransformContextPtr(resourceProfiles, scopeProfiles, profile.Transform(dic, scopeProfiles), dic)
+	return ottlprofile.NewTransformContext(resourceProfiles, scopeProfiles, profile.Transform(dic, scopeProfiles), dic)
 }
 
 func constructProfileTransformContextValueExpressions() *ottlprofile.TransformContext {
@@ -1727,7 +1727,7 @@ func constructProfileTransformContextValueExpressions() *ottlprofile.TransformCo
 
 	dic := pprofile.NewProfilesDictionary()
 	scopeProfiles := pprofile.NewScopeProfiles()
-	return ottlprofile.NewTransformContextPtr(resourceProfiles, scopeProfiles, profile.Transform(dic, scopeProfiles), dic)
+	return ottlprofile.NewTransformContext(resourceProfiles, scopeProfiles, profile.Transform(dic, scopeProfiles), dic)
 }
 
 func newResourceProfiles(tCtx *ottlprofile.TransformContext) pprofile.ResourceProfiles {

--- a/pkg/ottl/like_getter_bench_test.go
+++ b/pkg/ottl/like_getter_bench_test.go
@@ -45,7 +45,7 @@ func newLikeGetterLogContext(attributeCount int) *ottllog.TransformContext {
 	for i := range attributeCount {
 		logRecord.Attributes().PutStr(fmt.Sprintf("source_%d", i), fmt.Sprintf("value_%d", i))
 	}
-	return ottllog.NewTransformContextPtr(resourceLogs, scopeLogs, logRecord)
+	return ottllog.NewTransformContext(resourceLogs, scopeLogs, logRecord)
 }
 
 func BenchmarkLikeGetterStatements(b *testing.B) {

--- a/pkg/ottl/ottlfuncs/func_is_root_span_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_root_span_test.go
@@ -25,7 +25,7 @@ func Test_IsRootSpan(t *testing.T) {
 		0, 0, 0, 0, 0, 0, 0, 0,
 	})
 
-	rootCtx := ottlspan.NewTransformContextPtr(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), spanRoot)
+	rootCtx := ottlspan.NewTransformContext(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), spanRoot)
 	defer rootCtx.Close()
 	value, err := exprFunc(nil, rootCtx)
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func Test_IsRootSpan(t *testing.T) {
 		1, 0, 0, 0, 0, 0, 0, 0,
 	})
 
-	nonRootCtx := ottlspan.NewTransformContextPtr(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), spanNonRoot)
+	nonRootCtx := ottlspan.NewTransformContext(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), spanNonRoot)
 	defer nonRootCtx.Close()
 	value, err = exprFunc(nil, nonRootCtx)
 	require.NoError(t, err)

--- a/pkg/ottl/performance_bench_test.go
+++ b/pkg/ottl/performance_bench_test.go
@@ -422,7 +422,7 @@ func newBenchmarkMetricContext(attributeCount int) *ottlmetric.TransformContext 
 		dp.Attributes().PutStr(fmt.Sprintf("label_%d", i), fmt.Sprintf("value_%d", i))
 	}
 
-	return ottlmetric.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric)
+	return ottlmetric.NewTransformContext(resourceMetrics, scopeMetrics, metric)
 }
 
 func buildLogStatements(count int) []string {
@@ -504,7 +504,7 @@ func newBenchmarkLogContext(attributeCount int) *ottllog.TransformContext {
 
 	logRecord.Body().SetStr("benchmark log record")
 
-	return ottllog.NewTransformContextPtr(resourceLogs, scopeLogs, logRecord)
+	return ottllog.NewTransformContext(resourceLogs, scopeLogs, logRecord)
 }
 
 func newBenchmarkSpanContext(attributeCount int) *ottlspan.TransformContext {
@@ -534,7 +534,7 @@ func newBenchmarkSpanContext(attributeCount int) *ottlspan.TransformContext {
 		span.Attributes().PutStr(fmt.Sprintf("source_%d", i), fmt.Sprintf("span_value_%d", i))
 	}
 
-	return ottlspan.NewTransformContextPtr(resourceSpans, scopeSpans, span)
+	return ottlspan.NewTransformContext(resourceSpans, scopeSpans, span)
 }
 
 func BenchmarkSliceToMap(b *testing.B) {
@@ -643,7 +643,7 @@ func newSliceContextWithPrimitiveArr(arrSize int) *ottllog.TransformContext {
 		arr.AppendEmpty().SetStr("v_" + strconv.Itoa(i))
 	}
 
-	return ottllog.NewTransformContextPtr(rl, sl, lr)
+	return ottllog.NewTransformContext(rl, sl, lr)
 }
 
 func newSliceContextWithMapArr(arrSize int) *ottllog.TransformContext {
@@ -666,7 +666,7 @@ func newSliceContextWithMapArr(arrSize int) *ottllog.TransformContext {
 		nm.PutStr("k", "v_"+strconv.Itoa(i))
 	}
 
-	return ottllog.NewTransformContextPtr(rl, sl, lr)
+	return ottllog.NewTransformContext(rl, sl, lr)
 }
 
 func BenchmarkStringifyAll(b *testing.B) {
@@ -702,7 +702,7 @@ func BenchmarkStringifyAll(b *testing.B) {
 			lr := sl.LogRecords().AppendEmpty()
 			lr.Body().SetStr("benchmark")
 			scenario.template.CopyTo(lr.Attributes())
-			tCtx := ottllog.NewTransformContextPtr(rl, sl, lr)
+			tCtx := ottllog.NewTransformContext(rl, sl, lr)
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/processor/adaptivetailsamplingprocessor/processor.go
+++ b/processor/adaptivetailsamplingprocessor/processor.go
@@ -653,7 +653,7 @@ func (p *adaptiveTailSamplingProcessor) evalRootSpanCondition(ctx context.Contex
 	if p.rootSpanFastPath {
 		return span.ParentSpanID().IsEmpty()
 	}
-	tCtx := ottlspan.NewTransformContextPtr(rs, ss, span)
+	tCtx := ottlspan.NewTransformContext(rs, ss, span)
 	ok, err := p.rootSpanCond.Eval(ctx, tCtx)
 	tCtx.Close()
 	if err != nil {

--- a/processor/adaptivetailsamplingprocessor/rules.go
+++ b/processor/adaptivetailsamplingprocessor/rules.go
@@ -57,7 +57,7 @@ func (r *rule) matchesSameSpan(ctx context.Context, spans []ptrace.ResourceSpans
 	for _, rs := range spans {
 		for _, ss := range rs.ScopeSpans().All() {
 			for _, span := range ss.Spans().All() {
-				tCtx := ottlspan.NewTransformContextPtr(rs, ss, span)
+				tCtx := ottlspan.NewTransformContext(rs, ss, span)
 				allMatch := true
 				for _, cond := range r.conditions {
 					ok, err := cond.Eval(ctx, tCtx)
@@ -96,7 +96,7 @@ func (r *rule) anySpanSatisfies(ctx context.Context, spans []ptrace.ResourceSpan
 	for _, rs := range spans {
 		for _, ss := range rs.ScopeSpans().All() {
 			for _, span := range ss.Spans().All() {
-				tCtx := ottlspan.NewTransformContextPtr(rs, ss, span)
+				tCtx := ottlspan.NewTransformContext(rs, ss, span)
 				ok, err := cond.Eval(ctx, tCtx)
 				tCtx.Close()
 				if err != nil {

--- a/processor/attributesprocessor/attributes_log.go
+++ b/processor/attributesprocessor/attributes_log.go
@@ -42,7 +42,7 @@ func (a *logAttributesProcessor) processLogs(ctx context.Context, ld plog.Logs) 
 			for k := 0; k < logs.Len(); k++ {
 				lr := logs.At(k)
 				if a.skipExpr != nil {
-					lCtx := ottllog.NewTransformContextPtr(rs, ils, lr)
+					lCtx := ottllog.NewTransformContext(rs, ils, lr)
 					skip, err := a.skipExpr.Eval(ctx, lCtx)
 					lCtx.Close()
 					if err != nil {

--- a/processor/attributesprocessor/attributes_metric.go
+++ b/processor/attributesprocessor/attributes_metric.go
@@ -42,7 +42,7 @@ func (a *metricAttributesProcessor) processMetrics(ctx context.Context, md pmetr
 			for k := 0; k < metrics.Len(); k++ {
 				m := metrics.At(k)
 				if a.skipExpr != nil {
-					tCtx := ottlmetric.NewTransformContextPtr(rs, ils, m)
+					tCtx := ottlmetric.NewTransformContext(rs, ils, m)
 					skip, err := a.skipExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {

--- a/processor/attributesprocessor/attributes_trace.go
+++ b/processor/attributesprocessor/attributes_trace.go
@@ -42,7 +42,7 @@ func (a *spanAttributesProcessor) processTraces(ctx context.Context, td ptrace.T
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
 				if a.skipExpr != nil {
-					tCtx := ottlspan.NewTransformContextPtr(rs, ils, span)
+					tCtx := ottlspan.NewTransformContext(rs, ils, span)
 					skip, err := a.skipExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {

--- a/processor/filterprocessor/internal/condition/logs.go
+++ b/processor/filterprocessor/internal/condition/logs.go
@@ -37,7 +37,7 @@ func (lc LogsConsumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	var condErr error
 	ld.ResourceLogs().RemoveIf(func(rlogs plog.ResourceLogs) bool {
 		if lc.resourceExpr != nil {
-			rCtx := ottlresource.NewTransformContextPtr(rlogs.Resource(), rlogs)
+			rCtx := ottlresource.NewTransformContext(rlogs.Resource(), rlogs)
 			rCond, rErr := lc.resourceExpr.Eval(ctx, rCtx)
 			rCtx.Close()
 			if rErr != nil {
@@ -55,7 +55,7 @@ func (lc LogsConsumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 
 		rlogs.ScopeLogs().RemoveIf(func(slogs plog.ScopeLogs) bool {
 			if lc.scopeExpr != nil {
-				sCtx := ottlscope.NewTransformContextPtr(slogs.Scope(), rlogs.Resource(), slogs, rlogs)
+				sCtx := ottlscope.NewTransformContext(slogs.Scope(), rlogs.Resource(), slogs, rlogs)
 				sCond, sErr := lc.scopeExpr.Eval(ctx, sCtx)
 				sCtx.Close()
 				if sErr != nil {
@@ -69,7 +69,7 @@ func (lc LogsConsumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 
 			if lc.logExpr != nil {
 				slogs.LogRecords().RemoveIf(func(log plog.LogRecord) bool {
-					tCtx := ottllog.NewTransformContextPtr(rlogs, slogs, log)
+					tCtx := ottllog.NewTransformContext(rlogs, slogs, log)
 					cond, err := lc.logExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {

--- a/processor/filterprocessor/internal/condition/metrics.go
+++ b/processor/filterprocessor/internal/condition/metrics.go
@@ -40,7 +40,7 @@ func (mc MetricsConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 	var condErr error
 	md.ResourceMetrics().RemoveIf(func(rm pmetric.ResourceMetrics) bool {
 		if mc.resourceExpr != nil {
-			rCtx := ottlresource.NewTransformContextPtr(rm.Resource(), rm)
+			rCtx := ottlresource.NewTransformContext(rm.Resource(), rm)
 			rCond, rErr := mc.resourceExpr.Eval(ctx, rCtx)
 			rCtx.Close()
 			if rErr != nil {
@@ -58,7 +58,7 @@ func (mc MetricsConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 
 		rm.ScopeMetrics().RemoveIf(func(sm pmetric.ScopeMetrics) bool {
 			if mc.scopeExpr != nil {
-				sCtx := ottlscope.NewTransformContextPtr(sm.Scope(), rm.Resource(), sm, rm)
+				sCtx := ottlscope.NewTransformContext(sm.Scope(), rm.Resource(), sm, rm)
 				sCond, sErr := mc.scopeExpr.Eval(ctx, sCtx)
 				sCtx.Close()
 				if sErr != nil {
@@ -76,7 +76,7 @@ func (mc MetricsConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 
 			sm.Metrics().RemoveIf(func(metric pmetric.Metric) bool {
 				if mc.metricExpr != nil {
-					tCtx := ottlmetric.NewTransformContextPtr(rm, sm, metric)
+					tCtx := ottlmetric.NewTransformContext(rm, sm, metric)
 					mCond, err := mc.metricExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {
@@ -146,7 +146,7 @@ func (mc MetricsConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 func (mc MetricsConsumer) handleNumberDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.NumberDataPointSlice) error {
 	var errors error
 	dps.RemoveIf(func(datapoint pmetric.NumberDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, datapoint)
+		tCtx := ottldatapoint.NewTransformContext(rm, sm, m, datapoint)
 		cond, err := mc.dataPointExpr.Eval(ctx, tCtx)
 		tCtx.Close()
 		if err != nil {
@@ -161,7 +161,7 @@ func (mc MetricsConsumer) handleNumberDataPoints(ctx context.Context, rm pmetric
 func (mc MetricsConsumer) handleHistogramDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.HistogramDataPointSlice) error {
 	var errors error
 	dps.RemoveIf(func(dp pmetric.HistogramDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		tCtx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 		cond, err := mc.dataPointExpr.Eval(ctx, tCtx)
 		tCtx.Close()
 		if err != nil {
@@ -176,7 +176,7 @@ func (mc MetricsConsumer) handleHistogramDataPoints(ctx context.Context, rm pmet
 func (mc MetricsConsumer) handleExponentialHistogramDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.ExponentialHistogramDataPointSlice) error {
 	var errors error
 	dps.RemoveIf(func(dp pmetric.ExponentialHistogramDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		tCtx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 		cond, err := mc.dataPointExpr.Eval(ctx, tCtx)
 		tCtx.Close()
 		if err != nil {
@@ -191,7 +191,7 @@ func (mc MetricsConsumer) handleExponentialHistogramDataPoints(ctx context.Conte
 func (mc MetricsConsumer) handleSummaryDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.SummaryDataPointSlice) error {
 	var errors error
 	dps.RemoveIf(func(dp pmetric.SummaryDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		tCtx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 		cond, err := mc.dataPointExpr.Eval(ctx, tCtx)
 		tCtx.Close()
 		if err != nil {

--- a/processor/filterprocessor/internal/condition/profiles.go
+++ b/processor/filterprocessor/internal/condition/profiles.go
@@ -37,7 +37,7 @@ func (pc ProfilesConsumer) ConsumeProfiles(ctx context.Context, pd pprofile.Prof
 	var condErr error
 	pd.ResourceProfiles().RemoveIf(func(rp pprofile.ResourceProfiles) bool {
 		if pc.resourceExpr != nil {
-			rCtx := ottlresource.NewTransformContextPtr(rp.Resource(), rp)
+			rCtx := ottlresource.NewTransformContext(rp.Resource(), rp)
 			rCond, err := pc.resourceExpr.Eval(ctx, rCtx)
 			rCtx.Close()
 			if err != nil {
@@ -55,7 +55,7 @@ func (pc ProfilesConsumer) ConsumeProfiles(ctx context.Context, pd pprofile.Prof
 
 		rp.ScopeProfiles().RemoveIf(func(sp pprofile.ScopeProfiles) bool {
 			if pc.scopeExpr != nil {
-				sCtx := ottlscope.NewTransformContextPtr(sp.Scope(), rp.Resource(), sp, rp)
+				sCtx := ottlscope.NewTransformContext(sp.Scope(), rp.Resource(), sp, rp)
 				sCond, err := pc.scopeExpr.Eval(ctx, sCtx)
 				sCtx.Close()
 				if err != nil {
@@ -69,7 +69,7 @@ func (pc ProfilesConsumer) ConsumeProfiles(ctx context.Context, pd pprofile.Prof
 
 			if pc.profileExpr != nil {
 				sp.Profiles().RemoveIf(func(profile pprofile.Profile) bool {
-					tCtx := ottlprofile.NewTransformContextPtr(rp, sp, profile, pd.Dictionary())
+					tCtx := ottlprofile.NewTransformContext(rp, sp, profile, pd.Dictionary())
 					cond, err := pc.profileExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {

--- a/processor/filterprocessor/internal/condition/traces.go
+++ b/processor/filterprocessor/internal/condition/traces.go
@@ -40,7 +40,7 @@ func (tc TracesConsumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 	var condErr error
 	td.ResourceSpans().RemoveIf(func(rs ptrace.ResourceSpans) bool {
 		if tc.resourceExpr != nil {
-			rCtx := ottlresource.NewTransformContextPtr(rs.Resource(), rs)
+			rCtx := ottlresource.NewTransformContext(rs.Resource(), rs)
 			rCond, rErr := tc.resourceExpr.Eval(ctx, rCtx)
 			rCtx.Close()
 			if rErr != nil {
@@ -58,7 +58,7 @@ func (tc TracesConsumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 
 		rs.ScopeSpans().RemoveIf(func(ss ptrace.ScopeSpans) bool {
 			if tc.scopeExpr != nil {
-				sCtx := ottlscope.NewTransformContextPtr(ss.Scope(), rs.Resource(), ss, rs)
+				sCtx := ottlscope.NewTransformContext(ss.Scope(), rs.Resource(), ss, rs)
 				sCond, sErr := tc.scopeExpr.Eval(ctx, sCtx)
 				sCtx.Close()
 				if sErr != nil {
@@ -76,7 +76,7 @@ func (tc TracesConsumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 
 			ss.Spans().RemoveIf(func(span ptrace.Span) bool {
 				if tc.spanExpr != nil {
-					spanCtx := ottlspan.NewTransformContextPtr(rs, ss, span)
+					spanCtx := ottlspan.NewTransformContext(rs, ss, span)
 					spanCond, err := tc.spanExpr.Eval(ctx, spanCtx)
 					spanCtx.Close()
 					if err != nil {
@@ -90,7 +90,7 @@ func (tc TracesConsumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 
 				if tc.spanEventExpr != nil {
 					span.Events().RemoveIf(func(spanEvent ptrace.SpanEvent) bool {
-						seCtx := ottlspanevent.NewTransformContextPtr(rs, ss, span, spanEvent)
+						seCtx := ottlspanevent.NewTransformContext(rs, ss, span, spanEvent)
 						seCond, err := tc.spanEventExpr.Eval(ctx, seCtx)
 						seCtx.Close()
 						if err != nil {

--- a/processor/filterprocessor/logs.go
+++ b/processor/filterprocessor/logs.go
@@ -127,7 +127,7 @@ func (flp *filterLogProcessor) processSkipExpression(ctx context.Context, ld plo
 	var errs error
 	ld.ResourceLogs().RemoveIf(func(rl plog.ResourceLogs) bool {
 		if flp.skipResourceExpr != nil {
-			tCtx := ottlresource.NewTransformContextPtr(rl.Resource(), rl)
+			tCtx := ottlresource.NewTransformContext(rl.Resource(), rl)
 			skip, err := flp.skipResourceExpr.Eval(ctx, tCtx)
 			tCtx.Close()
 			if err != nil {
@@ -144,7 +144,7 @@ func (flp *filterLogProcessor) processSkipExpression(ctx context.Context, ld plo
 		rl.ScopeLogs().RemoveIf(func(sl plog.ScopeLogs) bool {
 			lrs := sl.LogRecords()
 			lrs.RemoveIf(func(lr plog.LogRecord) bool {
-				tCtx := ottllog.NewTransformContextPtr(rl, sl, lr)
+				tCtx := ottllog.NewTransformContext(rl, sl, lr)
 				skip, err := flp.skipLogRecordExpr.Eval(ctx, tCtx)
 				tCtx.Close()
 				if err != nil {

--- a/processor/filterprocessor/metrics.go
+++ b/processor/filterprocessor/metrics.go
@@ -182,7 +182,7 @@ func (fmp *filterMetricProcessor) processSkipExpression(ctx context.Context, md 
 	var errs error
 	md.ResourceMetrics().RemoveIf(func(rm pmetric.ResourceMetrics) bool {
 		if fmp.skipResourceExpr != nil {
-			tCtx := ottlresource.NewTransformContextPtr(rm.Resource(), rm)
+			tCtx := ottlresource.NewTransformContext(rm.Resource(), rm)
 			skip, err := fmp.skipResourceExpr.Eval(ctx, tCtx)
 			tCtx.Close()
 			if err != nil {
@@ -199,7 +199,7 @@ func (fmp *filterMetricProcessor) processSkipExpression(ctx context.Context, md 
 		rm.ScopeMetrics().RemoveIf(func(smetrics pmetric.ScopeMetrics) bool {
 			smetrics.Metrics().RemoveIf(func(metric pmetric.Metric) bool {
 				if fmp.skipMetricExpr != nil {
-					tCtx := ottlmetric.NewTransformContextPtr(rm, smetrics, metric)
+					tCtx := ottlmetric.NewTransformContext(rm, smetrics, metric)
 					skip, err := fmp.skipMetricExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {
@@ -315,7 +315,7 @@ func newResExpr(mp *filterconfig.MetricMatchProperties) (expr.BoolExpr[*ottlreso
 func (fmp *filterMetricProcessor) handleNumberDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.NumberDataPointSlice) error {
 	var errs error
 	dps.RemoveIf(func(dp pmetric.NumberDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		tCtx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 		defer tCtx.Close()
 		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
 		if err != nil {
@@ -330,7 +330,7 @@ func (fmp *filterMetricProcessor) handleNumberDataPoints(ctx context.Context, rm
 func (fmp *filterMetricProcessor) handleHistogramDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.HistogramDataPointSlice) error {
 	var errs error
 	dps.RemoveIf(func(dp pmetric.HistogramDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		tCtx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 		defer tCtx.Close()
 		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
 		if err != nil {
@@ -345,7 +345,7 @@ func (fmp *filterMetricProcessor) handleHistogramDataPoints(ctx context.Context,
 func (fmp *filterMetricProcessor) handleExponentialHistogramDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.ExponentialHistogramDataPointSlice) error {
 	var errs error
 	dps.RemoveIf(func(dp pmetric.ExponentialHistogramDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		tCtx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 		defer tCtx.Close()
 		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
 		if err != nil {
@@ -360,7 +360,7 @@ func (fmp *filterMetricProcessor) handleExponentialHistogramDataPoints(ctx conte
 func (fmp *filterMetricProcessor) handleSummaryDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.SummaryDataPointSlice) error {
 	var errs error
 	dps.RemoveIf(func(dp pmetric.SummaryDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		tCtx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 		defer tCtx.Close()
 		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
 		if err != nil {

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -1782,7 +1782,7 @@ func Test_ResourceSkipExpr_With_Bridge(t *testing.T) {
 			resource := pcommon.NewResource()
 			resource.Attributes().PutStr("test", "test")
 
-			tCtx := ottlresource.NewTransformContextPtr(resource, pmetric.NewResourceMetrics())
+			tCtx := ottlresource.NewTransformContext(resource, pmetric.NewResourceMetrics())
 			defer tCtx.Close()
 
 			includeMatchProperties, err := filterconfig.CreateMetricMatchPropertiesFromDefault(tt.condition.Include)

--- a/processor/filterprocessor/profiles.go
+++ b/processor/filterprocessor/profiles.go
@@ -110,7 +110,7 @@ func (fpp *filterProfileProcessor) processSkipExpression(ctx context.Context, pd
 	pd.ResourceProfiles().RemoveIf(func(rp pprofile.ResourceProfiles) bool {
 		resource := rp.Resource()
 		if fpp.skipResourceExpr != nil {
-			tCtx := ottlresource.NewTransformContextPtr(resource, rp)
+			tCtx := ottlresource.NewTransformContext(resource, rp)
 			skip, err := fpp.skipResourceExpr.Eval(ctx, tCtx)
 			tCtx.Close()
 			if err != nil {
@@ -126,7 +126,7 @@ func (fpp *filterProfileProcessor) processSkipExpression(ctx context.Context, pd
 		}
 		rp.ScopeProfiles().RemoveIf(func(sp pprofile.ScopeProfiles) bool {
 			sp.Profiles().RemoveIf(func(profile pprofile.Profile) bool {
-				tCtx := ottlprofile.NewTransformContextPtr(rp, sp, profile, dic)
+				tCtx := ottlprofile.NewTransformContext(rp, sp, profile, dic)
 				defer tCtx.Close()
 				skip, err := fpp.skipProfileExpr.Eval(ctx, tCtx)
 				if err != nil {

--- a/processor/filterprocessor/traces.go
+++ b/processor/filterprocessor/traces.go
@@ -143,7 +143,7 @@ func (fsp *filterSpanProcessor) processSkipExpression(ctx context.Context, td pt
 	td.ResourceSpans().RemoveIf(func(rs ptrace.ResourceSpans) bool {
 		resource := rs.Resource()
 		if fsp.skipResourceExpr != nil {
-			tCtx := ottlresource.NewTransformContextPtr(resource, rs)
+			tCtx := ottlresource.NewTransformContext(resource, rs)
 			skip, err := fsp.skipResourceExpr.Eval(ctx, tCtx)
 			tCtx.Close()
 			if err != nil {
@@ -160,7 +160,7 @@ func (fsp *filterSpanProcessor) processSkipExpression(ctx context.Context, td pt
 		rs.ScopeSpans().RemoveIf(func(ss ptrace.ScopeSpans) bool {
 			ss.Spans().RemoveIf(func(span ptrace.Span) bool {
 				if fsp.skipSpanExpr != nil {
-					tCtx := ottlspan.NewTransformContextPtr(rs, ss, span)
+					tCtx := ottlspan.NewTransformContext(rs, ss, span)
 					skip, err := fsp.skipSpanExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {
@@ -173,7 +173,7 @@ func (fsp *filterSpanProcessor) processSkipExpression(ctx context.Context, td pt
 				}
 				if fsp.skipSpanEventExpr != nil {
 					span.Events().RemoveIf(func(spanEvent ptrace.SpanEvent) bool {
-						tCtx := ottlspanevent.NewTransformContextPtr(rs, ss, span, spanEvent)
+						tCtx := ottlspanevent.NewTransformContext(rs, ss, span, spanEvent)
 						skip, err := fsp.skipSpanEventExpr.Eval(ctx, tCtx)
 						tCtx.Close()
 						if err != nil {

--- a/processor/logdedupprocessor/processor.go
+++ b/processor/logdedupprocessor/processor.go
@@ -260,7 +260,7 @@ func (p *logDedupProcessor) ConsumeLogs(ctx context.Context, pl plog.Logs) error
 					return true
 				}
 
-				logCtx := ottllog.NewTransformContextPtr(rl, sl, logRecord)
+				logCtx := ottllog.NewTransformContext(rl, sl, logRecord)
 				defer logCtx.Close()
 				logMatch, err := p.conditions.Eval(ctx, logCtx)
 				if err != nil {

--- a/processor/lookupprocessor/processor.go
+++ b/processor/lookupprocessor/processor.go
@@ -116,7 +116,7 @@ func (p *logsLookupProcessor) processLogs(ctx context.Context, ld plog.Logs) (pl
 			sl := rl.ScopeLogs().At(j)
 			for k := 0; k < sl.LogRecords().Len(); k++ {
 				lr := sl.LogRecords().At(k)
-				tCtx := ottllog.NewTransformContextPtr(rl, sl, lr)
+				tCtx := ottllog.NewTransformContext(rl, sl, lr)
 				p.evalAndProcess(ctx, tCtx, lr.Attributes(), resourceAttrs)
 				tCtx.Close()
 			}
@@ -137,7 +137,7 @@ func (p *tracesLookupProcessor) processTraces(ctx context.Context, td ptrace.Tra
 			ss := rs.ScopeSpans().At(j)
 			for k := 0; k < ss.Spans().Len(); k++ {
 				span := ss.Spans().At(k)
-				tCtx := ottlspan.NewTransformContextPtr(rs, ss, span)
+				tCtx := ottlspan.NewTransformContext(rs, ss, span)
 				p.evalAndProcess(ctx, tCtx, span.Attributes(), resourceAttrs)
 				tCtx.Close()
 			}
@@ -198,7 +198,7 @@ func processDataPoints[DP dataPointWithAttributes](
 ) {
 	for i := 0; i < dps.Len(); i++ {
 		dp := dps.At(i)
-		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		tCtx := ottldatapoint.NewTransformContext(rm, sm, m, dp)
 		p.evalAndProcess(ctx, tCtx, dp.Attributes(), resourceAttrs)
 		tCtx.Close()
 	}

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -77,7 +77,7 @@ func (sp *spanProcessor) processTraces(ctx context.Context, td ptrace.Traces) (p
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
 				if sp.skipExpr != nil {
-					tCtx := ottlspan.NewTransformContextPtr(rs, ils, span)
+					tCtx := ottlspan.NewTransformContext(rs, ils, span)
 					skip, err := sp.skipExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {

--- a/processor/spanpruningprocessor/processor.go
+++ b/processor/spanpruningprocessor/processor.go
@@ -255,7 +255,7 @@ func (p *spanPruningProcessor) traceMatchesConditions(ctx context.Context, spans
 	}
 
 	for _, si := range spans {
-		tCtx := ottlspan.NewTransformContextPtr(si.resourceSpans, si.scopeSpans, si.span)
+		tCtx := ottlspan.NewTransformContext(si.resourceSpans, si.scopeSpans, si.span)
 		matches, err := p.conditions.Eval(ctx, tCtx)
 		tCtx.Close()
 		if err != nil {

--- a/processor/tailsamplingprocessor/internal/sampling/ottl.go
+++ b/processor/tailsamplingprocessor/internal/sampling/ottl.go
@@ -86,7 +86,7 @@ func (ocf *ottlConditionFilter) Evaluate(ctx context.Context, traceID pcommon.Tr
 
 				// Span evaluation
 				if ocf.sampleSpanExpr != nil {
-					tCtx := ottlspan.NewTransformContextPtr(rs, ss, span)
+					tCtx := ottlspan.NewTransformContext(rs, ss, span)
 					ok, err = ocf.sampleSpanExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {
@@ -101,7 +101,7 @@ func (ocf *ottlConditionFilter) Evaluate(ctx context.Context, traceID pcommon.Tr
 				if ocf.sampleSpanEventExpr != nil {
 					spanEvents := span.Events()
 					for l := 0; l < spanEvents.Len(); l++ {
-						tCtx := ottlspanevent.NewTransformContextPtr(rs, ss, span, spanEvents.At(l))
+						tCtx := ottlspanevent.NewTransformContext(rs, ss, span, spanEvents.At(l))
 						ok, err = ocf.sampleSpanEventExpr.Eval(ctx, tCtx)
 						tCtx.Close()
 						if err != nil {

--- a/processor/transformprocessor/internal/common/logs.go
+++ b/processor/transformprocessor/internal/common/logs.go
@@ -37,7 +37,7 @@ func (l logStatements) ConsumeLogs(ctx context.Context, ld plog.Logs, cache *pco
 			slogs := rlogs.ScopeLogs().At(j)
 			logs := slogs.LogRecords()
 			for k := 0; k < logs.Len(); k++ {
-				tCtx := ottllog.NewTransformContextPtr(rlogs, slogs, logs.At(k), ottllog.WithCache(cache))
+				tCtx := ottllog.NewTransformContext(rlogs, slogs, logs.At(k), ottllog.WithCache(cache))
 				condition, err := l.Eval(ctx, tCtx)
 				if err != nil {
 					tCtx.Close()

--- a/processor/transformprocessor/internal/common/metrics.go
+++ b/processor/transformprocessor/internal/common/metrics.go
@@ -39,7 +39,7 @@ func (m metricStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 			smetrics := rmetrics.ScopeMetrics().At(j)
 			metrics := smetrics.Metrics()
 			for k := 0; k < metrics.Len(); k++ {
-				tCtx := ottlmetric.NewTransformContextPtr(rmetrics, smetrics, metrics.At(k), ottlmetric.WithCache(cache))
+				tCtx := ottlmetric.NewTransformContext(rmetrics, smetrics, metrics.At(k), ottlmetric.WithCache(cache))
 				condition, err := m.Eval(ctx, tCtx)
 				if err != nil {
 					tCtx.Close()
@@ -101,7 +101,7 @@ func (d dataPointStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metr
 
 func (d dataPointStatements) handleNumberDataPoints(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.NumberDataPointSlice, cache *pcommon.Map) error {
 	for i := 0; i < dps.Len(); i++ {
-		tCtx := ottldatapoint.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dps.At(i), ottldatapoint.WithCache(cache))
+		tCtx := ottldatapoint.NewTransformContext(resourceMetrics, scopeMetrics, metric, dps.At(i), ottldatapoint.WithCache(cache))
 		condition, err := d.Eval(ctx, tCtx)
 		if err != nil {
 			tCtx.Close()
@@ -121,7 +121,7 @@ func (d dataPointStatements) handleNumberDataPoints(ctx context.Context, resourc
 
 func (d dataPointStatements) handleHistogramDataPoints(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.HistogramDataPointSlice, cache *pcommon.Map) error {
 	for i := 0; i < dps.Len(); i++ {
-		tCtx := ottldatapoint.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dps.At(i), ottldatapoint.WithCache(cache))
+		tCtx := ottldatapoint.NewTransformContext(resourceMetrics, scopeMetrics, metric, dps.At(i), ottldatapoint.WithCache(cache))
 		condition, err := d.Eval(ctx, tCtx)
 		if err != nil {
 			tCtx.Close()
@@ -141,7 +141,7 @@ func (d dataPointStatements) handleHistogramDataPoints(ctx context.Context, reso
 
 func (d dataPointStatements) handleExponentialHistogramDataPoints(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.ExponentialHistogramDataPointSlice, cache *pcommon.Map) error {
 	for i := 0; i < dps.Len(); i++ {
-		tCtx := ottldatapoint.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dps.At(i), ottldatapoint.WithCache(cache))
+		tCtx := ottldatapoint.NewTransformContext(resourceMetrics, scopeMetrics, metric, dps.At(i), ottldatapoint.WithCache(cache))
 		condition, err := d.Eval(ctx, tCtx)
 		if err != nil {
 			tCtx.Close()
@@ -161,7 +161,7 @@ func (d dataPointStatements) handleExponentialHistogramDataPoints(ctx context.Co
 
 func (d dataPointStatements) handleSummaryDataPoints(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.SummaryDataPointSlice, cache *pcommon.Map) error {
 	for i := 0; i < dps.Len(); i++ {
-		tCtx := ottldatapoint.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dps.At(i), ottldatapoint.WithCache(cache))
+		tCtx := ottldatapoint.NewTransformContext(resourceMetrics, scopeMetrics, metric, dps.At(i), ottldatapoint.WithCache(cache))
 		condition, err := d.Eval(ctx, tCtx)
 		if err != nil {
 			tCtx.Close()
@@ -217,7 +217,7 @@ func (e exemplarStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 func (e exemplarStatements) handleNumberDataPointExemplars(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.NumberDataPointSlice, cache *pcommon.Map) error {
 	for _, dp := range dps.All() {
 		for _, exemplar := range dp.Exemplars().All() {
-			tCtx := ottlexemplar.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dp, exemplar, ottlexemplar.WithCache(cache))
+			tCtx := ottlexemplar.NewTransformContext(resourceMetrics, scopeMetrics, metric, dp, exemplar, ottlexemplar.WithCache(cache))
 			if err := e.executeExemplar(ctx, tCtx); err != nil {
 				return err
 			}
@@ -229,7 +229,7 @@ func (e exemplarStatements) handleNumberDataPointExemplars(ctx context.Context, 
 func (e exemplarStatements) handleHistogramDataPointExemplars(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.HistogramDataPointSlice, cache *pcommon.Map) error {
 	for _, dp := range dps.All() {
 		for _, exemplar := range dp.Exemplars().All() {
-			tCtx := ottlexemplar.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dp, exemplar, ottlexemplar.WithCache(cache))
+			tCtx := ottlexemplar.NewTransformContext(resourceMetrics, scopeMetrics, metric, dp, exemplar, ottlexemplar.WithCache(cache))
 			if err := e.executeExemplar(ctx, tCtx); err != nil {
 				return err
 			}
@@ -241,7 +241,7 @@ func (e exemplarStatements) handleHistogramDataPointExemplars(ctx context.Contex
 func (e exemplarStatements) handleExponentialHistogramDataPointExemplars(ctx context.Context, resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, dps pmetric.ExponentialHistogramDataPointSlice, cache *pcommon.Map) error {
 	for _, dp := range dps.All() {
 		for _, exemplar := range dp.Exemplars().All() {
-			tCtx := ottlexemplar.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric, dp, exemplar, ottlexemplar.WithCache(cache))
+			tCtx := ottlexemplar.NewTransformContext(resourceMetrics, scopeMetrics, metric, dp, exemplar, ottlexemplar.WithCache(cache))
 			if err := e.executeExemplar(ctx, tCtx); err != nil {
 				return err
 			}

--- a/processor/transformprocessor/internal/common/processor.go
+++ b/processor/transformprocessor/internal/common/processor.go
@@ -33,7 +33,7 @@ func (resourceStatements) Context() ContextID {
 
 func (r resourceStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces, cache *pcommon.Map) error {
 	for _, rspans := range td.ResourceSpans().All() {
-		tCtx := ottlresource.NewTransformContextPtr(rspans.Resource(), rspans, ottlresource.WithCache(cache))
+		tCtx := ottlresource.NewTransformContext(rspans.Resource(), rspans, ottlresource.WithCache(cache))
 		condition, err := r.Eval(ctx, tCtx)
 		if err != nil {
 			tCtx.Close()
@@ -53,7 +53,7 @@ func (r resourceStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces,
 
 func (r resourceStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metrics, cache *pcommon.Map) error {
 	for _, rmetrics := range md.ResourceMetrics().All() {
-		tCtx := ottlresource.NewTransformContextPtr(rmetrics.Resource(), rmetrics, ottlresource.WithCache(cache))
+		tCtx := ottlresource.NewTransformContext(rmetrics.Resource(), rmetrics, ottlresource.WithCache(cache))
 		condition, err := r.Eval(ctx, tCtx)
 		if err != nil {
 			tCtx.Close()
@@ -73,7 +73,7 @@ func (r resourceStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 
 func (r resourceStatements) ConsumeLogs(ctx context.Context, ld plog.Logs, cache *pcommon.Map) error {
 	for _, rlogs := range ld.ResourceLogs().All() {
-		tCtx := ottlresource.NewTransformContextPtr(rlogs.Resource(), rlogs, ottlresource.WithCache(cache))
+		tCtx := ottlresource.NewTransformContext(rlogs.Resource(), rlogs, ottlresource.WithCache(cache))
 		condition, err := r.Eval(ctx, tCtx)
 		if err != nil {
 			tCtx.Close()
@@ -93,7 +93,7 @@ func (r resourceStatements) ConsumeLogs(ctx context.Context, ld plog.Logs, cache
 
 func (r resourceStatements) ConsumeProfiles(ctx context.Context, ld pprofile.Profiles, cache *pcommon.Map) error {
 	for _, rprofiles := range ld.ResourceProfiles().All() {
-		tCtx := ottlresource.NewTransformContextPtr(rprofiles.Resource(), rprofiles, ottlresource.WithCache(cache))
+		tCtx := ottlresource.NewTransformContext(rprofiles.Resource(), rprofiles, ottlresource.WithCache(cache))
 		condition, err := r.Eval(ctx, tCtx)
 		if err != nil {
 			tCtx.Close()
@@ -125,7 +125,7 @@ func (scopeStatements) Context() ContextID {
 func (s scopeStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces, cache *pcommon.Map) error {
 	for _, rspans := range td.ResourceSpans().All() {
 		for _, sspans := range rspans.ScopeSpans().All() {
-			tCtx := ottlscope.NewTransformContextPtr(sspans.Scope(), rspans.Resource(), sspans, rspans, ottlscope.WithCache(cache))
+			tCtx := ottlscope.NewTransformContext(sspans.Scope(), rspans.Resource(), sspans, rspans, ottlscope.WithCache(cache))
 			condition, err := s.Eval(ctx, tCtx)
 			if err != nil {
 				tCtx.Close()
@@ -147,7 +147,7 @@ func (s scopeStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces, ca
 func (s scopeStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metrics, cache *pcommon.Map) error {
 	for _, rmetrics := range md.ResourceMetrics().All() {
 		for _, smetrics := range rmetrics.ScopeMetrics().All() {
-			tCtx := ottlscope.NewTransformContextPtr(smetrics.Scope(), rmetrics.Resource(), smetrics, rmetrics, ottlscope.WithCache(cache))
+			tCtx := ottlscope.NewTransformContext(smetrics.Scope(), rmetrics.Resource(), smetrics, rmetrics, ottlscope.WithCache(cache))
 			condition, err := s.Eval(ctx, tCtx)
 			if err != nil {
 				tCtx.Close()
@@ -169,7 +169,7 @@ func (s scopeStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metrics,
 func (s scopeStatements) ConsumeLogs(ctx context.Context, ld plog.Logs, cache *pcommon.Map) error {
 	for _, rlogs := range ld.ResourceLogs().All() {
 		for _, slogs := range rlogs.ScopeLogs().All() {
-			tCtx := ottlscope.NewTransformContextPtr(slogs.Scope(), rlogs.Resource(), slogs, rlogs, ottlscope.WithCache(cache))
+			tCtx := ottlscope.NewTransformContext(slogs.Scope(), rlogs.Resource(), slogs, rlogs, ottlscope.WithCache(cache))
 			condition, err := s.Eval(ctx, tCtx)
 			if err != nil {
 				tCtx.Close()
@@ -191,7 +191,7 @@ func (s scopeStatements) ConsumeLogs(ctx context.Context, ld plog.Logs, cache *p
 func (s scopeStatements) ConsumeProfiles(ctx context.Context, ld pprofile.Profiles, cache *pcommon.Map) error {
 	for _, rprofiles := range ld.ResourceProfiles().All() {
 		for _, sprofiles := range rprofiles.ScopeProfiles().All() {
-			tCtx := ottlscope.NewTransformContextPtr(sprofiles.Scope(), rprofiles.Resource(), sprofiles, rprofiles, ottlscope.WithCache(cache))
+			tCtx := ottlscope.NewTransformContext(sprofiles.Scope(), rprofiles.Resource(), sprofiles, rprofiles, ottlscope.WithCache(cache))
 			condition, err := s.Eval(ctx, tCtx)
 			if err != nil {
 				tCtx.Close()

--- a/processor/transformprocessor/internal/common/profiles.go
+++ b/processor/transformprocessor/internal/common/profiles.go
@@ -35,7 +35,7 @@ func (l profileStatements) ConsumeProfiles(ctx context.Context, ld pprofile.Prof
 	for _, rprofiles := range ld.ResourceProfiles().All() {
 		for _, sprofiles := range rprofiles.ScopeProfiles().All() {
 			for _, profile := range sprofiles.Profiles().All() {
-				tCtx := ottlprofile.NewTransformContextPtr(rprofiles, sprofiles, profile, dic, ottlprofile.WithCache(cache))
+				tCtx := ottlprofile.NewTransformContext(rprofiles, sprofiles, profile, dic, ottlprofile.WithCache(cache))
 				condition, err := l.Eval(ctx, tCtx)
 				if err != nil {
 					tCtx.Close()

--- a/processor/transformprocessor/internal/common/traces.go
+++ b/processor/transformprocessor/internal/common/traces.go
@@ -38,7 +38,7 @@ func (t traceStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces, ca
 			sspans := rspans.ScopeSpans().At(j)
 			spans := sspans.Spans()
 			for k := 0; k < spans.Len(); k++ {
-				tCtx := ottlspan.NewTransformContextPtr(rspans, sspans, spans.At(k), ottlspan.WithCache(cache))
+				tCtx := ottlspan.NewTransformContext(rspans, sspans, spans.At(k), ottlspan.WithCache(cache))
 				condition, err := t.Eval(ctx, tCtx)
 				if err != nil {
 					tCtx.Close()
@@ -77,7 +77,7 @@ func (s spanEventStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces
 				span := spans.At(k)
 				spanEvents := span.Events()
 				for n := 0; n < spanEvents.Len(); n++ {
-					tCtx := ottlspanevent.NewTransformContextPtr(rspans, sspans, span, spanEvents.At(n), ottlspanevent.WithCache(cache))
+					tCtx := ottlspanevent.NewTransformContext(rspans, sspans, span, spanEvents.At(n), ottlspanevent.WithCache(cache))
 					condition, err := s.Eval(ctx, tCtx)
 					if err != nil {
 						tCtx.Close()

--- a/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
@@ -317,7 +317,7 @@ func Test_aggregateOnAttributes(t *testing.T) {
 			evaluate, err := AggregateOnAttributes(tt.t, tt.attributes)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input)
 			_, err = evaluate(nil, tCtx)
 			tCtx.Close()
 			assert.Equal(t, tt.wantErr, err)

--- a/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics_test.go
@@ -486,7 +486,7 @@ func Test_aggregateOnAttributeValues(t *testing.T) {
 			evaluate, err := AggregateOnAttributeValue(tt.t, tt.attribute, tt.values, tt.newValue)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input)
 			_, err = evaluate(t.Context(), tCtx)
 			tCtx.Close()
 			require.NoError(t, err)

--- a/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
@@ -253,7 +253,7 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			ctx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
@@ -436,7 +436,7 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			ctx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
@@ -566,7 +566,7 @@ func TestUniform_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			ctx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
@@ -696,7 +696,7 @@ func TestRandom_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			ctx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
@@ -115,7 +115,7 @@ func Test_convertGaugeToSum(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input.CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			ctx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, _ := convertGaugeToSum(tt.stringAggTemp, tt.monotonic)

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
@@ -83,7 +83,7 @@ func Test_convertSumToGauge(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input.CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
+			ctx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, _ := convertSumToGauge()

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
@@ -120,7 +120,7 @@ func Test_ConvertSummaryCountValToSum(t *testing.T) {
 			evaluate, err := convertSummaryCountValToSum(tt.temporality, tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottldatapoint.NewTransformContextPtr(pmetric.NewResourceMetrics(), smetrics, smetrics.Metrics().At(0), pmetric.NewNumberDataPoint())
+			tCtx := ottldatapoint.NewTransformContext(pmetric.NewResourceMetrics(), smetrics, smetrics.Metrics().At(0), pmetric.NewNumberDataPoint())
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			require.NoError(t, err)

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge_test.go
@@ -129,7 +129,7 @@ func Test_ConvertSummaryQuantileValToGauge(t *testing.T) {
 			evaluate, err := convertSummaryQuantileValToGauge(tt.key, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), sMetrics, sMetrics.Metrics().At(0))
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), sMetrics, sMetrics.Metrics().At(0))
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			require.NoError(t, err)

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
@@ -130,7 +130,7 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 			evaluate, err := convertSummarySumValToSum(tt.temporality, tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottldatapoint.NewTransformContextPtr(pmetric.NewResourceMetrics(), sMetrics, sMetrics.Metrics().At(0), pmetric.NewNumberDataPoint())
+			tCtx := ottldatapoint.NewTransformContext(pmetric.NewResourceMetrics(), sMetrics, sMetrics.Metrics().At(0), pmetric.NewNumberDataPoint())
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			require.NoError(t, err)

--- a/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
@@ -126,7 +126,7 @@ func Test_copyMetric(t *testing.T) {
 
 			exprFunc, err := copyMetric(tt.name, tt.desc, tt.unit)
 			require.NoError(t, err)
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), ms, input)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), ms, input)
 			defer tCtx.Close()
 			_, err = exprFunc(t.Context(), tCtx)
 			require.NoError(t, err)

--- a/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
@@ -180,7 +180,7 @@ func Test_extractCountMetric(t *testing.T) {
 			evaluate, err := extractCountMetric(tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), sMetrics, tt.input)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), sMetrics, tt.input)
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			assert.Equal(t, tt.wantErr, err)

--- a/processor/transformprocessor/internal/metrics/func_extract_percentile_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_percentile_metric_test.go
@@ -167,7 +167,7 @@ func Test_extractPercentileMetric_SkippedMetricTypes(t *testing.T) {
 			scopeMetrics := pmetric.NewScopeMetrics()
 			metric.CopyTo(scopeMetrics.Metrics().AppendEmpty())
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), scopeMetrics, metric)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), scopeMetrics, metric)
 
 			_, err = exprFunc(t.Context(), tCtx)
 			require.NoError(t, err)
@@ -367,7 +367,7 @@ func Test_extractPercentileMetric_Histogram(t *testing.T) {
 			scopeMetrics := pmetric.NewScopeMetrics()
 			metric.CopyTo(scopeMetrics.Metrics().AppendEmpty())
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), scopeMetrics, metric)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), scopeMetrics, metric)
 
 			_, err = exprFunc(t.Context(), tCtx)
 			require.NoError(t, err)
@@ -610,7 +610,7 @@ func Test_extractPercentileMetric_ExponentialHistogram(t *testing.T) {
 			scopeMetrics := pmetric.NewScopeMetrics()
 			metric.CopyTo(scopeMetrics.Metrics().AppendEmpty())
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), scopeMetrics, metric)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), scopeMetrics, metric)
 
 			_, err = exprFunc(t.Context(), tCtx)
 			require.NoError(t, err)
@@ -717,7 +717,7 @@ func Test_extractPercentileMetric_MalformedData(t *testing.T) {
 			scopeMetrics := pmetric.NewScopeMetrics()
 			metric.CopyTo(scopeMetrics.Metrics().AppendEmpty())
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), scopeMetrics, metric)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), scopeMetrics, metric)
 
 			_, err = exprFunc(t.Context(), tCtx)
 			assert.EqualError(t, err, tt.wantErr)

--- a/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
@@ -308,7 +308,7 @@ func Test_extractSumMetric(t *testing.T) {
 			evaluate, err := extractSumMetric(tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), sMetrics, tt.input)
+			tCtx := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), sMetrics, tt.input)
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			assert.Equal(t, tt.wantErr, err)

--- a/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
+++ b/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
@@ -231,7 +231,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			dp.BucketCounts().FromRaw(tt.inputCounts)
 			dp.ExplicitBounds().FromRaw(tt.inputBounds)
 
-			ctx := ottldatapoint.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric, dp)
+			ctx := ottldatapoint.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric, dp)
 			defer ctx.Close()
 
 			result, err := exprFunc(t.Context(), ctx)
@@ -287,7 +287,7 @@ func TestMergeHistogramBucketsNonHistogramDataPoint(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exprFunc)
 
-	ctx := ottldatapoint.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric, dp)
+	ctx := ottldatapoint.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric, dp)
 	defer ctx.Close()
 	result, err := exprFunc(t.Context(), ctx)
 

--- a/processor/transformprocessor/internal/metrics/func_scale_test.go
+++ b/processor/transformprocessor/internal/metrics/func_scale_test.go
@@ -161,7 +161,7 @@ func TestScale(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			target := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.valueFunc())
+			target := ottlmetric.NewTransformContext(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.valueFunc())
 			defer target.Close()
 
 			expressionFunc, _ := Scale(tt.args)

--- a/processor/transformprocessor/internal/traces/func_set_semconv_span_name_test.go
+++ b/processor/transformprocessor/internal/traces/func_set_semconv_span_name_test.go
@@ -529,7 +529,7 @@ VALUES (@p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16);
 			require.NoError(t, err)
 			require.NotNil(t, setSemconvNameFunction)
 
-			tCtx := ottlspan.NewTransformContextPtr(resourceSpans, scopeSpans, span)
+			tCtx := ottlspan.NewTransformContext(resourceSpans, scopeSpans, span)
 			defer tCtx.Close()
 			_, err = setSemconvNameFunction(t.Context(), tCtx)
 			require.NoError(t, err)


### PR DESCRIPTION
#### Description

Finishes the pointer change by renaming all the `NewTransformContextPtr` functions to `NewTransformContext`

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
