### PR TITLE
[chore] fix go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ OTEL_STABLE_VERSION=main
 VERSION=$(shell git describe --always --match "v[0-9]*" HEAD)
 TRIMMED_VERSION=$(shell grep -o 'v[^-]*' <<< "$(VERSION)" | cut -c 2-)
 CORE_VERSIONS=$(SRC_PARENT_DIR)/opentelemetry-collector/versions.yaml
-GO_COMPAT_VERSION=$(shell grep '^go ' go.mod | awk '{print $$2}')
 
 COMP_REL_PATH=cmd/otelcontribcol/components.go
 MOD_NAME=github.com/open-telemetry/opentelemetry-collector-contrib

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -17,6 +17,7 @@ COVER_DIR_ABS?=$(SRC_ROOT)/$(COVER_DIR)
 GO_BUILD_TAGS=""
 # These ldflags allow the build tool to omit the symbol table, debug information, and the DWARF symbol table to downscale binary size.
 GO_BUILD_LDFLAGS="-s -w"
+GO_COMPAT_VERSION=$(shell awk '/^go /{print $$2}' go.mod)
 GOTEST_TIMEOUT?= 900s
 GOCMD?= go
 GOOS=$(shell $(GOCMD) env GOOS)


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

the go version was missing when running make -C {module} tidy because the GO_COMPAT_VERSION wasn't being expanded. this is fixed now, also simplifying the grep/awk into a single awk

Before:
```
make -C internal/healthcheck tidy
rm -fr go.sum
go mod tidy -compat=
```

After:
```
make -C internal/healthcheck tidy
rm -fr go.sum
go mod tidy -compat=1.26.0
```

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
