### PR TITLE
[receiver/webhookevent] fix: Validate path fields

### DIFF
--- a/.chloggen/webhookeventreceiver-validate-path-leading-slash.yaml
+++ b/.chloggen/webhookeventreceiver-validate-path-leading-slash.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/webhook_event
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Validate that `path` and `health_path` begin with a leading `/` so the collector fails at config load instead of panicking at startup.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  A `path` or `health_path` without a leading `/` caused `httprouter` to panic in `Start()`,
+  after the collector had already bound its telemetry port. The panic left the port held, so every
+  restart attempt failed with `bind: address already in use`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/webhookeventreceiver-validate-path-leading-slash.yaml
+++ b/.chloggen/webhookeventreceiver-validate-path-leading-slash.yaml
@@ -10,7 +10,7 @@ component: receiver/webhook_event
 note: Validate that `path` and `health_path` begin with a leading `/` so the collector fails at config load instead of panicking at startup.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50893]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/webhookeventreceiver/README.md
+++ b/receiver/webhookeventreceiver/README.md
@@ -29,8 +29,8 @@ The following settings are required:
 
 The following settings are optional:
 
-* `path` (default: '/events'): Path where the receiver instance will accept events 
-* `health_path` (default: '/health_check'): Path available for checking receiver status
+* `path` (default: '/events'): Path where the receiver instance will accept events. Must begin with a leading `/`.
+* `health_path` (default: '/health_check'): Path available for checking receiver status. Must begin with a leading `/`.
 * `read_timeout` (default: '500ms'): Maximum wait time while attempting to read a received event
 * `write_timeout` (default: '500ms'): Maximum wait time while attempting to write a response
 * `required_header` (optional):  
@@ -124,8 +124,8 @@ receivers:
     webhook_event:
         endpoint: localhost:8088
         read_timeout: "500ms"
-        path: "eventsource/receiver"
-        health_path: "eventreceiver/healthcheck"
+        path: "/eventsource/receiver"
+        health_path: "/eventreceiver/healthcheck"
         required_header:
             key: "required-header-key"
             value: "required-header-value"

--- a/receiver/webhookeventreceiver/config.go
+++ b/receiver/webhookeventreceiver/config.go
@@ -6,6 +6,7 @@ package webhookeventreceiver // import "github.com/open-telemetry/opentelemetry-
 import (
 	"errors"
 	"regexp"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -22,6 +23,8 @@ var (
 	errHMACMissingSecret           = errors.New("hmac_signature.secret is required when hmac_signature is configured")
 	errHMACMissingHeader           = errors.New("hmac_signature.header is required when hmac_signature is configured")
 	errHMACMissingPrefix           = errors.New("hmac_signature.prefix is required when hmac_signature is configured")
+	errPathMissingLeadingSlash     = errors.New("path must begin with a leading '/'")
+	errHealthPathMissingSlash      = errors.New("health_path must begin with a leading '/'")
 )
 
 // Config defines configuration for the Generic Webhook receiver.
@@ -63,6 +66,15 @@ func (cfg *Config) Validate() error {
 
 	if cfg.ServerConfig.NetAddr.Endpoint == "" {
 		errs = multierr.Append(errs, errMissingEndpointFromConfig)
+	}
+
+	// httprouter panics at Start() if a registered path does not begin with '/'.
+	// Catch it here so it surfaces as a config error instead of a runtime panic.
+	if !strings.HasPrefix(cfg.Path, "/") {
+		errs = multierr.Append(errs, errPathMissingLeadingSlash)
+	}
+	if !strings.HasPrefix(cfg.HealthPath, "/") {
+		errs = multierr.Append(errs, errHealthPathMissingSlash)
 	}
 
 	// If a user defines a custom read/write timeout there is a maximum value

--- a/receiver/webhookeventreceiver/config_test.go
+++ b/receiver/webhookeventreceiver/config_test.go
@@ -211,6 +211,34 @@ func TestValidateConfig(t *testing.T) {
 			},
 		},
 		{
+			desc:   "Path missing leading slash",
+			expect: errPathMissingLeadingSlash,
+			conf: Config{
+				ServerConfig: confighttp.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Transport: confignet.TransportTypeTCP,
+						Endpoint:  "localhost:0",
+					},
+				},
+				Path:       "eventsource/receiver",
+				HealthPath: defaultHealthPath,
+			},
+		},
+		{
+			desc:   "HealthPath missing leading slash",
+			expect: errHealthPathMissingSlash,
+			conf: Config{
+				ServerConfig: confighttp.ServerConfig{
+					NetAddr: confignet.AddrConfig{
+						Transport: confignet.TransportTypeTCP,
+						Endpoint:  "localhost:0",
+					},
+				},
+				Path:       defaultPath,
+				HealthPath: "eventreceiver/healthcheck",
+			},
+		},
+		{
 			desc:   "Multiple invalid configs",
 			expect: errs,
 			conf: Config{
@@ -227,6 +255,12 @@ func TestValidateConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			if test.conf.Path == "" {
+				test.conf.Path = defaultPath
+			}
+			if test.conf.HealthPath == "" {
+				test.conf.HealthPath = defaultHealthPath
+			}
 			err := test.conf.Validate()
 			if test.expect != nil {
 				require.ErrorContains(t, err, test.expect.Error())
@@ -344,6 +378,8 @@ func TestMaxRequestBodySizeAutoCorrection(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			test.conf.Path = defaultPath
+			test.conf.HealthPath = defaultHealthPath
 			err := test.conf.Validate()
 			require.NoError(t, err)
 			require.Equal(t, test.expected, test.conf.ServerConfig.MaxRequestBodySize)
@@ -376,8 +412,8 @@ func TestLoadConfig(t *testing.T) {
 		ServerConfig: expectServerConfig,
 		ReadTimeout:  "500ms",
 		WriteTimeout: "500ms",
-		Path:         "some/path",
-		HealthPath:   "health/path",
+		Path:         "/some/path",
+		HealthPath:   "/health/path",
 		RequiredHeader: RequiredHeader{
 			Key:   "key-present",
 			Value: "value-present",

--- a/receiver/webhookeventreceiver/testdata/config.yaml
+++ b/receiver/webhookeventreceiver/testdata/config.yaml
@@ -3,8 +3,8 @@ webhookevent/valid_config:
   endpoint: localhost:8080
   read_timeout: "500ms"
   write_timeout: "500ms"
-  path: "some/path"
-  health_path: "health/path"
+  path: "/some/path"
+  health_path: "/health/path"
   required_header:
     key: key-present
     value: value-present


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The receiver will panic when it receives a `path` or `health_path` that doesn't include a leading `\`. This PR changes the configuration validation to check these fields and fail instead of panicking. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50893

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Built the collector on main, verified the panic when passing this receiver configuration:
```
  webhook_event:
    endpoint: localhost:443
    path: 'eventsource/invalid/path'
    health_path: 'eventreceiver/invalid/health'
```

Built the collector on `fix/webhookeventrevceiver-panics`, verified the error instead of a panic with the same configuration:
```
Error: invalid configuration: receivers::webhook_event: health_path must begin with a leading '/'
```

<!--Describe the documentation added.-->
#### Documentation
Updates the receiver's README.md to explicitly call out the leading `/` requirement for `path` and `health_path`.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
