### PR TITLE
[pkg/ottl]: promote ottl.PanicDuplicateName feature gate to stable

### DIFF
--- a/.chloggen/ottl-panic-duplicate-name-stable.yaml
+++ b/.chloggen/ottl-panic-duplicate-name-stable.yaml
@@ -10,7 +10,7 @@ component: pkg/ottl
 note: Promote the `ottl.PanicDuplicateName` feature gate to stable.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [44630]
+issues: [50873]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/ottl-panic-duplicate-name-stable.yaml
+++ b/.chloggen/ottl-panic-duplicate-name-stable.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote the `ottl.PanicDuplicateName` feature gate to stable.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44630]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/documentation.md
+++ b/pkg/ottl/documentation.md
@@ -8,7 +8,7 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `ottl.PanicDuplicateName` | stable | When enabled, the CreateFactoryMap panics if the name is duplicated. | v0.141.0 | v0.160.0 | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630) |
+| `ottl.PanicDuplicateName` | stable | When enabled, the CreateFactoryMap panics if the name is duplicated. | v0.141.0 | v0.161.0 | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630) |
 | `ottl.contexts.enableOTelColContext` | beta | Enable the `otelcol` context for OTTL. This allows users using `otelcol.*` paths in their OTTL statements and conditions. | v0.147.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46437) |
 | `ottl.functions.enableLambda` | alpha | Allow OTTL functions to take lambda arguments. When disabled, lambda arguments are rejected. | v0.155.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48227) |
 | `ottl.set.allowNil` | alpha | When enabled, the set function passes nil values directly to the target. | v0.158.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49741) |

--- a/pkg/ottl/documentation.md
+++ b/pkg/ottl/documentation.md
@@ -8,7 +8,7 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `ottl.PanicDuplicateName` | beta | When enabled, the CreateFactoryMap panics if the name is duplicated. | v0.141.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630) |
+| `ottl.PanicDuplicateName` | stable | When enabled, the CreateFactoryMap panics if the name is duplicated. | v0.141.0 | v0.160.0 | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630) |
 | `ottl.contexts.enableOTelColContext` | beta | Enable the `otelcol` context for OTTL. This allows users using `otelcol.*` paths in their OTTL statements and conditions. | v0.147.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46437) |
 | `ottl.functions.enableLambda` | alpha | Allow OTTL functions to take lambda arguments. When disabled, lambda arguments are rejected. | v0.155.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48227) |
 | `ottl.set.allowNil` | alpha | When enabled, the set function passes nil values directly to the target. | v0.158.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/49741) |

--- a/pkg/ottl/factory.go
+++ b/pkg/ottl/factory.go
@@ -5,8 +5,6 @@ package ottl // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"go.opentelemetry.io/collector/component"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/metadata"
 )
 
 // Arguments holds the arguments for an OTTL function, with arguments
@@ -84,10 +82,8 @@ func CreateFactoryMap[K any](factories ...Factory[K]) map[string]Factory[K] {
 	factoryMap := map[string]Factory[K]{}
 
 	for _, fn := range factories {
-		if metadata.OttlPanicDuplicateNameFeatureGate.IsEnabled() {
-			if _, ok := factoryMap[fn.Name()]; ok {
-				panic("duplicate factory name: " + fn.Name())
-			}
+		if _, ok := factoryMap[fn.Name()]; ok {
+			panic("duplicate factory name: " + fn.Name())
 		}
 		factoryMap[fn.Name()] = fn
 	}

--- a/pkg/ottl/internal/metadata/generated_feature_gates.go
+++ b/pkg/ottl/internal/metadata/generated_feature_gates.go
@@ -12,7 +12,7 @@ var OttlPanicDuplicateNameFeatureGate = featuregate.GlobalRegistry().MustRegiste
 	featuregate.WithRegisterDescription("When enabled, the CreateFactoryMap panics if the name is duplicated."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630"),
 	featuregate.WithRegisterFromVersion("v0.141.0"),
-	featuregate.WithRegisterToVersion("v0.160.0"),
+	featuregate.WithRegisterToVersion("v0.161.0"),
 )
 
 var OttlContextsEnableOTelColContextFeatureGate = featuregate.GlobalRegistry().MustRegister(

--- a/pkg/ottl/internal/metadata/generated_feature_gates.go
+++ b/pkg/ottl/internal/metadata/generated_feature_gates.go
@@ -8,10 +8,11 @@ import (
 
 var OttlPanicDuplicateNameFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"ottl.PanicDuplicateName",
-	featuregate.StageBeta,
+	featuregate.StageStable,
 	featuregate.WithRegisterDescription("When enabled, the CreateFactoryMap panics if the name is duplicated."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630"),
 	featuregate.WithRegisterFromVersion("v0.141.0"),
+	featuregate.WithRegisterToVersion("v0.160.0"),
 )
 
 var OttlContextsEnableOTelColContextFeatureGate = featuregate.GlobalRegistry().MustRegister(

--- a/pkg/ottl/metadata.yaml
+++ b/pkg/ottl/metadata.yaml
@@ -14,8 +14,9 @@ status:
 feature_gates:
   - id: "ottl.PanicDuplicateName"
     description: When enabled, the CreateFactoryMap panics if the name is duplicated.
-    stage: beta
+    stage: stable
     from_version: v0.141.0
+    to_version: v0.160.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630
 
   - id: "ottl.contexts.enableOTelColContext"

--- a/pkg/ottl/metadata.yaml
+++ b/pkg/ottl/metadata.yaml
@@ -16,7 +16,7 @@ feature_gates:
     description: When enabled, the CreateFactoryMap panics if the name is duplicated.
     stage: stable
     from_version: v0.141.0
-    to_version: v0.160.0
+    to_version: v0.161.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44630
 
   - id: "ottl.contexts.enableOTelColContext"


### PR DESCRIPTION
#### Description

promote ottl.PanicDuplicateName feature gate to stable. We want this feature in the API permanently. 

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
