### PR TITLE
[pkg/ottl]: remove old experimental warnings

### DIFF
--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -31,7 +31,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for datapoints.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxdatapoint.Name
 
 var (
@@ -138,8 +137,6 @@ func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/contexts/ottlexemplar/exemplar.go
+++ b/pkg/ottl/contexts/ottlexemplar/exemplar.go
@@ -31,7 +31,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for exemplars.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxexemplar.Name
 
 var (
@@ -150,8 +149,6 @@ func (tCtx *TransformContext) GetMetrics() pmetric.MetricSlice {
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -31,7 +31,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for logs.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxlog.Name
 
 var (
@@ -145,8 +144,6 @@ func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -30,7 +30,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for metrics.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxmetric.Name
 
 var (
@@ -129,8 +128,6 @@ func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/contexts/ottlotelcol/otelcol.go
+++ b/pkg/ottl/contexts/ottlotelcol/otelcol.go
@@ -24,7 +24,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for context.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxotelcol.Name
 
 var _ zapcore.ObjectMarshaler = (*TransformContext)(nil)
@@ -62,8 +61,6 @@ func (tCtx *TransformContext) Close() {
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{ContextName})(p)

--- a/pkg/ottl/contexts/ottlprofile/profile.go
+++ b/pkg/ottl/contexts/ottlprofile/profile.go
@@ -31,7 +31,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for profiles.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxprofile.Name
 
 var (
@@ -150,8 +149,6 @@ func NewParser(functions map[string]ottl.Factory[*TransformContext], telemetrySe
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/contexts/ottlprofilesample/profilesample.go
+++ b/pkg/ottl/contexts/ottlprofilesample/profilesample.go
@@ -32,7 +32,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for profiles.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxprofilesample.Name
 
 var (
@@ -147,8 +146,6 @@ func NewParser(functions map[string]ottl.Factory[*TransformContext], telemetrySe
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -26,7 +26,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for resources.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxresource.Name
 
 var (
@@ -98,8 +97,6 @@ func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -27,7 +27,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for instrumentation scopes.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxscope.Name
 
 var (
@@ -117,8 +116,6 @@ func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -30,7 +30,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for spans.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxspan.Name
 
 var _ zapcore.ObjectMarshaler = (*TransformContext)(nil)
@@ -119,8 +118,6 @@ func (tCtx *TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -32,7 +32,6 @@ var tcPool = sync.Pool{
 }
 
 // ContextName is the name of the context for span events.
-// Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxspanevent.Name
 
 var _ zapcore.ObjectMarshaler = (*TransformContext)(nil)
@@ -155,8 +154,6 @@ func (tCtx *TransformContext) GetEventIndex() (int64, error) {
 // EnablePathContextNames enables the support for path's context names on statements.
 // When this option is configured, all statement's paths must have a valid context prefix,
 // otherwise an error is reported.
-//
-// Experimental: *NOTE* this option is subject to change or removal in the future.
 func EnablePathContextNames() ottl.Option[*TransformContext] {
 	return func(p *ottl.Parser[*TransformContext]) {
 		ottl.WithPathContextNames[*TransformContext]([]string{

--- a/pkg/ottl/parser_collection.go
+++ b/pkg/ottl/parser_collection.go
@@ -11,46 +11,34 @@ import (
 )
 
 // StatementsGetter represents a set of statements to be parsed.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 type StatementsGetter interface {
 	// GetStatements retrieves the OTTL statements to be parsed
 	GetStatements() []string
 }
 
 // NewStatementsGetter creates a new StatementsGetter.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func NewStatementsGetter(statements []string) StatementsGetter {
 	return defaultOTTLGetter(statements)
 }
 
 // ConditionsGetter represents a set of conditions to be parsed.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 type ConditionsGetter interface {
 	// GetConditions retrieves the OTTL conditions to be parsed
 	GetConditions() []string
 }
 
 // NewConditionsGetter creates a new ConditionsGetter.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func NewConditionsGetter(conditions []string) ConditionsGetter {
 	return defaultOTTLGetter(conditions)
 }
 
 // ValueExpressionsGetter represents a set of value expressions to be parsed.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 type ValueExpressionsGetter interface {
 	// GetValueExpressions retrieves the OTTL value expressions to be parsed
 	GetValueExpressions() []string
 }
 
 // NewValueExpressionsGetter creates a new ValueExpressionsGetter.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func NewValueExpressionsGetter(expressions []string) ValueExpressionsGetter {
 	return defaultOTTLGetter(expressions)
 }
@@ -72,8 +60,6 @@ func (d defaultOTTLGetter) GetValueExpressions() []string {
 // ParserCollection is a configurable set of ottl.Parser that can handle multiple OTTL contexts
 // parsings, inferring the context, choosing the right parser for the given statements, and
 // transforming the parsed ottl.Statement[K] slice into a common result of type R.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 type ParserCollection[R any] struct {
 	contextParsers            map[string]*ParserCollectionContextParser[R]
 	contextInferrer           contextInferrer
@@ -85,13 +71,9 @@ type ParserCollection[R any] struct {
 }
 
 // ParserCollectionOption is a configurable ParserCollection option.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 type ParserCollectionOption[R any] func(*ParserCollection[R]) error
 
 // NewParserCollection creates a new ParserCollection.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func NewParserCollection[R any](
 	settings component.TelemetrySettings,
 	options ...ParserCollectionOption[R],
@@ -120,8 +102,6 @@ func NewParserCollection[R any](
 // Given each parser has its own transform context type, they must agree on a common type [R]
 // so it can be returned by the ParserCollection.ParseStatements and ParserCollection.ParseStatementsWithContext
 // functions.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 type ParsedStatementsConverter[K any, R any] func(collection *ParserCollection[R], statements StatementsGetter, parsedStatements []*Statement[K]) (R, error)
 
 // ParsedConditionsConverter is a function that converts the parsed ottl.Condition[K] into
@@ -129,8 +109,6 @@ type ParsedStatementsConverter[K any, R any] func(collection *ParserCollection[R
 // Given each parser has its own transform context type, they must agree on a common type [R]
 // so it can be returned by the ParserCollection.ParseConditions and ParserCollection.ParseConditionsWithContext
 // functions.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 type ParsedConditionsConverter[K any, R any] func(collection *ParserCollection[R], conditions ConditionsGetter, parsedConditions []*Condition[K]) (R, error)
 
 // ParsedValueExpressionsConverter is a function that converts the parsed ottl.ValueExpression[K] into
@@ -138,8 +116,6 @@ type ParsedConditionsConverter[K any, R any] func(collection *ParserCollection[R
 // Given each parser has its own transform context type, they must agree on a common type [R]
 // so it can be returned by the ParserCollection.ParseValueExpressions and ParserCollection.ParseValueExpressionsWithContext
 // functions.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 type ParsedValueExpressionsConverter[K any, R any] func(collection *ParserCollection[R], expressions ValueExpressionsGetter, parsedValueExpressions []*ValueExpression[K]) (R, error)
 
 func newNopParsedStatementsConverter[K any]() ParsedStatementsConverter[K, any] {
@@ -174,8 +150,6 @@ func newNopParsedValueExpressionsConverter[K any]() ParsedValueExpressionsConver
 
 type (
 	// ParserCollectionContextOption is a configurable ParserCollectionContext option.
-	//
-	// Experimental: *NOTE* this API is subject to change or removal in the future.
 	ParserCollectionContextOption[K, R any] func(*ParserCollectionContextParser[R], *Parser[K])
 
 	// parserCollectionContextParserFunc is the internal generic type that parses the given []string
@@ -186,8 +160,6 @@ type (
 	parserCollectionContextParserFunc[R any, G any] func(collection *ParserCollection[R], context string, getter G, prependPathsContext bool) (R, error)
 	// ParserCollectionContextParser is a struct that holds the converters for parsing statements and conditions
 	// into a common representation of type [R].
-	//
-	// Experimental: *NOTE* this API is subject to change or removal in the future.
 	ParserCollectionContextParser[R any] struct {
 		parseStatements       parserCollectionContextParserFunc[R, StatementsGetter]
 		parseConditions       parserCollectionContextParserFunc[R, ConditionsGetter]
@@ -309,8 +281,6 @@ func createStatementsParserWithConverter[K, R any](converter ParsedStatementsCon
 // WithConditionConverter sets the condition converter for the given context.
 // The provided converter function will be used to convert parsed OTTL conditions into a common representation of type R.
 // The context's OTTL parser will parse the conditions, and the converter function will transform the parsed conditions into the desired representation.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func WithConditionConverter[K, R any](converter ParsedConditionsConverter[K, R]) ParserCollectionContextOption[K, R] {
 	return func(pcp *ParserCollectionContextParser[R], parser *Parser[K]) {
 		pcp.parseConditions = createConditionsParserWithConverter(converter, parser)
@@ -320,8 +290,6 @@ func WithConditionConverter[K, R any](converter ParsedConditionsConverter[K, R])
 // WithValueExpressionConverter sets the value expression converter for the given context.
 // The provided converter function will be used to convert parsed OTTL value expressions into a common representation of type R.
 // The context's OTTL parser will parse the value expressions, and the converter function will transform the parsed value expressions into the desired representation.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func WithValueExpressionConverter[K, R any](converter ParsedValueExpressionsConverter[K, R]) ParserCollectionContextOption[K, R] {
 	return func(pcp *ParserCollectionContextParser[R], parser *Parser[K]) {
 		pcp.parseValueExpressions = createValueExpressionsParserWithConverter(converter, parser)
@@ -331,8 +299,6 @@ func WithValueExpressionConverter[K, R any](converter ParsedValueExpressionsConv
 // WithStatementConverter sets the statement converter for the given context.
 // The provided converter function will be used to convert parsed OTTL statements into a common representation of type R.
 // The context's OTTL parser will parse the statements, and the converter function will transform the parsed statements into the desired representation.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func WithStatementConverter[K, R any](converter ParsedStatementsConverter[K, R]) ParserCollectionContextOption[K, R] {
 	return func(pcp *ParserCollectionContextParser[R], parser *Parser[K]) {
 		pcp.parseStatements = createStatementsParserWithConverter(converter, parser)
@@ -342,8 +308,6 @@ func WithStatementConverter[K, R any](converter ParsedStatementsConverter[K, R])
 // WithParserCollectionContext configures an ottl.Parser for the given context.
 // The provided ottl.Parser must be configured to support the provided context using
 // the ottl.WithPathContextNames option.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func WithParserCollectionContext[K, R any](
 	context string,
 	parser *Parser[K],
@@ -386,8 +350,6 @@ func (pc *ParserCollection[R]) getLowerContexts(context string) []string {
 
 // WithParserCollectionErrorMode has no effect on the ParserCollection, but might be used
 // by the ParsedStatementsConverter functions to handle/create StatementSequence.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func WithParserCollectionErrorMode[R any](errorMode ErrorMode) ParserCollectionOption[R] {
 	return func(tp *ParserCollection[R]) error {
 		tp.ErrorMode = errorMode
@@ -398,8 +360,6 @@ func WithParserCollectionErrorMode[R any](errorMode ErrorMode) ParserCollectionO
 // EnableParserCollectionModifiedPathsLogging controls the modification logs.
 // When enabled, it logs any modifications performed by the parsing operations,
 // instructing users to rewrite the statements accordingly.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func EnableParserCollectionModifiedPathsLogging[R any](enabled bool) ParserCollectionOption[R] {
 	return func(tp *ParserCollection[R]) error {
 		tp.modifiedLogging = enabled
@@ -413,15 +373,11 @@ type parseCollectionContextInferenceOptions struct {
 
 // ParserCollectionContextInferenceOption allows configuring the context inference and use
 // this option with the supported parsing functions.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 type ParserCollectionContextInferenceOption func(p *parseCollectionContextInferenceOptions)
 
 // WithContextInferenceConditions sets additional OTTL conditions to be used to enhance
 // the context inference process. This is particularly useful when the statements alone are
 // insufficient for determine the correct context, or when a less-specific context is desired.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func WithContextInferenceConditions(conditions []string) ParserCollectionContextInferenceOption {
 	return func(p *parseCollectionContextInferenceOptions) {
 		p.conditions = conditions
@@ -439,8 +395,6 @@ func WithContextInferenceConditions(conditions []string) ParserCollectionContext
 // additional OTTL conditions to enhance the context inference. This is particularly useful when
 // the statements alone are insufficient for determine the correct context, or if an less-specific
 // parser is desired.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func (pc *ParserCollection[R]) ParseStatements(statements StatementsGetter, options ...ParserCollectionContextInferenceOption) (R, error) {
 	statementsValues := statements.GetStatements()
 
@@ -484,8 +438,6 @@ func (pc *ParserCollection[R]) ParseStatements(statements StatementsGetter, opti
 // argument should be set to true, so it rewrites the statements prepending the missing paths
 // contexts.
 // If parsing the statements fails, it returns the underlying [ottl.Parser.ParseStatements] error.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func (pc *ParserCollection[R]) ParseStatementsWithContext(context string, statements StatementsGetter, prependPathsContext bool) (R, error) {
 	contextParser, ok := pc.contextParsers[context]
 	if !ok {
@@ -509,8 +461,6 @@ func (pc *ParserCollection[R]) ParseStatementsWithContext(context string, statem
 // If no contexts are present in the conditions, or if the inferred value is not supported by
 // the [ParserCollection], it returns an error.
 // If parsing the conditions fails, it returns the underlying [ottl.Parser.ParseConditions] error.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func (pc *ParserCollection[R]) ParseConditions(conditions ConditionsGetter) (R, error) {
 	conditionsValues := conditions.GetConditions()
 	inferredContext, err := pc.contextInferrer.inferFromConditions(conditionsValues)
@@ -539,8 +489,6 @@ func (pc *ParserCollection[R]) ParseConditions(conditions ConditionsGetter) (R, 
 // argument should be set to true, so it rewrites the conditions prepending the missing paths
 // contexts.
 // If parsing the conditions fails, it returns the underlying [ottl.Parser.ParseConditions] error.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func (pc *ParserCollection[R]) ParseConditionsWithContext(context string, conditions ConditionsGetter, prependPathsContext bool) (R, error) {
 	contextParser, ok := pc.contextParsers[context]
 	if !ok {
@@ -565,8 +513,6 @@ func (pc *ParserCollection[R]) ParseConditionsWithContext(context string, condit
 // If no contexts are present in the expressions, or if the inferred value is not supported by
 // the [ParserCollection], it returns an error.
 // If parsing the expressions fails, it returns the underlying [ottl.Parser.ParseValueExpressions] error.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func (pc *ParserCollection[R]) ParseValueExpressions(expressions ValueExpressionsGetter, options ...ParserCollectionContextInferenceOption) (R, error) {
 	expressionStrings := expressions.GetValueExpressions()
 
@@ -611,8 +557,6 @@ func (pc *ParserCollection[R]) ParseValueExpressions(expressions ValueExpression
 // argument should be set to true, so it rewrites the expressions prepending the missing paths
 // contexts.
 // If parsing the expressions fails, it returns the underlying [ottl.Parser.ParseValueExpressions] error.
-//
-// Experimental: *NOTE* this API is subject to change or removal in the future.
 func (pc *ParserCollection[R]) ParseValueExpressionsWithContext(context string, expressions ValueExpressionsGetter, prependPathsContext bool) (R, error) {
 	contextParser, ok := pc.contextParsers[context]
 	if !ok {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

A lot of the API we depend on still had experimental warnings. Those can be removed now. What stays experimental:

- lambdas
- SliceGetter
- WithCache

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

- fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50896

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
