### PR TITLE
[extension/encoding/azureencoding] Promote log convention feature gates to Beta

### DIFF
--- a/.chloggen/azureencoding_log_conventions_to_beta.yaml
+++ b/.chloggen/azureencoding_log_conventions_to_beta.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/azure_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote extension.azureencoding.DontEmitV0LogConventions and extension.azureencoding.EmitV1LogConventions feature gates to Beta
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [47543]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: >-
+  The gates are now enabled by default, so Azure log records emit the v1 semconv attribute
+  exception.message instead of the deprecated v1.39.0 attribute error.message. Disable both
+  gates to restore the previous behavior.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/azureencoding_log_conventions_to_beta.yaml
+++ b/.chloggen/azureencoding_log_conventions_to_beta.yaml
@@ -10,7 +10,7 @@ component: extension/azure_encoding
 note: Promote extension.azureencoding.DontEmitV0LogConventions and extension.azureencoding.EmitV1LogConventions feature gates to Beta
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [47543]
+issues: [50885]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/extension/encoding/azureencodingextension/documentation.md
+++ b/extension/encoding/azureencodingextension/documentation.md
@@ -8,7 +8,7 @@ This component has the following feature gates:
 
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
-| `extension.azureencoding.DontEmitV0LogConventions` | alpha | When enabled, v0 semconv log attribute names are not emitted. | v0.149.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543) |
-| `extension.azureencoding.EmitV1LogConventions` | alpha | When enabled, v1 semconv log attribute names are emitted. | v0.149.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543) |
+| `extension.azureencoding.DontEmitV0LogConventions` | beta | When enabled, v0 semconv log attribute names are not emitted. | v0.149.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543) |
+| `extension.azureencoding.EmitV1LogConventions` | beta | When enabled, v1 semconv log attribute names are emitted. | v0.149.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/extension/encoding/azureencodingextension/internal/metadata/generated_feature_gates.go
+++ b/extension/encoding/azureencodingextension/internal/metadata/generated_feature_gates.go
@@ -8,7 +8,7 @@ import (
 
 var ExtensionAzureencodingDontEmitV0LogConventionsFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"extension.azureencoding.DontEmitV0LogConventions",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, v0 semconv log attribute names are not emitted."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543"),
 	featuregate.WithRegisterFromVersion("v0.149.0"),
@@ -16,7 +16,7 @@ var ExtensionAzureencodingDontEmitV0LogConventionsFeatureGate = featuregate.Glob
 
 var ExtensionAzureencodingEmitV1LogConventionsFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"extension.azureencoding.EmitV1LogConventions",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, v1 semconv log attribute names are emitted."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543"),
 	featuregate.WithRegisterFromVersion("v0.149.0"),

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/feature_gates_test.go
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/feature_gates_test.go
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package logs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension/internal/metadata"
+)
+
+// TestLogConventionsFeatureGates verifies which semconv error attributes the
+// messaging unmarshaler emits for each combination of the DontEmitV0/EmitV1 log
+// convention feature gates. The v0 attribute is error.message; the v1 attribute
+// is exception.message.
+func TestLogConventionsFeatureGates(t *testing.T) {
+	// not parallel: mutates the global featuregate registry
+	data, err := os.ReadFile(filepath.Join(testFilesDirectory, "messaging", "diagnostic-error-log.json"))
+	require.NoError(t, err)
+
+	const wantMessage = "Entity not found"
+
+	tests := []struct {
+		name       string
+		emitV1     bool
+		dontEmitV0 bool
+		wantV0     bool // error.message
+		wantV1     bool // exception.message
+	}{
+		{
+			name:       "default (beta): only v1",
+			emitV1:     true,
+			dontEmitV0: true,
+			wantV0:     false,
+			wantV1:     true,
+		},
+		{
+			name:       "legacy: only v0",
+			emitV1:     false,
+			dontEmitV0: false,
+			wantV0:     true,
+			wantV1:     false,
+		},
+		{
+			name:       "migration: both v0 and v1",
+			emitV1:     true,
+			dontEmitV0: false,
+			wantV0:     true,
+			wantV1:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := featuregate.GlobalRegistry()
+			require.NoError(t, registry.Set(metadata.ExtensionAzureencodingEmitV1LogConventionsFeatureGate.ID(), tt.emitV1))
+			require.NoError(t, registry.Set(metadata.ExtensionAzureencodingDontEmitV0LogConventionsFeatureGate.ID(), tt.dontEmitV0))
+			t.Cleanup(func() {
+				require.NoError(t, registry.Set(metadata.ExtensionAzureencodingEmitV1LogConventionsFeatureGate.ID(), true))
+				require.NoError(t, registry.Set(metadata.ExtensionAzureencodingDontEmitV0LogConventionsFeatureGate.ID(), true))
+			})
+
+			unmarshaler := NewAzureResourceLogsUnmarshaler(testBuildInfo, zap.NewNop(), LogsConfig{
+				TimeFormats: []string{
+					"01/02/2006 15:04:05",
+					"2006-01-02T15:04:05Z",
+					"1/2/2006 3:04:05.000 PM -07:00",
+					"1/2/2006 3:04:05 PM -07:00",
+				},
+			})
+
+			logs, err := unmarshaler.UnmarshalLogs(data)
+			require.NoError(t, err)
+
+			v0, hasV0 := findLogAttr(logs, "error.message")
+			v1, hasV1 := findLogAttr(logs, "exception.message")
+
+			require.Equal(t, tt.wantV0, hasV0, "error.message presence")
+			require.Equal(t, tt.wantV1, hasV1, "exception.message presence")
+			if tt.wantV0 {
+				require.Equal(t, wantMessage, v0.Str())
+			}
+			if tt.wantV1 {
+				require.Equal(t, wantMessage, v1.Str())
+			}
+		})
+	}
+}
+
+// findLogAttr returns the first log record attribute matching key across all
+// resource logs, scope logs, and log records.
+func findLogAttr(logs plog.Logs, key string) (pcommon.Value, bool) {
+	for i := 0; i < logs.ResourceLogs().Len(); i++ {
+		scopeLogs := logs.ResourceLogs().At(i).ScopeLogs()
+		for j := 0; j < scopeLogs.Len(); j++ {
+			records := scopeLogs.At(j).LogRecords()
+			for k := 0; k < records.Len(); k++ {
+				if v, ok := records.At(k).Attributes().Get(key); ok {
+					return v, true
+				}
+			}
+		}
+	}
+	return pcommon.Value{}, false
+}

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/messaging/diagnostic-error-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/messaging/diagnostic-error-log_expected.yaml
@@ -46,7 +46,7 @@ resourceLogs:
               - key: azure.messaging.task.name
                 value:
                   stringValue: DiagnosticErrorLogsShoebox
-              - key: error.message
+              - key: exception.message
                 value:
                   stringValue: Entity not found
               - key: azure.messaging.error.count

--- a/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/messaging/operation-log_expected.yaml
+++ b/extension/encoding/azureencodingextension/internal/unmarshaler/logs/testdata/messaging/operation-log_expected.yaml
@@ -103,7 +103,7 @@ resourceLogs:
               - key: error.code
                 value:
                   stringValue: BadRequest
-              - key: error.message
+              - key: exception.message
                 value:
                   stringValue: SubCode=40000. Partitioning cannot be changed for Queue. To know more visit https://aka.ms/sbResourceMgrExceptions
             body: {}

--- a/extension/encoding/azureencodingextension/metadata.yaml
+++ b/extension/encoding/azureencodingextension/metadata.yaml
@@ -18,12 +18,12 @@ status:
 
 feature_gates:
   - id: extension.azureencoding.DontEmitV0LogConventions
-    stage: alpha
+    stage: beta
     description: When enabled, v0 semconv log attribute names are not emitted.
     from_version: v0.149.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543
   - id: extension.azureencoding.EmitV1LogConventions
-    stage: alpha
+    stage: beta
     description: When enabled, v1 semconv log attribute names are emitted.
     from_version: v0.149.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47543


### PR DESCRIPTION
#### Description
This PR promotes the `extension.azureencoding.DontEmitV0LogConventions` and `extension.azureencoding.EmitV1LogConventions` feature gates from Alpha to Beta, enabling them by default. Both have been Alpha since `v0.149.0` (#47569) and have soaked for eleven minor releases without reported issues, and per the semconv RFC the pair is promoted together. With them enabled, Azure log records now emit the v1 semconv attribute `exception.message` instead of the deprecated `v1.39.0` attribute `error.message`

This PR also adds `TestLogConventionsFeatureGates` covering the legacy, migration, and default gate combinations, and refreshes the affected messaging golden files.

#### Link to tracking issue
Fixes #50885


#### Testing
Tuned.

#### Documentation
Tuned.

#### Authorship

- [x] I, a human, wrote this pull request description myself.