### PR TITLE
[receiver/postgresqlreceiver] fix postgresql.table.size to include indexes and TOAST data

### DIFF
--- a/.chloggen/50914-postgresqlreceiver-table-size-total.yaml
+++ b/.chloggen/50914-postgresqlreceiver-table-size-total.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: receiver/postgresql
+
+note: Fix `postgresql.table.size` to report total disk space used by a table, including its indexes and TOAST data
+
+issues: [50914]
+
+subtext:
+
+change_logs: [user]

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -633,7 +633,7 @@ func (c *postgreSQLClient) getDatabaseTableMetrics(ctx context.Context, db strin
     s.n_tup_del AS del,
     s.n_tup_hot_upd AS hot_upd,
     s.seq_scan AS seq_scans,
-    pg_relation_size(s.relid) AS table_size,
+    pg_total_relation_size(s.relid) AS table_size,
     s.vacuum_count
 FROM pg_stat_user_tables s
 LEFT JOIN (

--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -252,7 +252,7 @@ Number of user tables in a database.
 
 ### postgresql.table.size
 
-Disk space used by a table.
+Total disk space used by a table, including its indexes and TOAST data.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -1021,3 +1021,129 @@ func tableCountEquivalenceTest(pgVersion string) func(*testing.T) {
 		assert.Equal(t, int64(len(tableMetrics)), count, "cheap table count must equal the full per-table query's row count")
 	}
 }
+
+// TestTableSizeIncludesIndexesAndToast is a regression test for the table_size
+// query using pg_relation_size, which silently excludes a table's indexes and
+// TOAST storage. Both fixture tables are built so pg_total_relation_size
+// exceeds pg_relation_size by an unambiguous, multi-page margin: reverting to
+// pg_relation_size (or only adding index size, but forgetting TOAST) fails
+// this test rather than passing by a rounding coincidence.
+//
+// Run against both sides of the PG14 pg_stat_user_tables boundary that
+// tableCountEquivalenceTest also straddles: pg_total_relation_size and TOAST
+// storage predate both test versions, but nothing else in this file exercises
+// table_size against a real database on pre17TestVersion.
+func TestTableSizeIncludesIndexesAndToast(t *testing.T) {
+	t.Run("pre17", tableSizeIncludesIndexesAndToastTest(pre17TestVersion))
+	t.Run("post17", tableSizeIncludesIndexesAndToastTest(post17TestVersion))
+}
+
+func tableSizeIncludesIndexesAndToastTest(pgVersion string) func(*testing.T) {
+	return func(t *testing.T) {
+		ci, err := testcontainers.GenericContainer(
+			t.Context(),
+			testcontainers.GenericContainerRequest{
+				ContainerRequest: testcontainers.ContainerRequest{
+					Image: fmt.Sprintf("postgres:%s", pgVersion),
+					Env: map[string]string{
+						"POSTGRES_USER":     "root",
+						"POSTGRES_PASSWORD": "otel",
+						"POSTGRES_DB":       "otel",
+					},
+					Files: []testcontainers.ContainerFile{{
+						HostFilePath:      filepath.Join("testdata", "integration", "03-table-size-init.sql"),
+						ContainerFilePath: "/docker-entrypoint-initdb.d/01-init.sql",
+						FileMode:          700,
+					}},
+					ExposedPorts: []string{postgresqlPort},
+					// A listening port is not enough: the postgres image runs a temporary
+					// server for its init scripts, so the port accepts connections while the
+					// real server is still "starting up" (57P03). The readiness log line is
+					// emitted twice -- once for the init server, once for the real one -- so
+					// waiting for the second occurrence guarantees the DB is ready to query.
+					WaitingFor: wait.ForLog("database system is ready to accept connections").
+						WithOccurrence(2).
+						WithStartupTimeout(2 * time.Minute),
+				},
+			},
+		)
+		require.NoError(t, err)
+		defer testcontainers.CleanupContainer(t, ci)
+
+		require.NoError(t, ci.Start(t.Context()))
+
+		p, err := ci.MappedPort(t.Context(), postgresqlPort)
+		require.NoError(t, err)
+
+		clientDB, err := getDB(t.Context(), postgreSQLConfig{
+			username: "otelu",
+			password: "otelp",
+			address: confignet.AddrConfig{
+				Endpoint: net.JoinHostPort("localhost", p.Port()),
+			},
+			tls: configtls.ClientConfig{
+				Insecure: true,
+			},
+		}, "otel")
+		require.NoError(t, err)
+
+		client := postgreSQLClient{client: clientDB, closeFn: clientDB.Close}
+		defer func() {
+			require.NoError(t, client.Close())
+		}()
+
+		// The receiver's own connection runs as otelu, so compute the reference
+		// values it can actually see rather than as the superuser -- a permission
+		// gap here would otherwise surface as a silent 0, not a test failure.
+		referenceQuery := `SELECT
+    c.relname,
+    pg_total_relation_size(c.oid),
+    pg_relation_size(c.oid),
+    pg_indexes_size(c.oid),
+    COALESCE(pg_total_relation_size(c.reltoastrelid), 0)
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relname IN ('big_index_table', 'toasted_table') AND n.nspname = 'public';`
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		rows, err := clientDB.QueryContext(ctx, referenceQuery)
+		require.NoError(t, err)
+		defer rows.Close()
+
+		type reference struct {
+			totalSize, relationSize, indexesSize, toastSize int64
+		}
+		referenceByTable := map[string]reference{}
+		for rows.Next() {
+			var name string
+			var ref reference
+			require.NoError(t, rows.Scan(&name, &ref.totalSize, &ref.relationSize, &ref.indexesSize, &ref.toastSize))
+			referenceByTable[name] = ref
+		}
+		require.NoError(t, rows.Err())
+		require.Len(t, referenceByTable, 2, "reference query should see both fixture tables")
+
+		tableMetrics, err := client.getDatabaseTableMetrics(ctx, "otel")
+		require.NoError(t, err)
+
+		indexRef := referenceByTable["big_index_table"]
+		require.Positive(t, indexRef.indexesSize, "fixture bug: index has no measurable size, assertion below would be vacuous")
+		indexStats, ok := tableMetrics[tableKey("otel", "public", "big_index_table")]
+		require.True(t, ok, "big_index_table missing from getDatabaseTableMetrics result")
+		assert.Equal(t, indexRef.totalSize, indexStats.size,
+			"postgresql.table.size must equal pg_total_relation_size, not pg_relation_size alone")
+		assert.Greater(t, indexStats.size, indexRef.relationSize,
+			"reported size must exceed the data-only size now that the table has a non-trivial index")
+
+		toastRef := referenceByTable["toasted_table"]
+		require.Positive(t, toastRef.toastSize, "fixture bug: no TOAST data was created, assertion below would be vacuous")
+		toastStats, ok := tableMetrics[tableKey("otel", "public", "toasted_table")]
+		require.True(t, ok, "toasted_table missing from getDatabaseTableMetrics result")
+		assert.Equal(t, toastRef.totalSize, toastStats.size,
+			"postgresql.table.size must equal pg_total_relation_size, not pg_relation_size alone")
+		assert.Greater(t, toastStats.size, toastRef.relationSize+toastRef.indexesSize,
+			"reported size must include TOAST data, not just the main heap and indexes")
+	}
+}

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
@@ -2829,7 +2829,7 @@ type metricPostgresqlTableSize struct {
 // init fills postgresql.table.size metric with initial data.
 func (m *metricPostgresqlTableSize) init() {
 	m.data.SetName("postgresql.table.size")
-	m.data.SetDescription("Disk space used by a table.")
+	m.data.SetDescription("Total disk space used by a table, including its indexes and TOAST data.")
 	m.data.SetUnit("By")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
@@ -1531,7 +1531,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["postgresql.table.size"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Disk space used by a table.", mi.Description())
+						assert.Equal(t, "Total disk space used by a table, including its indexes and TOAST data.", mi.Description())
 						assert.Equal(t, "By", mi.Unit())
 						assert.False(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())
@@ -1551,7 +1551,7 @@ func TestMetricsBuilder(t *testing.T) {
 						validatedMetrics["postgresql.table.size"] = true
 						assert.Equal(t, pmetric.MetricTypeSum, mi.Type())
 						assert.Equal(t, 1, mi.Sum().DataPoints().Len())
-						assert.Equal(t, "Disk space used by a table.", mi.Description())
+						assert.Equal(t, "Total disk space used by a table, including its indexes and TOAST data.", mi.Description())
 						assert.Equal(t, "By", mi.Unit())
 						assert.False(t, mi.Sum().IsMonotonic())
 						assert.Equal(t, pmetric.AggregationTemporalityCumulative, mi.Sum().AggregationTemporality())

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -588,7 +588,7 @@ metrics:
     unit: "{table}"
     attributes: [db.namespace]
   postgresql.table.size:
-    description: Disk space used by a table.
+    description: Total disk space used by a table, including its indexes and TOAST data.
     stability: development
     enabled: true
     unit: By

--- a/receiver/postgresqlreceiver/testdata/integration/03-table-size-init.sql
+++ b/receiver/postgresqlreceiver/testdata/integration/03-table-size-init.sql
@@ -1,0 +1,32 @@
+CREATE USER otelu WITH PASSWORD 'otelp';
+GRANT SELECT ON pg_stat_database TO otelu;
+GRANT pg_monitor TO otelu;
+
+-- big_index_table: enough rows for its primary-key btree index to be a
+-- meaningful, multi-page size on its own (a handful of rows would round to
+-- the same single page as an empty index, making the assertion flaky).
+-- Measured on postgres:17.2: 5000 rows -> index size roughly matches the
+-- data size, so pg_total_relation_size is comfortably ~2x pg_relation_size.
+CREATE TABLE big_index_table (
+    id serial PRIMARY KEY,
+    val integer NOT NULL
+);
+INSERT INTO big_index_table (val)
+SELECT g FROM generate_series(1, 5000) AS g;
+
+-- toasted_table: a wide text column pushed out-of-line into TOAST storage.
+-- Postgres only TOASTs values that make a row exceed roughly a quarter of
+-- the page size, so each value here is well past that threshold. Measured
+-- on postgres:17.2: 50 such rows already push the TOAST relation to several
+-- times the size of the main heap and its index combined.
+CREATE TABLE toasted_table (
+    id serial PRIMARY KEY,
+    payload text NOT NULL
+);
+INSERT INTO toasted_table (payload)
+SELECT repeat('x', 20000) FROM generate_series(1, 50);
+
+VACUUM ANALYZE big_index_table;
+VACUUM ANALYZE toasted_table;
+
+GRANT SELECT ON big_index_table, toasted_table TO otelu;

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db.yaml
@@ -964,7 +964,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1124,7 +1124,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1284,7 +1284,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1444,7 +1444,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db_connpool.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db_connpool.yaml
@@ -364,7 +364,7 @@ resourceMetrics:
                   timeUnixNano: "1706802526712082422"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -524,7 +524,7 @@ resourceMetrics:
                   timeUnixNano: "1706802526712082422"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -979,7 +979,7 @@ resourceMetrics:
                   timeUnixNano: "1706802526712082422"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1139,7 +1139,7 @@ resourceMetrics:
                   timeUnixNano: "1706802526712082422"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db_schemaattr.yaml
@@ -967,7 +967,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1130,7 +1130,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1293,7 +1293,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1456,7 +1456,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db.yaml
@@ -737,7 +737,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -897,7 +897,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1057,7 +1057,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1217,7 +1217,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_connpool.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_connpool.yaml
@@ -137,7 +137,7 @@ resourceMetrics:
                   timeUnixNano: "1706802461712893428"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -297,7 +297,7 @@ resourceMetrics:
                   timeUnixNano: "1706802461712893428"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -752,7 +752,7 @@ resourceMetrics:
                   timeUnixNano: "1706802461712893428"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -912,7 +912,7 @@ resourceMetrics:
                   timeUnixNano: "1706802461712893428"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_schemaattr.yaml
@@ -740,7 +740,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -903,7 +903,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1066,7 +1066,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1229,7 +1229,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_semconv.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_semconv.yaml
@@ -1447,7 +1447,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{table}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db.yaml
@@ -506,7 +506,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -666,7 +666,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db_connpool.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db_connpool.yaml
@@ -137,7 +137,7 @@ resourceMetrics:
                   timeUnixNano: "1706802396744882628"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -297,7 +297,7 @@ resourceMetrics:
                   timeUnixNano: "1706802396744882628"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db_post17.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db_post17.yaml
@@ -492,7 +492,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -652,7 +652,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db_schemaattr.yaml
@@ -509,7 +509,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -672,7 +672,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude.yaml
@@ -381,7 +381,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -531,7 +531,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -681,7 +681,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -831,7 +831,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude_schemaattr.yaml
@@ -384,7 +384,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -537,7 +537,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -690,7 +690,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -843,7 +843,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
@@ -975,7 +975,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1138,7 +1138,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1301,7 +1301,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1464,7 +1464,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1627,7 +1627,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1790,7 +1790,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag.yaml
@@ -975,7 +975,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1138,7 +1138,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1301,7 +1301,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1464,7 +1464,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1627,7 +1627,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1790,7 +1790,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag_schemaattr.yaml
@@ -978,7 +978,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1144,7 +1144,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1310,7 +1310,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1476,7 +1476,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1642,7 +1642,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1808,7 +1808,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
@@ -978,7 +978,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1144,7 +1144,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1310,7 +1310,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1476,7 +1476,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1642,7 +1642,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -1808,7 +1808,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_semconv.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_semconv.yaml
@@ -1903,7 +1903,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{table}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
@@ -609,7 +609,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -772,7 +772,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics.yaml
@@ -324,7 +324,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -474,7 +474,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics_schemaattr.yaml
@@ -327,7 +327,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -480,7 +480,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_execution_time.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_execution_time.yaml
@@ -348,7 +348,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -501,7 +501,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_execution_time_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_execution_time_schemaattr.yaml
@@ -351,7 +351,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -507,7 +507,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
@@ -612,7 +612,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -778,7 +778,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{sequential_scan}'
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_vector.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_vector.yaml
@@ -456,7 +456,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
@@ -609,7 +609,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
+          - description: Total disk space used by a table, including its indexes and TOAST data.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
- `postgresql.table.size` was computed using `pg_relation_size()`, which only measures a table's main data heap
- It silently excludes the table's indexes and TOAST storage (used for large column values)
- Metric is documented as "Disk space used by a table" — the old query didn't match that description
- Fixed by switching the query to `pg_total_relation_size()` (data + indexes + TOAST)
- Added a regression test since the existing shared integration fixture explicitly excludes this metric from value comparison (`IgnoreMetricValues`), so nothing previously caught this
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #50914

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- `make fmt` - clean
- `make lint` - clean
- `make generate` - clean, no unexpected diffs
- Full unit test suite - passing
- Full integration test suite - passing, including new test on both `postgres:13.18` and `postgres:17.2`
<!--Describe the documentation added.-->
#### Documentation
- metadata.yaml description updated to reflect the corrected behavior
- documentation.md regenerated via make generate to match
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
