### PR TITLE
[connector/spanmetrics] Skip resource iteration in resetState when nothing needs resetting

### DIFF
--- a/.chloggen/spanmetrics-skip-reset-iteration.yaml
+++ b/.chloggen/spanmetrics-skip-reset-iteration.yaml
@@ -10,8 +10,7 @@ component: connector/span_metrics
 note: Skip the per-flush resource iteration in cumulative mode when no exemplar clearing or expiration is configured.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-# TODO: fill in the PR number.
-issues: []
+issues: [50925]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/spanmetrics-skip-reset-iteration.yaml
+++ b/.chloggen/spanmetrics-skip-reset-iteration.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/span_metrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skip the per-flush resource iteration in cumulative mode when no exemplar clearing or expiration is configured.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+# TODO: fill in the PR number.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -379,7 +379,7 @@ func (p *connectorImp) resetState() {
 
 		// If none of these features are enabled then we can skip the remaining operations.
 		// Enabling either of these features requires to go over resource metrics and do operation on each.
-		if p.config.Histogram.Disable && p.config.MetricsExpiration == 0 && p.config.SeriesExpiration == 0 && !p.config.Exemplars.Enabled {
+		if p.config.MetricsExpiration == 0 && p.config.SeriesExpiration == 0 && !p.config.Exemplars.Enabled {
 			return
 		}
 

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -1432,6 +1432,18 @@ func TestSeriesExpiration(t *testing.T) {
 	assert.True(t, hasDataPointWithStringAttrValue(exported, "B"))
 }
 
+func TestResetStateSkipsIterationWhenNothingToReset(t *testing.T) {
+	p, err := newConnectorImp(new("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, disabledEventsConfig, cumulative, 0, []string{}, 1000, clockwork.NewFakeClock(), false)
+	require.NoError(t, err)
+	require.NoError(t, p.ConsumeTraces(metadata.NewIncomingContext(t.Context(), nil), buildSampleTrace()))
+
+	// With cumulative temporality and no exemplars or expiration configured, resetState has
+	// nothing to do per resource, so it must not iterate over (and allocate a key slice for) the cache.
+	allocs := testing.AllocsPerRun(10, p.resetState)
+	assert.Zero(t, allocs)
+	assert.Equal(t, 2, p.resourceMetrics.Len())
+}
+
 func TestResourceMetricsKeyAttributes(t *testing.T) {
 	resourceMetricsKeyAttributes := []string{
 		"service.name",


### PR DESCRIPTION
#### Description

`p.config.Histogram.Disable` condition in `resetState()` function becomes stale from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32210 change. This makes `p.config.Histogram.Disable` condition as no-ops, cause `m.histograms.ClearExemplars()` is called only when `p.config.Exemplars.Enabled && !p.config.Histogram.Disable`. So when histogram is enabled (default) and exemplar is disabled (default), early return is false and need to loop through resource cache even though iteration doesn't call clearing exemplar.

#### Link to tracking issue

N/A. Found small issue during investigation and create PR since it is small fix.

#### Testing

created minimal test case. confirmed it failed before change, passed after change.

before
```bash
$ go test -count=1 -run TestResetStateSkipsIterationWhenNothingToReset -v .
=== RUN   TestResetStateSkipsIterationWhenNothingToReset
    connector_test.go:1443:
                Error Trace:    /opentelemetry-collector-contrib/connector/spanmetricsconnector/connector_test.go:1443
                Error:          Should be zero, but was 1
                Test:           TestResetStateSkipsIterationWhenNothingToReset
--- FAIL: TestResetStateSkipsIterationWhenNothingToReset (0.00s)
FAIL
FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector        1.835s
FAIL
```

after
```bash
$ go test -count=1 -run TestResetStateSkipsIterationWhenNothingToReset -v .
=== RUN   TestResetStateSkipsIterationWhenNothingToReset
--- PASS: TestResetStateSkipsIterationWhenNothingToReset (0.00s)
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector        2.387s
```

#### Documentation

No update.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
