### PR TITLE
[exporter/clickhouse] Upgrade traces table with text indices, improved compression

### DIFF
--- a/.chloggen/clickhouseexporter-traces-schema-upgrade.yaml
+++ b/.chloggen/clickhouseexporter-traces-schema-upgrade.yaml
@@ -10,7 +10,7 @@ component: exporter/clickhouse
 note: Upgrade trace table with better compression, text indices
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50878]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/clickhouseexporter-traces-schema-upgrade.yaml
+++ b/.chloggen/clickhouseexporter-traces-schema-upgrade.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Upgrade trace table with better compression, text indices
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/clickhouseexporter/README.md
+++ b/exporter/clickhouseexporter/README.md
@@ -163,6 +163,14 @@ LIMIT 100;
 
 ### Traces
 
+> [!NOTE]
+> On ClickHouse 26.2 or newer, the traces table is created with `text` (full-text-search) indexes on
+> `TraceId`, the attribute map keys, and the attribute items columns; on older servers it falls back
+> to `bloom_filter` indexes. The table also exposes zero-storage
+> `ResourceAttributeItems`/`SpanAttributeItems` ALIAS columns that render attributes as `key=value`
+> arrays for exact-match lookups, e.g.
+> `WHERE has(SpanAttributeItems, 'peer.service=telemetrygen-server')`.
+
 - Find spans with specific attribute.
 
 ```sql

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -286,6 +286,25 @@ func (cfg *Config) tableEngineString() string {
 	return fmt.Sprintf("%s(%s)", engine, params)
 }
 
+// traceIDTsTableEngineString generates the ENGINE string for the trace ID timestamp lookup
+// table, which requires an aggregating engine to collapse rows with the same TraceId.
+func (cfg *Config) traceIDTsTableEngineString() string {
+	engine := cfg.TableEngine.Name
+	params := cfg.TableEngine.Params
+
+	switch engine {
+	case "":
+		engine = "AggregatingMergeTree"
+		params = ""
+	case defaultTableEngineName:
+		engine = "AggregatingMergeTree"
+	case "ReplicatedMergeTree":
+		engine = "ReplicatedAggregatingMergeTree"
+	}
+
+	return fmt.Sprintf("%s(%s)", engine, params)
+}
+
 // database returns the preferred database for creating tables and inserting data.
 // The config option takes precedence over the DSN's settings.
 // Falls back to default if neither are set.

--- a/exporter/clickhouseexporter/exporter_traces.go
+++ b/exporter/clickhouseexporter/exporter_traces.go
@@ -4,12 +4,14 @@
 package clickhouseexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter"
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
@@ -51,7 +53,7 @@ func (e *tracesExporter) start(ctx context.Context, _ component.Host) error {
 			return err
 		}
 
-		if err := createTraceTables(ctx, e.cfg, e.db); err != nil {
+		if err := createTraceTables(ctx, e.cfg, e.db, e.logger); err != nil {
 			return err
 		}
 	}
@@ -200,43 +202,97 @@ func renderInsertTracesSQL(cfg *Config) string {
 	return fmt.Sprintf(sqltemplates.TracesInsert, cfg.database(), cfg.TracesTableName)
 }
 
-func renderCreateTracesTableSQL(cfg *Config) string {
+func renderCreateTracesTableSQL(cfg *Config, hasFullTextSearch bool) (string, error) {
 	ttlExpr := internal.GenerateTTLExpr(cfg.TTL, "toDateTime(Timestamp)")
-	return fmt.Sprintf(sqltemplates.TracesCreateTable,
-		cfg.database(), cfg.TracesTableName, cfg.clusterString(),
-		cfg.tableEngineString(),
-		ttlExpr,
-	)
-}
-
-func renderCreateTraceIDTsTableSQL(cfg *Config) string {
-	ttlExpr := internal.GenerateTTLExpr(cfg.TTL, "toDateTime(Start)")
-	return fmt.Sprintf(sqltemplates.TracesCreateTsTable,
-		cfg.database(), cfg.TracesTableName, cfg.clusterString(),
-		cfg.tableEngineString(),
-		ttlExpr,
-	)
-}
-
-func renderTraceIDTsMaterializedViewSQL(cfg *Config) string {
-	database := cfg.database()
-	return fmt.Sprintf(sqltemplates.TracesCreateTsView,
-		database, cfg.TracesTableName, cfg.clusterString(),
-		database, cfg.TracesTableName,
-		database, cfg.TracesTableName,
-	)
-}
-
-func createTraceTables(ctx context.Context, cfg *Config, db driver.Conn) error {
-	if err := db.Exec(ctx, renderCreateTracesTableSQL(cfg)); err != nil {
-		return fmt.Errorf("exec create traces table sql: %w", err)
+	data := sqltemplates.CreateTableData{
+		Database:          cfg.database(),
+		TableName:         cfg.TracesTableName,
+		ClusterString:     cfg.clusterString(),
+		Engine:            cfg.tableEngineString(),
+		TTL:               ttlExpr,
+		HasFullTextSearch: hasFullTextSearch,
 	}
-	if err := db.Exec(ctx, renderCreateTraceIDTsTableSQL(cfg)); err != nil {
+
+	var buf bytes.Buffer
+	if err := sqltemplates.TracesCreateTableTmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute traces create table template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+func renderCreateTraceIDTsTableSQL(cfg *Config) (string, error) {
+	ttlExpr := internal.GenerateTTLExpr(cfg.TTL, "toDateTime(Start)")
+	data := sqltemplates.CreateTableData{
+		Database:      cfg.database(),
+		TableName:     cfg.TracesTableName + "_trace_id_ts",
+		ClusterString: cfg.clusterString(),
+		Engine:        cfg.traceIDTsTableEngineString(),
+		TTL:           ttlExpr,
+	}
+
+	var buf bytes.Buffer
+	if err := sqltemplates.TracesCreateTsTableTmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute trace ID timestamp table template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+func renderTraceIDTsMaterializedViewSQL(cfg *Config) (string, error) {
+	data := sqltemplates.TracesTsMVData{
+		Database:        cfg.database(),
+		ViewName:        cfg.TracesTableName + "_trace_id_ts_mv",
+		TableName:       cfg.TracesTableName + "_trace_id_ts",
+		SourceTableName: cfg.TracesTableName,
+		ClusterString:   cfg.clusterString(),
+	}
+
+	var buf bytes.Buffer
+	if err := sqltemplates.TracesCreateTsViewTmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute trace ID timestamp view template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+func createTraceIDTsTable(ctx context.Context, cfg *Config, db driver.Conn) error {
+	tsTableSQL, err := renderCreateTraceIDTsTableSQL(cfg)
+	if err != nil {
+		return err
+	}
+	tsViewSQL, err := renderTraceIDTsMaterializedViewSQL(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := db.Exec(ctx, tsTableSQL); err != nil {
 		return fmt.Errorf("exec create traceID timestamp table sql: %w", err)
 	}
-	if err := db.Exec(ctx, renderTraceIDTsMaterializedViewSQL(cfg)); err != nil {
+	if err := db.Exec(ctx, tsViewSQL); err != nil {
 		return fmt.Errorf("exec create traceID timestamp view sql: %w", err)
 	}
 
 	return nil
+}
+
+func createTraceTables(ctx context.Context, cfg *Config, db driver.Conn, logger *zap.Logger) error {
+	hasFullTextSearch := false
+	sv, err := db.ServerVersion()
+	if err != nil {
+		logger.Warn("failed to get ClickHouse server version, falling back to bloom filter indexes", zap.Error(err))
+	} else {
+		hasFullTextSearch = proto.CheckMinVersion(versionFullTextSearch, sv.Version)
+	}
+
+	tracesSQL, err := renderCreateTracesTableSQL(cfg, hasFullTextSearch)
+	if err != nil {
+		return err
+	}
+
+	if err := db.Exec(ctx, tracesSQL); err != nil {
+		return fmt.Errorf("exec create traces table sql: %w", err)
+	}
+
+	return createTraceIDTsTable(ctx, cfg, db)
 }

--- a/exporter/clickhouseexporter/exporter_traces_json.go
+++ b/exporter/clickhouseexporter/exporter_traces_json.go
@@ -302,12 +302,6 @@ func createTraceJSONTables(ctx context.Context, cfg *Config, db driver.Conn) err
 	if err := db.Exec(ctx, renderCreateTracesJSONTableSQL(cfg)); err != nil {
 		return fmt.Errorf("exec create json traces table sql: %w", err)
 	}
-	if err := db.Exec(ctx, renderCreateTraceIDTsTableSQL(cfg)); err != nil {
-		return fmt.Errorf("exec create traceID timestamp table sql: %w", err)
-	}
-	if err := db.Exec(ctx, renderTraceIDTsMaterializedViewSQL(cfg)); err != nil {
-		return fmt.Errorf("exec create traceID timestamp view sql: %w", err)
-	}
 
-	return nil
+	return createTraceIDTsTable(ctx, cfg, db)
 }

--- a/exporter/clickhouseexporter/exporter_traces_test.go
+++ b/exporter/clickhouseexporter/exporter_traces_test.go
@@ -1,0 +1,144 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package clickhouseexporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderCreateTracesTableSQL(t *testing.T) {
+	cfg := withDefaultConfig(func(c *Config) {
+		c.Endpoint = defaultEndpoint
+		c.Database = "test_db"
+		c.TracesTableName = "otel_traces"
+		c.TTL = 72 * time.Hour
+	})
+
+	t.Run("bloom filter indexes for CH < 26.2", func(t *testing.T) {
+		sql, err := renderCreateTracesTableSQL(cfg, false)
+		require.NoError(t, err)
+
+		require.Contains(t, sql, "TYPE bloom_filter")
+		require.NotContains(t, sql, "TYPE text(")
+
+		require.Contains(t, sql, "`test_db`.`otel_traces`")
+		require.Contains(t, sql, "PRIMARY KEY (ServiceName, SpanName, toDateTime(Timestamp))")
+		require.Contains(t, sql, "ORDER BY (ServiceName, SpanName, toDateTime(Timestamp), Timestamp)")
+		require.Contains(t, sql, "Duration UInt64 CODEC(T64, ZSTD(1))")
+		require.Contains(t, sql, "ResourceAttributeItems Array(String) ALIAS")
+		require.Contains(t, sql, "SpanAttributeItems Array(String) ALIAS")
+		require.Contains(t, sql, "TYPE minmax")
+		require.Contains(t, sql, "TTL toDateTime(Timestamp) + toIntervalDay(3)")
+
+		require.Contains(t, sql, "INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter")
+		require.Contains(t, sql, "INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter")
+
+		require.NotContains(t, sql, "__otel_materialized")
+	})
+
+	t.Run("full text search indexes for CH >= 26.2", func(t *testing.T) {
+		sql, err := renderCreateTracesTableSQL(cfg, true)
+		require.NoError(t, err)
+
+		require.Contains(t, sql, "TYPE text(tokenizer = 'array')")
+		require.NotContains(t, sql, "TYPE bloom_filter")
+
+		require.Contains(t, sql, "INDEX idx_trace_id TraceId TYPE text(tokenizer = 'array')")
+		require.Contains(t, sql, "INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE text(tokenizer = 'array')")
+		require.Contains(t, sql, "INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE text(tokenizer = 'array')")
+		require.Contains(t, sql, "INDEX idx_res_attr_items ResourceAttributeItems TYPE text(tokenizer = 'array')")
+		require.Contains(t, sql, "INDEX idx_span_attr_items SpanAttributeItems TYPE text(tokenizer = 'array')")
+		require.Contains(t, sql, "`test_db`.`otel_traces`")
+		require.Contains(t, sql, "TYPE minmax")
+
+		require.NotContains(t, sql, "mapValues")
+		require.NotContains(t, sql, "idx_res_attr_value")
+		require.NotContains(t, sql, "idx_span_attr_value")
+
+		require.NotContains(t, sql, "__otel_materialized")
+	})
+
+	t.Run("no TTL when zero", func(t *testing.T) {
+		noTTLCfg := withDefaultConfig(func(c *Config) {
+			c.Endpoint = defaultEndpoint
+			c.Database = "test_db"
+			c.TTL = 0
+		})
+
+		sql, err := renderCreateTracesTableSQL(noTTLCfg, false)
+		require.NoError(t, err)
+		require.NotContains(t, sql, "TTL ")
+	})
+}
+
+func TestRenderCreateTraceIDTsTableSQL(t *testing.T) {
+	cfg := withDefaultConfig(func(c *Config) {
+		c.Endpoint = defaultEndpoint
+		c.Database = "test_db"
+		c.TracesTableName = "otel_traces"
+		c.TTL = 72 * time.Hour
+	})
+
+	sql, err := renderCreateTraceIDTsTableSQL(cfg)
+	require.NoError(t, err)
+
+	require.Contains(t, sql, "`test_db`.`otel_traces_trace_id_ts`")
+	require.Contains(t, sql, "ENGINE = AggregatingMergeTree()")
+	require.Contains(t, sql, "Start SimpleAggregateFunction(min, DateTime)")
+	require.Contains(t, sql, "End SimpleAggregateFunction(max, DateTime)")
+	require.Contains(t, sql, "PARTITION BY toStartOfWeek(Start)")
+	require.Contains(t, sql, "ORDER BY (TraceId)")
+	require.NotContains(t, sql, "bloom_filter")
+	require.Contains(t, sql, "TTL toDateTime(Start) + toIntervalDay(3)")
+}
+
+func TestRenderTraceIDTsMaterializedViewSQL(t *testing.T) {
+	cfg := withDefaultConfig(func(c *Config) {
+		c.Endpoint = defaultEndpoint
+		c.Database = "test_db"
+		c.TracesTableName = "otel_traces"
+	})
+
+	sql, err := renderTraceIDTsMaterializedViewSQL(cfg)
+	require.NoError(t, err)
+
+	require.Contains(t, sql, "`test_db`.`otel_traces_trace_id_ts_mv`")
+	require.Contains(t, sql, "TO `test_db`.`otel_traces_trace_id_ts`")
+	require.Contains(t, sql, "FROM `test_db`.`otel_traces`")
+	require.Contains(t, sql, "GROUP BY TraceId")
+}
+
+func TestTraceIDTsTableEngineString(t *testing.T) {
+	tests := []struct {
+		name     string
+		engine   TableEngine
+		expected string
+	}{
+		{name: "default", engine: TableEngine{}, expected: "AggregatingMergeTree()"},
+		{name: "explicit MergeTree", engine: TableEngine{Name: "MergeTree"}, expected: "AggregatingMergeTree()"},
+		{
+			name:     "ReplicatedMergeTree",
+			engine:   TableEngine{Name: "ReplicatedMergeTree", Params: "'/clickhouse/tables/{shard}/table_name', '{replica}'"},
+			expected: "ReplicatedAggregatingMergeTree('/clickhouse/tables/{shard}/table_name', '{replica}')",
+		},
+		{
+			name:     "custom engine unchanged",
+			engine:   TableEngine{Name: "SharedMergeTree", Params: "'a', 'b'"},
+			expected: "SharedMergeTree('a', 'b')",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := withDefaultConfig(func(c *Config) {
+				c.TableEngine = tt.engine
+			})
+
+			require.Equal(t, tt.expected, cfg.traceIDTsTableEngineString())
+		})
+	}
+}

--- a/exporter/clickhouseexporter/internal/sqltemplates/embed.go
+++ b/exporter/clickhouseexporter/internal/sqltemplates/embed.go
@@ -82,6 +82,22 @@ var TracesInsert string
 //go:embed traces_json_insert.sql
 var TracesJSONInsert string
 
+// Parsed templates for traces (text/template).
+var (
+	TracesCreateTableTmpl   = newTemplate("traces_table", TracesCreateTable)
+	TracesCreateTsTableTmpl = newTemplate("traces_id_ts_lookup_table", TracesCreateTsTable)
+	TracesCreateTsViewTmpl  = newTemplate("traces_id_ts_lookup_mv", TracesCreateTsView)
+)
+
+// TracesTsMVData contains the template parameters for the trace ID timestamp materialized view.
+type TracesTsMVData struct {
+	Database        string
+	ViewName        string
+	TableName       string
+	SourceTableName string
+	ClusterString   string
+}
+
 // PROFILES
 
 //go:embed profiles_table.sql

--- a/exporter/clickhouseexporter/internal/sqltemplates/traces_id_ts_lookup_mv.sql
+++ b/exporter/clickhouseexporter/internal/sqltemplates/traces_id_ts_lookup_mv.sql
@@ -1,9 +1,9 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS "%s"."%s_trace_id_ts_mv" %s
-TO "%s"."%s_trace_id_ts"
+CREATE MATERIALIZED VIEW IF NOT EXISTS {{ident .Database}}.{{ident .ViewName}} {{.ClusterString}}
+TO {{ident .Database}}.{{ident .TableName}}
 AS SELECT
-              TraceId,
-              min(Timestamp) as Start,
-              max(Timestamp) as End
-   FROM "%s"."%s"
-   WHERE TraceId != ''
-   GROUP BY TraceId
+    TraceId,
+    min(toDateTime(Timestamp)) AS Start,
+    max(toDateTime(Timestamp)) AS End
+FROM {{ident .Database}}.{{ident .SourceTableName}}
+WHERE TraceId != ''
+GROUP BY TraceId

--- a/exporter/clickhouseexporter/internal/sqltemplates/traces_id_ts_lookup_table.sql
+++ b/exporter/clickhouseexporter/internal/sqltemplates/traces_id_ts_lookup_table.sql
@@ -1,10 +1,9 @@
-CREATE TABLE IF NOT EXISTS "%s"."%s_trace_id_ts" %s (
+CREATE TABLE IF NOT EXISTS {{ident .Database}}.{{ident .TableName}} {{.ClusterString}} (
     TraceId String CODEC(ZSTD(1)),
-    Start DateTime CODEC(Delta, ZSTD(1)),
-    End DateTime CODEC(Delta, ZSTD(1)),
-    INDEX idx_trace_id TraceId TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE = %s
-    PARTITION BY toDate(Start)
-    ORDER BY (TraceId, Start)
-    %s
-    SETTINGS index_granularity=8192, ttl_only_drop_parts = 1
+    Start SimpleAggregateFunction(min, DateTime) CODEC(ZSTD(1)),
+    End SimpleAggregateFunction(max, DateTime) CODEC(ZSTD(1))
+) ENGINE = {{.Engine}}
+PARTITION BY toStartOfWeek(Start)
+ORDER BY (TraceId)
+{{.TTL}}
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1

--- a/exporter/clickhouseexporter/internal/sqltemplates/traces_table.sql
+++ b/exporter/clickhouseexporter/internal/sqltemplates/traces_table.sql
@@ -1,5 +1,5 @@
-CREATE TABLE IF NOT EXISTS %q.%q %s (
-    Timestamp DateTime64(9) CODEC(Delta, ZSTD(1)),
+CREATE TABLE IF NOT EXISTS {{ident .Database}}.{{ident .TableName}} {{.ClusterString}} (
+    Timestamp DateTime64(9) CODEC(Delta(8), ZSTD(1)),
     TraceId String CODEC(ZSTD(1)),
     SpanId String CODEC(ZSTD(1)),
     ParentSpanId String CODEC(ZSTD(1)),
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS %q.%q %s (
     ScopeName String CODEC(ZSTD(1)),
     ScopeVersion String CODEC(ZSTD(1)),
     SpanAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-    Duration UInt64 CODEC(ZSTD(1)),
+    Duration UInt64 CODEC(T64, ZSTD(1)),
     StatusCode LowCardinality(String) CODEC(ZSTD(1)),
     StatusMessage String CODEC(ZSTD(1)),
     Events Nested (
@@ -25,14 +25,25 @@ CREATE TABLE IF NOT EXISTS %q.%q %s (
         TraceState String,
         Attributes Map(LowCardinality(String), String)
     ) CODEC(ZSTD(1)),
+    ResourceAttributeItems Array(String) ALIAS arrayMap(kv -> concat(kv.1, '=', kv.2), CAST(ResourceAttributes, 'Array(Tuple(String, String))')),
+    SpanAttributeItems Array(String) ALIAS arrayMap(kv -> concat(kv.1, '=', kv.2), CAST(SpanAttributes, 'Array(Tuple(String, String))')),
+{{- if .HasFullTextSearch}}
+    INDEX idx_trace_id TraceId TYPE text(tokenizer = 'array'),
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE text(tokenizer = 'array'),
+    INDEX idx_res_attr_items ResourceAttributeItems TYPE text(tokenizer = 'array'),
+    INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE text(tokenizer = 'array'),
+    INDEX idx_span_attr_items SpanAttributeItems TYPE text(tokenizer = 'array'),
+{{- else}}
     INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
     INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
     INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+{{- end}}
     INDEX idx_duration Duration TYPE minmax GRANULARITY 1
-) ENGINE = %s
+) ENGINE = {{.Engine}}
 PARTITION BY toDate(Timestamp)
-ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
-%s
-SETTINGS index_granularity=8192, ttl_only_drop_parts = 1
+PRIMARY KEY (ServiceName, SpanName, toDateTime(Timestamp))
+ORDER BY (ServiceName, SpanName, toDateTime(Timestamp), Timestamp)
+{{.TTL}}
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR optimizes the trace table for faster queries. It adds text indices for `TraceID` and other attribute columns, along with subtle changes to compression and order by intended to improve storage. This only applies to new tables created on ClickHouse 26.2, but you can add the text indices yourself if you wanted. Note that the speed increase for attributes comes from clever querying using text functions such as `has(ResourceAttributeItems, 'host.name=foo')`, performance for `ResourceAttributes[k] = v` is same as before (not optimal).

I ran an A/B benchmark (75 billion rows on each over the weekend, around 300k spans/s). Notable results:
- Searching by attributes is 9-14x faster at p50 (35s to 3s)
- Trace ID lookups: 7.6x faster on misses (the text index reads zero rows vs bloom false-positives around 1M), and 2.6-3.2x on trace window queries (the timestamp table still helps).
- 2.05x query throughput, due to lower read latency

The tradeoff is an increase of 24% on insert latency (945 to 1,175ms per 25k-row insert), and +44% disk (entirely from the text indices). Merge CPU is around 1.7x, which lowers max ingest by roughly 45% on the hardware I was using. Yes ingest is slower due to the text indices, but the queries are typically where most of the hardware is required for these scales, so this is a fair trade in my opinion. Also note that due to the false positives in bloom filters, some storage configurations are bottlenecked on IO (less CPU while waiting for network). The new schema was able to make more use of the available compute.

If you have any questions let me know, feedback is welcome here

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests for template generation

<!--Describe the documentation added.-->
#### Documentation

Added note to README

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
