### PR TITLE
fix(receiver/sshcheckreceiver): apply the configured timeout

### DIFF
--- a/.chloggen/sshcheckreceiver-timeout-not-applied.yaml
+++ b/.chloggen/sshcheckreceiver-timeout-not-applied.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/ssh_check
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the configured `timeout` never being applied to the underlying SSH connection.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50911]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sshcheckreceiver/internal/configssh/configssh.go
+++ b/receiver/sshcheckreceiver/internal/configssh/configssh.go
@@ -125,6 +125,7 @@ func (scs *SSHClientSettings) ToClient(component.Host, component.TelemetrySettin
 			Auth:            []ssh.AuthMethod{auth},
 			HostKeyCallback: hkc,
 			ClientVersion:   defaultClientVersion,
+			Timeout:         scs.Timeout,
 		},
 		DialFunc: ssh.Dial,
 	}, nil

--- a/receiver/sshcheckreceiver/internal/configssh/configssh_test.go
+++ b/receiver/sshcheckreceiver/internal/configssh/configssh_test.go
@@ -116,6 +116,7 @@ func TestAllSSHClientSettings(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, client.User, test.settings.Username)
+			assert.Equal(t, test.settings.Timeout, client.Timeout)
 
 			if test.settings.KeyFile != "" || test.settings.Password != "" {
 				assert.Len(t, client.Auth, 1)


### PR DESCRIPTION
#### Description

`ToClient` built the `ssh.ClientConfig` without setting `Timeout`, so the configured timeout never reached the underlying SSH connection. As a result, an unresponsive endpoint could cause the dial to hang indefinitely regardless of the configured value.

This change propagates the configured timeout to `ssh.ClientConfig.Timeout`.

#### Link to tracking issue

N/A - found while reviewing the code; there is no tracking issue.

#### Testing

Added an assertion to the existing `TestAllSSHClientSettings` test verifying that `client.Timeout` matches the configured value.

Without the fix, 5 of 6 subtests fail with the configured timeout expected (for example, `5s`) but the actual value remaining `0s`.

#### Documentation

N/A

#### Authorship

- [x] I, a human, wrote this pull request description myself.