### PR TITLE
[extension/datadog] migrate to NotifyConfigSnapshot

### DIFF
--- a/.chloggen/codbeoten_migrate-1.yaml
+++ b/.chloggen/codbeoten_migrate-1.yaml
@@ -10,7 +10,7 @@ component: extension/datadog
 note: Migrate from NotifyConfig to NotifyConfigSnapshot
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [50928]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codbeoten_migrate-1.yaml
+++ b/.chloggen/codbeoten_migrate-1.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Migrate from NotifyConfig to NotifyConfigSnapshot
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -112,11 +112,8 @@ func (e *datadogExtension) NotifyConfigSnapshot(_ context.Context, configSnapsho
 	e.configs.mutex.Lock()
 	defer e.configs.mutex.Unlock()
 
-	var conf *confmap.Conf
-
-	if configSnapshot.Effective() != nil {
-		conf = configSnapshot.Effective()
-	} else {
+	conf := configSnapshot.Effective()
+	if conf == nil {
 		conf = confmap.New()
 	}
 

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -100,17 +100,25 @@ type datadogExtension struct {
 }
 
 var (
-	_ extensioncapabilities.ConfigWatcher   = (*datadogExtension)(nil)
-	_ extensioncapabilities.PipelineWatcher = (*datadogExtension)(nil)
-	_ componentstatus.Watcher               = (*datadogExtension)(nil)
+	_ extensioncapabilities.ConfigSnapshotWatcher = (*datadogExtension)(nil)
+	_ extensioncapabilities.PipelineWatcher       = (*datadogExtension)(nil)
+	_ componentstatus.Watcher                     = (*datadogExtension)(nil)
 )
 
-// NotifyConfig implements the extensioncapabilities.ConfigWatcher interface, which allows
+// NotifyConfigSnapshot implements the extensioncapabilities.ConfigSnapshotWatcher interface, which allows
 // this extension to be notified of the Collector's effective configuration.
 // This method is called during startup by the Collector's service after calling Start.
-func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) error {
+func (e *datadogExtension) NotifyConfigSnapshot(_ context.Context, configSnapshot extensioncapabilities.ConfigSnapshot) error {
 	e.configs.mutex.Lock()
 	defer e.configs.mutex.Unlock()
+
+	var conf *confmap.Conf
+
+	if configSnapshot.Effective() != nil {
+		conf = configSnapshot.Effective()
+	} else {
+		conf = confmap.New()
+	}
 
 	e.configs.collector = conf
 

--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/service"
 
@@ -122,8 +123,8 @@ func TestExtensionLifecycle(t *testing.T) {
 		assert.True(t, mockSerializer.startCalled, "serializer.Start should be called")
 		assert.NotEmpty(t, ext.info.modules.Receiver, "module infos should be populated")
 
-		// NotifyConfig will create and start the http server
-		err = ext.NotifyConfig(t.Context(), confmap.New())
+		// NotifyConfigSnapshot will create and start the http server
+		err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(confmap.New(), nil))
 		require.NoError(t, err)
 		require.NotNil(t, ext.httpServer, "httpServer should be created")
 
@@ -196,7 +197,7 @@ func TestNotifyConfig(t *testing.T) {
 			component.MustNewType("otlp"): {BuilderRef: "gomod.example/otlp v1.0.0"},
 		}}
 
-		err = ext.NotifyConfig(t.Context(), conf)
+		err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(conf, nil))
 		require.NoError(t, err)
 		assert.NotNil(t, ext.configs.collector)
 		assert.NotNil(t, ext.otelCollectorMetadata)
@@ -242,9 +243,8 @@ func TestCollectorResourceAttributesArePopulated(t *testing.T) {
 	ext.serializer = &mockSerializer{}
 	require.NoError(t, ext.Start(t.Context(), componenttest.NewNopHost()))
 
-	// Minimal config to trigger NotifyConfig
-	conf := confmap.NewFromStringMap(map[string]any{})
-	err = ext.NotifyConfig(t.Context(), conf)
+	// Minimal config to trigger NotifyConfigSnapshot
+	err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(nil, nil))
 	require.NoError(t, err)
 
 	// Expect map with keys and values (os.type is always injected as a fallback)
@@ -289,9 +289,8 @@ func TestCollectorResourceAttributesWithMultipleKeys(t *testing.T) {
 	ext.serializer = &mockSerializer{}
 	require.NoError(t, ext.Start(t.Context(), componenttest.NewNopHost()))
 
-	// Minimal config to trigger NotifyConfig
-	conf := confmap.NewFromStringMap(map[string]any{})
-	err = ext.NotifyConfig(t.Context(), conf)
+	// Minimal config to trigger NotifyConfigSnapshot
+	err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(nil, nil))
 	require.NoError(t, err)
 
 	// Verify all resource attributes are collected (os.type is always injected as a fallback)
@@ -357,7 +356,7 @@ func TestNotifyConfigErrorPaths(t *testing.T) {
 		})
 
 		// This should trigger the error path when SendPayload fails
-		err = ext.NotifyConfig(t.Context(), conf)
+		err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(conf, nil))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "payload send failed")
 
@@ -398,7 +397,7 @@ func TestNotifyConfigErrorPaths(t *testing.T) {
 		})
 
 		// This should trigger warning but not fail
-		err = ext.NotifyConfig(t.Context(), conf)
+		err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(conf, nil))
 		require.NoError(t, err) // Should not fail, just log warning
 
 		// Cleanup
@@ -447,7 +446,7 @@ func TestNotifyConfigErrorPaths(t *testing.T) {
 		}
 
 		// This should trigger warning but not fail
-		err = ext.NotifyConfig(t.Context(), conf)
+		err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(conf, nil))
 		require.NoError(t, err) // Should not fail, just log warning
 
 		// Cleanup
@@ -521,9 +520,8 @@ func TestExtension_DeploymentTypeInPayload(t *testing.T) {
 			ext.serializer = &mockSerializer{}
 			require.NoError(t, ext.Start(t.Context(), componenttest.NewNopHost()))
 
-			// Minimal config to trigger NotifyConfig
-			conf := confmap.NewFromStringMap(map[string]any{})
-			err = ext.NotifyConfig(t.Context(), conf)
+			// Minimal config to trigger NotifyConfigSnapshot
+			err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(nil, nil))
 			require.NoError(t, err)
 
 			// Verify the deployment type is set correctly in the payload
@@ -579,8 +577,8 @@ func TestPeriodicPayloadSending(t *testing.T) {
 			component.MustNewType("otlp"): {BuilderRef: "gomod.example/otlp v1.0.0"},
 		}}
 
-		// NotifyConfig should start the periodic payload sending
-		err = ext.NotifyConfig(t.Context(), conf)
+		// NotifyConfigSnapshot should start the periodic payload sending
+		err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(conf, nil))
 		require.NoError(t, err)
 
 		// Verify periodic sending components are initialized
@@ -638,8 +636,8 @@ func TestPeriodicPayloadSending(t *testing.T) {
 			component.MustNewType("otlp"): {BuilderRef: "gomod.example/otlp v1.0.0"},
 		}}
 
-		// NotifyConfig will send the initial payload
-		err = ext.NotifyConfig(t.Context(), conf)
+		// NotifyConfigSnapshot will send the initial payload
+		err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(conf, nil))
 		require.NoError(t, err)
 
 		initialCount := mockSerializer.GetSendCount()
@@ -698,8 +696,8 @@ func TestPeriodicPayloadSending(t *testing.T) {
 			component.MustNewType("otlp"): {BuilderRef: "gomod.example/otlp v1.0.0"},
 		}}
 
-		// NotifyConfig will succeed with the first payload
-		err = ext.NotifyConfig(t.Context(), conf)
+		// NotifyConfigSnapshot will succeed with the first payload
+		err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(conf, nil))
 		require.NoError(t, err)
 
 		// Trigger manual payload send which should fail but not crash
@@ -729,7 +727,7 @@ func TestPeriodicPayloadSending(t *testing.T) {
 }
 
 func TestNotifyConfigConcurrentAccess(t *testing.T) {
-	t.Run("concurrent NotifyConfig calls are synchronized", func(t *testing.T) {
+	t.Run("concurrent NotifyConfigSnapshot calls are synchronized", func(t *testing.T) {
 		set := extension.Settings{
 			TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 			BuildInfo:         component.BuildInfo{Version: "1.2.3"},
@@ -776,7 +774,7 @@ func TestNotifyConfigConcurrentAccess(t *testing.T) {
 			}),
 		}
 
-		// Run concurrent NotifyConfig calls
+		// Run concurrent NotifyConfigSnapshot calls
 		const numGoroutines = 10
 		var wg sync.WaitGroup
 		errors := make(chan error, numGoroutines)
@@ -786,7 +784,7 @@ func TestNotifyConfigConcurrentAccess(t *testing.T) {
 			go func(confIndex int) {
 				defer wg.Done()
 				conf := confs[confIndex%len(confs)]
-				if err := ext.NotifyConfig(t.Context(), conf); err != nil {
+				if err := ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(conf, nil)); err != nil {
 					// First call might succeed, subsequent calls will fail due to HTTP server already running
 					// But they should not race condition or panic
 					errors <- err
@@ -1185,8 +1183,8 @@ func TestExtensionLivenessMetric(t *testing.T) {
 		err = ext.Start(t.Context(), componenttest.NewNopHost())
 		require.NoError(t, err)
 
-		// Trigger NotifyConfig which starts periodic sending
-		err = ext.NotifyConfig(t.Context(), confmap.New())
+		// Trigger NotifyConfigSnapshot which starts periodic sending
+		err = ext.NotifyConfigSnapshot(t.Context(), extensioncapabilities.NewConfigSnapshot(nil, nil))
 		require.NoError(t, err)
 
 		// Wait a bit for the initial liveness metric to be sent

--- a/extension/datadogextension/internal/httpserver/httpserver.go
+++ b/extension/datadogextension/internal/httpserver/httpserver.go
@@ -53,7 +53,7 @@ type Server struct {
 }
 
 // NewServer creates a new HTTP server instance.
-// It should be called after NotifyConfig has received full configuration.
+// It should be called after NotifyConfigSnapshot has received full configuration.
 // TODO: support generic payloads
 func NewServer(
 	logger *zap.Logger,


### PR DESCRIPTION
#### Description

NotifyConfig is being removed as it was deprecated, time to migrate.


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
