### PR TITLE
[pkg/semconvtest] Pin the default Weaver image version.

### DIFF
--- a/.chloggen/semconvtest-pin-weaver-image.yaml
+++ b/.chloggen/semconvtest-pin-weaver-image.yaml
@@ -10,7 +10,7 @@ component: pkg/semconvtest
 note: Pin the default Weaver image version instead of floating on the latest tag
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50915]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/semconvtest-pin-weaver-image.yaml
+++ b/.chloggen/semconvtest-pin-weaver-image.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/semconvtest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Pin the default Weaver image version instead of floating on the latest tag
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use WithVersion to select a different version, including latest.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/semconvtest/README.md
+++ b/pkg/semconvtest/README.md
@@ -62,19 +62,22 @@ validates it.
 ## Source of truth
 
 By default the check runs against the newest published semantic-conventions
-registry: Weaver downloads it when the container starts, and the container
-runs the `otel/weaver:latest` image. Two consequences follow:
+registry: Weaver downloads it when the container starts. As a consequence, a
+test can start to fail without any code change, when the conventions evolve.
+That is the compliance signal: the telemetry no longer matches the current
+specification. For deterministic results, pin the registry with
+`WithRegistry`.
 
-- A test can start to fail without any code change, when the conventions
-  evolve. That is the compliance signal: the telemetry no longer matches the
-  current specification.
-- For deterministic results, pin both floating parts with the options below.
+The Weaver image itself does not float: the package pins a tested
+`otel/weaver` version and updates it deliberately (Renovate opens a PR for
+each new Weaver release). Use `WithVersion` to select a different version.
 
 ## Options
 
 - `WithVersion(version string)`: select the `otel/weaver` image version.
-  The default is `latest`; the minimum is v0.22.1. Tags that are not semver
-  pass through to Docker unchecked.
+  The default is the pinned, tested version; the minimum is v0.22.1. Tags
+  that are not semver (for example, `latest`) pass through to Docker
+  unchecked.
 - `WithRegistry(registry string)`: set the semantic-conventions registry
   passed to Weaver's `--registry` flag. When unset, Weaver uses its default
   registry: the latest published semantic conventions.

--- a/pkg/semconvtest/semconvtest.go
+++ b/pkg/semconvtest/semconvtest.go
@@ -40,15 +40,22 @@ const (
 	// package: v0.22.1 introduced the --output=http flag that returns the
 	// live-check report in the /stop response.
 	minWeaverVersion = "v0.22.1"
+
+	// defaultWeaverVersion is the otel/weaver image version used when a test
+	// does not select one with WithVersion. Renovate watches the line below
+	// and opens an update PR when a new Weaver release appears.
+	// renovate: datasource=docker depName=otel/weaver
+	defaultWeaverVersion = "v0.26.1"
 )
 
 // WeaverOption configures the Weaver container used for a live-check test.
 type WeaverOption func(*weaverOptions)
 
 // WithVersion selects the otel/weaver image version to use.
-// Defaults to "latest"; must be v0.22.1+ (the first version with
-// --output=http support). Semver versions older than that fail the
-// test immediately; non-semver tags are passed to Docker as-is.
+// Defaults to defaultWeaverVersion, a pinned version tested with this
+// package; must be v0.22.1+ (the first version with --output=http
+// support). Semver versions older than that fail the test immediately;
+// non-semver tags (e.g. "latest") are passed to Docker as-is.
 func WithVersion(version string) WeaverOption {
 	return func(o *weaverOptions) { o.version = version }
 }
@@ -129,7 +136,7 @@ func TestTraces(tb testing.TB, traces ptrace.Traces, opts ...WeaverOption) []Pol
 func runLiveCheck(tb testing.TB, opts []WeaverOption, send func(context.Context, *pdataClients) error) []PolicyFinding {
 	tb.Helper()
 
-	options := &weaverOptions{version: "latest"}
+	options := &weaverOptions{version: defaultWeaverVersion}
 	for _, opt := range opts {
 		opt(options)
 	}

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,17 @@
     "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.7_0",
     "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.top_query"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^pkg/semconvtest/semconvtest\\.go$/"
+      ],
+      "matchStrings": [
+        "// renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\n\\s*defaultWeaverVersion\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ]
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The PR changes the default otel/weaver image version from latest to a pinned, tested version (v0.26.1). The rationale behind it is that the Weaver v0.26.0 release changed the tool's behaviour and broke adopter tests without any code change on our side (fixed in #50758). The semconv registry is still kept as “free to float”, because new violations after a registry update are the whole point.
The PR also adds a Renovate custom manager (the repo's first), that detects new Weaver releases and opens an update PR, so each version bump is reviewed and tested. `WithVersion` and `WithRegistry` stay as overrides and it’s still possible to select `latest`. This approach was discussed with @braydonk, who suggested using Renovate for this.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to #50758.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
No new tests; the existing integration tests cover the change.
<!--Describe the documentation added.-->
#### Documentation
I updated the pkg README accordingly.
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
