### PR TITLE
[processor/filter] Removing deprecated funcs

### DIFF
--- a/.chloggen/codeboten_remove-dep-funcs-1.yaml
+++ b/.chloggen/codeboten_remove-dep-funcs-1.yaml
@@ -10,7 +10,7 @@ component: processor/filter
 note: Removing deprecated funcs
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50898]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_remove-dep-funcs-1.yaml
+++ b/.chloggen/codeboten_remove-dep-funcs-1.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/filter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removing deprecated funcs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Remove the deprecated *FunctionsNew aliases (WithResourceFunctionsNew, WithDataPointFunctionsNew, WithLogFunctionsNew,
+  WithMetricFunctionsNew, WithSpanEventFunctionsNew, WithSpanFunctionsNew, WithProfileFunctionsNew, DefaultLogFunctionsNew,
+  DefaultMetricFunctionsNew, DefaultDataPointFunctionsNew, DefaultSpanFunctionsNew, DefaultSpanEventFunctionsNew,
+  DefaultProfileFunctionsNew) in favour of their non-New equivalents, deprecated since v0.152.0.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -60,11 +60,6 @@ func WithResourceFunctions(resourceFunctions []ottl.Factory[*ottlresource.Transf
 	}
 }
 
-// Deprecated: [v0.152.0] Use WithResourceFunctions.
-func WithResourceFunctionsNew(resourceFunctions []ottl.Factory[*ottlresource.TransformContext]) FactoryOption {
-	return WithResourceFunctions(resourceFunctions)
-}
-
 // WithDataPointFunctions will override the default OTTL datapoint context functions with the provided dataPointFunctions in resulting processor.
 // Subsequent uses of WithDataPointFunctions will merge the provided dataPointFunctions with the previously registered functions.
 func WithDataPointFunctions(dataPointFunctions []ottl.Factory[*ottldatapoint.TransformContext]) FactoryOption {
@@ -75,11 +70,6 @@ func WithDataPointFunctions(dataPointFunctions []ottl.Factory[*ottldatapoint.Tra
 		}
 		factory.dataPointFunctions = mergeFunctionsToMap(factory.dataPointFunctions, dataPointFunctions)
 	}
-}
-
-// Deprecated: [v0.152.0] Use WithDataPointFunctions.
-func WithDataPointFunctionsNew(dataPointFunctions []ottl.Factory[*ottldatapoint.TransformContext]) FactoryOption {
-	return WithDataPointFunctions(dataPointFunctions)
 }
 
 // WithLogFunctions will override the default OTTL log context functions with the provided logFunctions in the resulting processor.
@@ -94,11 +84,6 @@ func WithLogFunctions(logFunctions []ottl.Factory[*ottllog.TransformContext]) Fa
 	}
 }
 
-// Deprecated: [v0.152.0] Use WithLogFunctions.
-func WithLogFunctionsNew(logFunctions []ottl.Factory[*ottllog.TransformContext]) FactoryOption {
-	return WithLogFunctions(logFunctions)
-}
-
 // WithMetricFunctions will override the default OTTL metric context functions with the provided metricFunctions in the resulting processor.
 // Subsequent uses of WithMetricFunctions will merge the provided metricFunctions with the previously registered functions.
 func WithMetricFunctions(metricFunctions []ottl.Factory[*ottlmetric.TransformContext]) FactoryOption {
@@ -109,11 +94,6 @@ func WithMetricFunctions(metricFunctions []ottl.Factory[*ottlmetric.TransformCon
 		}
 		factory.metricFunctions = mergeFunctionsToMap(factory.metricFunctions, metricFunctions)
 	}
-}
-
-// Deprecated: [v0.152.0] Use WithMetricFunctions.
-func WithMetricFunctionsNew(metricFunctions []ottl.Factory[*ottlmetric.TransformContext]) FactoryOption {
-	return WithMetricFunctions(metricFunctions)
 }
 
 // WithSpanEventFunctions will override the default OTTL spanevent context functions with the provided spanEventFunctions in the resulting processor.
@@ -128,11 +108,6 @@ func WithSpanEventFunctions(spanEventFunctions []ottl.Factory[*ottlspanevent.Tra
 	}
 }
 
-// Deprecated: [v0.152.0] Use WithSpanEventFunctions.
-func WithSpanEventFunctionsNew(spanEventFunctions []ottl.Factory[*ottlspanevent.TransformContext]) FactoryOption {
-	return WithSpanEventFunctions(spanEventFunctions)
-}
-
 // WithSpanFunctions will override the default OTTL span context functions with the provided spanFunctions in the resulting processor.
 // Subsequent uses of WithSpanFunctions will merge the provided spanFunctions with the previously registered functions.
 func WithSpanFunctions(spanFunctions []ottl.Factory[*ottlspan.TransformContext]) FactoryOption {
@@ -145,11 +120,6 @@ func WithSpanFunctions(spanFunctions []ottl.Factory[*ottlspan.TransformContext])
 	}
 }
 
-// Deprecated: [v0.152.0] use WithSpanFunctions.
-func WithSpanFunctionsNew(spanFunctions []ottl.Factory[*ottlspan.TransformContext]) FactoryOption {
-	return WithSpanFunctions(spanFunctions)
-}
-
 // WithProfileFunctions will override the default OTTL profile context functions with the provided profileFunctions in the resulting processor.
 // Subsequent uses of WithProfileFunctions will merge the provided profileFunctions with the previously registered functions.
 func WithProfileFunctions(profileFunctions []ottl.Factory[*ottlprofile.TransformContext]) FactoryOption {
@@ -160,11 +130,6 @@ func WithProfileFunctions(profileFunctions []ottl.Factory[*ottlprofile.Transform
 		}
 		factory.profileFunctions = mergeFunctionsToMap(factory.profileFunctions, profileFunctions)
 	}
-}
-
-// Deprecated: [v0.152.0] use WithProfileFunctions.
-func WithProfileFunctionsNew(profileFunctions []ottl.Factory[*ottlprofile.TransformContext]) FactoryOption {
-	return WithProfileFunctions(profileFunctions)
 }
 
 // NewFactory returns a new factory for the Filter processor.

--- a/processor/filterprocessor/functions.go
+++ b/processor/filterprocessor/functions.go
@@ -26,54 +26,24 @@ func DefaultLogFunctions() []ottl.Factory[*ottllog.TransformContext] {
 	return slices.Collect(maps.Values(defaultLogFunctionsMap()))
 }
 
-// Deprecated: [v0.152.0] use DefaultLogFunctions.
-func DefaultLogFunctionsNew() []ottl.Factory[*ottllog.TransformContext] {
-	return DefaultLogFunctions()
-}
-
 func DefaultMetricFunctions() []ottl.Factory[*ottlmetric.TransformContext] {
 	return slices.Collect(maps.Values(defaultMetricFunctionsMap()))
-}
-
-// Deprecated: [v0.152.0] use DefaultMetricFunctions.
-func DefaultMetricFunctionsNew() []ottl.Factory[*ottlmetric.TransformContext] {
-	return DefaultMetricFunctions()
 }
 
 func DefaultDataPointFunctions() []ottl.Factory[*ottldatapoint.TransformContext] {
 	return slices.Collect(maps.Values(defaultDataPointFunctionsMap()))
 }
 
-// Deprecated: [v0.152.0] use DefaultDataPointFunctions.
-func DefaultDataPointFunctionsNew() []ottl.Factory[*ottldatapoint.TransformContext] {
-	return DefaultDataPointFunctions()
-}
-
 func DefaultSpanFunctions() []ottl.Factory[*ottlspan.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanFunctionsMap()))
-}
-
-// Deprecated: [v0.152.0] use DefaultSpanFunctions.
-func DefaultSpanFunctionsNew() []ottl.Factory[*ottlspan.TransformContext] {
-	return DefaultSpanFunctions()
 }
 
 func DefaultSpanEventFunctions() []ottl.Factory[*ottlspanevent.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanEventFunctionsMap()))
 }
 
-// Deprecated: [v0.152.0] use DefaultSpanEventFunctions.
-func DefaultSpanEventFunctionsNew() []ottl.Factory[*ottlspanevent.TransformContext] {
-	return DefaultSpanEventFunctions()
-}
-
 func DefaultProfileFunctions() []ottl.Factory[*ottlprofile.TransformContext] {
 	return slices.Collect(maps.Values(defaultProfileFunctionsMap()))
-}
-
-// Deprecated: [v0.152.0] use DefaultProfileFunctions.
-func DefaultProfileFunctionsNew() []ottl.Factory[*ottlprofile.TransformContext] {
-	return DefaultProfileFunctions()
 }
 
 func defaultResourceFunctionsMap() map[string]ottl.Factory[*ottlresource.TransformContext] {


### PR DESCRIPTION
#### Description

Remove the deprecated *FunctionsNew aliases (WithResourceFunctionsNew, WithDataPointFunctionsNew, WithLogFunctionsNew, WithMetricFunctionsNew, WithSpanEventFunctionsNew, WithSpanFunctionsNew, WithProfileFunctionsNew, DefaultLogFunctionsNew, DefaultMetricFunctionsNew, DefaultDataPointFunctionsNew, DefaultSpanFunctionsNew, DefaultSpanEventFunctionsNew, DefaultProfileFunctionsNew) in favour of their non-New equivalents, deprecated since v0.152.0.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
