### PR TITLE
[internal/healthcheck] migrate to NotifyConfigSnapshot

### DIFF
--- a/.chloggen/codeboten_notify-snapshot.yaml
+++ b/.chloggen/codeboten_notify-snapshot.yaml
@@ -10,7 +10,7 @@ component: internal/healthcheck
 note: Migrate to NotifyConfigSnapshot
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50924]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_notify-snapshot.yaml
+++ b/.chloggen/codeboten_notify-snapshot.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: internal/healthcheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Migrate to NotifyConfigSnapshot
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/healthcheck/extension.go
+++ b/internal/healthcheck/extension.go
@@ -9,7 +9,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 	"go.uber.org/multierr"
@@ -37,9 +36,9 @@ type HealthCheckExtension struct {
 }
 
 var (
-	_ component.Component                   = (*HealthCheckExtension)(nil)
-	_ extensioncapabilities.ConfigWatcher   = (*HealthCheckExtension)(nil)
-	_ extensioncapabilities.PipelineWatcher = (*HealthCheckExtension)(nil)
+	_ component.Component                         = (*HealthCheckExtension)(nil)
+	_ extensioncapabilities.ConfigSnapshotWatcher = (*HealthCheckExtension)(nil)
+	_ extensioncapabilities.PipelineWatcher       = (*HealthCheckExtension)(nil)
 )
 
 func NewHealthCheckExtension(
@@ -147,12 +146,12 @@ func (hc *HealthCheckExtension) ComponentStatusChanged(
 	hc.eventCh <- &eventSourcePair{source: source, event: event}
 }
 
-// NotifyConfig implements the extensioncapabilities.ConfigWatcher interface.
-func (hc *HealthCheckExtension) NotifyConfig(ctx context.Context, conf *confmap.Conf) error {
+// NotifyConfigSnapshot implements the extensioncapabilities.ConfigSnapshotWatcher interface.
+func (hc *HealthCheckExtension) NotifyConfigSnapshot(ctx context.Context, configSnapshot extensioncapabilities.ConfigSnapshot) error {
 	var err error
 	for _, comp := range hc.subcomponents {
-		if cw, ok := comp.(extensioncapabilities.ConfigWatcher); ok {
-			err = multierr.Append(err, cw.NotifyConfig(ctx, conf))
+		if cw, ok := comp.(extensioncapabilities.ConfigSnapshotWatcher); ok {
+			err = multierr.Append(err, cw.NotifyConfigSnapshot(ctx, configSnapshot))
 		}
 	}
 	return err

--- a/internal/healthcheck/extension_test.go
+++ b/internal/healthcheck/extension_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 	"go.opentelemetry.io/collector/extension/extensiontest"
 	"go.opentelemetry.io/collector/pipeline"
 
@@ -109,7 +110,7 @@ func TestComponentStatus(t *testing.T) {
 	assert.Equal(t, componentstatus.StatusStopping, st.Status())
 }
 
-func TestNotifyConfig(t *testing.T) {
+func TestNotifyConfigSnapshot(t *testing.T) {
 	confMap, err := confmaptest.LoadConf(
 		filepath.Join("internal", "httpserver", "testdata", "config.yaml"),
 	)
@@ -152,7 +153,8 @@ func TestNotifyConfig(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
-	require.NoError(t, ext.NotifyConfig(ctx, confMap))
+	snapshot := extensioncapabilities.NewConfigSnapshot(confMap, nil)
+	require.NoError(t, ext.NotifyConfigSnapshot(ctx, snapshot))
 
 	resp, err = client.Get(url)
 	require.NoError(t, err)

--- a/internal/healthcheck/internal/httpserver/server.go
+++ b/internal/healthcheck/internal/httpserver/server.go
@@ -16,7 +16,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 	"go.uber.org/zap"
 
@@ -39,8 +38,8 @@ type Server struct {
 }
 
 var (
-	_ component.Component                 = (*Server)(nil)
-	_ extensioncapabilities.ConfigWatcher = (*Server)(nil)
+	_ component.Component                         = (*Server)(nil)
+	_ extensioncapabilities.ConfigSnapshotWatcher = (*Server)(nil)
 )
 
 func NewServer(
@@ -130,9 +129,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 }
 
-// NotifyConfig implements the extension.ConfigWatcher interface.
-func (s *Server) NotifyConfig(_ context.Context, conf *confmap.Conf) error {
-	confBytes, err := json.Marshal(conf.ToStringMap())
+// NotifyConfigSnapshot implements the extension.ConfigSnapshotWatcher interface.
+func (s *Server) NotifyConfigSnapshot(_ context.Context, configSnapshot extensioncapabilities.ConfigSnapshot) error {
+	confBytes, err := json.Marshal(configSnapshot.Effective().ToStringMap())
 	if err != nil {
 		s.telemetry.Logger.Warn("could not marshal config", zap.Error(err))
 		return err

--- a/internal/healthcheck/internal/httpserver/server_test.go
+++ b/internal/healthcheck/internal/httpserver/server_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.uber.org/goleak"
@@ -3287,7 +3288,8 @@ func TestConfig(t *testing.T) {
 				},
 			},
 			setup: func() {
-				require.NoError(t, server.NotifyConfig(t.Context(), confMap))
+				snapshot := extensioncapabilities.NewConfigSnapshot(confMap, nil)
+				require.NoError(t, server.NotifyConfigSnapshot(t.Context(), snapshot))
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedBody:       confJSON,


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

NotifyConfig has been marked as deprecated for some versions, time to migrate.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
