### PR TITLE
[pkg/ottl]: add code coverage to readme

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -457,6 +457,122 @@ component_management:
     name: extension_tailstorage_pebbletailstorage
     paths:
     - extension/tailstorage/pebbletailstorageextension/**
+  - component_id: pkg_batchperresourceattr
+    name: pkg_batchperresourceattr
+    paths:
+    - pkg/batchperresourceattr/**
+  - component_id: pkg_batchpersignal
+    name: pkg_batchpersignal
+    paths:
+    - pkg/batchpersignal/**
+  - component_id: pkg_core_xidutils
+    name: pkg_core_xidutils
+    paths:
+    - pkg/core/xidutils/**
+  - component_id: pkg_datadog
+    name: pkg_datadog
+    paths:
+    - pkg/datadog/**
+  - component_id: pkg_experimentalmetricmetadata
+    name: pkg_experimentalmetricmetadata
+    paths:
+    - pkg/experimentalmetricmetadata/**
+  - component_id: pkg_expohisto
+    name: pkg_expohisto
+    paths:
+    - pkg/expohisto/**
+  - component_id: pkg_golden
+    name: pkg_golden
+    paths:
+    - pkg/golden/**
+  - component_id: pkg_kafka_configkafka
+    name: pkg_kafka_configkafka
+    paths:
+    - pkg/kafka/configkafka/**
+  - component_id: pkg_kafka_topic
+    name: pkg_kafka_topic
+    paths:
+    - pkg/kafka/topic/**
+  - component_id: pkg_ottl
+    name: pkg_ottl
+    paths:
+    - pkg/ottl/**
+  - component_id: pkg_pdatautil
+    name: pkg_pdatautil
+    paths:
+    - pkg/pdatautil/**
+  - component_id: pkg_resourcetotelemetry
+    name: pkg_resourcetotelemetry
+    paths:
+    - pkg/resourcetotelemetry/**
+  - component_id: pkg_sampling
+    name: pkg_sampling
+    paths:
+    - pkg/sampling/**
+  - component_id: pkg_stanza
+    name: pkg_stanza
+    paths:
+    - pkg/stanza/**
+  - component_id: pkg_status
+    name: pkg_status
+    paths:
+    - pkg/status/**
+  - component_id: pkg_translator_azure
+    name: pkg_translator_azure
+    paths:
+    - pkg/translator/azure/**
+  - component_id: pkg_translator_azurelogs
+    name: pkg_translator_azurelogs
+    paths:
+    - pkg/translator/azurelogs/**
+  - component_id: pkg_translator_faro
+    name: pkg_translator_faro
+    paths:
+    - pkg/translator/faro/**
+  - component_id: pkg_translator_jaeger
+    name: pkg_translator_jaeger
+    paths:
+    - pkg/translator/jaeger/**
+  - component_id: pkg_translator_loki
+    name: pkg_translator_loki
+    paths:
+    - pkg/translator/loki/**
+  - component_id: pkg_translator_pprof
+    name: pkg_translator_pprof
+    paths:
+    - pkg/translator/pprof/**
+  - component_id: pkg_translator_prometheus
+    name: pkg_translator_prometheus
+    paths:
+    - pkg/translator/prometheus/**
+  - component_id: pkg_translator_prometheusremotewrite
+    name: pkg_translator_prometheusremotewrite
+    paths:
+    - pkg/translator/prometheusremotewrite/**
+  - component_id: pkg_translator_signalfx
+    name: pkg_translator_signalfx
+    paths:
+    - pkg/translator/signalfx/**
+  - component_id: pkg_translator_skywalking
+    name: pkg_translator_skywalking
+    paths:
+    - pkg/translator/skywalking/**
+  - component_id: pkg_translator_splunk
+    name: pkg_translator_splunk
+    paths:
+    - pkg/translator/splunk/**
+  - component_id: pkg_translator_zipkin
+    name: pkg_translator_zipkin
+    paths:
+    - pkg/translator/zipkin/**
+  - component_id: pkg_winperfcounters
+    name: pkg_winperfcounters
+    paths:
+    - pkg/winperfcounters/**
+  - component_id: pkg_xstreamencoding
+    name: pkg_xstreamencoding
+    paths:
+    - pkg/xstreamencoding/**
   - component_id: processor_adaptivetailsampling
     name: processor_adaptivetailsampling
     paths:

--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ gendistributions:
 
 .PHONY: gencodecov
 gencodecov:
-	cd $(SRC_ROOT)/cmd/codecovgen && go run . --base-prefix github.com/open-telemetry/opentelemetry-collector-contrib --skipped-modules '**/*test,**/examples/**,pkg/**,cmd/**,internal/**,*/encoding/**' --dir $(SRC_ROOT)
+	cd $(SRC_ROOT)/cmd/codecovgen && go run . --base-prefix github.com/open-telemetry/opentelemetry-collector-contrib --skipped-modules '**/*test,**/examples/**,cmd/**,internal/**,*/encoding/**' --dir $(SRC_ROOT)
 
 # Regenerates all code, then updates CODEOWNERS, issue templates and component labels in .github
 .PHONY: update-codeowners

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -5,6 +5,7 @@
 | Stability     | [development]: profiles   |
 |               | [beta]: traces, metrics, logs   |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Apkg%2Fottl%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Apkg%2Fottl) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Apkg%2Fottl%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Apkg%2Fottl) |
+| Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=pkg_ottl)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=pkg_ottl&displayType=list) |
 | [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@TylerHelmuth](https://www.github.com/TylerHelmuth), [@evan-bradley](https://www.github.com/evan-bradley), [@edmocosta](https://www.github.com/edmocosta), [@bogdandrutu](https://www.github.com/bogdandrutu) \| Seeking more code owners! |
 | Emeritus      | [@anuraaga](https://www.github.com/anuraaga), [@kentquirk](https://www.github.com/kentquirk) |
 

--- a/pkg/ottl/metadata.yaml
+++ b/pkg/ottl/metadata.yaml
@@ -1,7 +1,6 @@
 type: ottl
 
 status:
-  disable_codecov_badge: true
   class: pkg
   stability:
     development: [ profiles ]

--- a/pkg/xk8stest/metadata.yaml
+++ b/pkg/xk8stest/metadata.yaml
@@ -1,4 +1,5 @@
 status:
+  disable_codecov_badge: true
   class: "pkg"
   codeowners:
     active: [crobert-1]


### PR DESCRIPTION
#### Description

As part of stability I wanted to include our code coverage in the OTTL readme like we have for components. This means removing the `pkg/**` exclusion. Since every other package explicitly opts out of code coverage in the readme this should be safe.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

- related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/47305

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
