### PR TITLE
[receiver/splunkenterprise] send search job TTL in seconds instead of nanoseconds

### DIFF
--- a/.chloggen/fix-splunk-search-job-ttl-units.yaml
+++ b/.chloggen/fix-splunk-search-job-ttl-units.yaml
@@ -1,0 +1,17 @@
+change_type: bug_fix
+
+component: receiver/splunk_enterprise
+
+note: Send the search job TTL to Splunk in seconds instead of nanoseconds
+
+issues: [50940]
+
+subtext: |
+  The receiver sets a TTL on every search job it dispatches, derived from the configured
+  `timeout`. The value was formatted from a Go duration with `%d`, which emits its raw
+  nanosecond count, and Splunk's `setttl` action reads the argument as seconds. A default
+  `timeout: 60s` therefore asked Splunk to retain each dispatched job for roughly 1900 years,
+  so search artifacts accumulated until the search dispatch directory filled and Splunk
+  reported extreme search lag. The duration is now converted to whole seconds.
+
+change_logs: [user]

--- a/receiver/splunkenterprisereceiver/scraper.go
+++ b/receiver/splunkenterprisereceiver/scraper.go
@@ -2166,7 +2166,9 @@ func (s *splunkScraper) getSearchEntries(sid string) (searchMetaEntries, error) 
 	return metaEntries, nil
 }
 
-// setSearchJobTTLById sets the SearchJob's TTL on the remote Splunk server to Timeout and returns a ControlResponse.
+// setSearchJobTTLByID sets the SearchJob's TTL on the remote Splunk server to the configured
+// Timeout. Splunk's setttl action expects a whole number of seconds, so the duration must be
+// converted; passing it directly would send its raw nanosecond representation.
 func (s *splunkScraper) setSearchJobTTLByID(sid string) error {
 	ept := fmt.Sprintf("/services/search/jobs/%s/control", sid)
 
@@ -2177,7 +2179,7 @@ func (s *splunkScraper) setSearchJobTTLByID(sid string) error {
 
 	form := url.Values{
 		"action": []string{"setttl"},
-		"ttl":    []string{fmt.Sprintf("%d", s.conf.ControllerConfig.Timeout)},
+		"ttl":    []string{strconv.Itoa(int(s.conf.ControllerConfig.Timeout.Seconds()))},
 	}
 	req.Body = io.NopCloser(strings.NewReader(form.Encode()))
 	req.Method = http.MethodPost

--- a/receiver/splunkenterprisereceiver/scraper_test.go
+++ b/receiver/splunkenterprisereceiver/scraper_test.go
@@ -650,3 +650,79 @@ func TestFormatDurationForSplunk(t *testing.T) {
 		})
 	}
 }
+
+// capturedTTLRequest is what the mock control endpoint observed, handed back over a channel so
+// the test goroutine owns it exclusively rather than sharing it with the handler.
+type capturedTTLRequest struct {
+	method string
+	path   string
+	body   []byte
+	err    error
+}
+
+// Regression test for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50940.
+// Splunk's setttl action reads the ttl argument as a whole number of seconds. The configured
+// Timeout was formatted straight out of a time.Duration, which emits its raw nanosecond count, so
+// a 60s timeout asked Splunk to retain every dispatched job for roughly 1900 years and the search
+// dispatch directory never drained.
+func TestSetSearchJobTTLByID(t *testing.T) {
+	const sid = "test-search-id"
+
+	tests := []struct {
+		desc     string
+		timeout  time.Duration
+		expected string
+	}{
+		{desc: "default timeout", timeout: 60 * time.Second, expected: "60"},
+		{desc: "sub minute timeout", timeout: 11 * time.Second, expected: "11"},
+		{desc: "multi minute timeout", timeout: 2 * time.Minute, expected: "120"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			// Buffered so the handler never blocks, and so a second unexpected request would be
+			// visible as a surplus entry rather than deadlocking the test.
+			captured := make(chan capturedTTLRequest, 1)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				captured <- capturedTTLRequest{method: r.Method, path: r.URL.Path, body: body, err: err}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ts.Close()
+
+			cfg := createConfig(ts, false)
+			cfg.ControllerConfig.Timeout = test.timeout
+
+			host := &mockHost{
+				extensions: map[component.ID]component.Component{
+					component.MustNewIDWithName("basicauth", "client"): extensionauthtest.NewNopClient(),
+				},
+			}
+
+			scraper := newSplunkMetricsScraper(receivertest.NewNopSettings(metadata.Type), cfg)
+			client, err := newSplunkEntClient(t.Context(), cfg, host, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+			scraper.splunkClient = client
+
+			require.NoError(t, scraper.setSearchJobTTLByID(sid))
+
+			var got capturedTTLRequest
+			select {
+			case got = <-captured:
+			default:
+				t.Fatal("control endpoint was never called")
+			}
+			require.Empty(t, captured, "expected exactly one request to the control endpoint")
+
+			require.NoError(t, got.err)
+			// createAPIRequest builds a GET, which this call has to flip to POST.
+			require.Equal(t, http.MethodPost, got.method)
+			require.Equal(t, "/services/search/jobs/"+sid+"/control", got.path)
+
+			form, err := url.ParseQuery(string(got.body))
+			require.NoError(t, err)
+			require.Equal(t, "setttl", form.Get("action"))
+			require.Equal(t, test.expected, form.Get("ttl"))
+		})
+	}
+}


### PR DESCRIPTION
#### Description
`setSearchJobTTLByID` formatted the configured timeout with `%d` which emits raw nanosecond count rather than seconds and Splunks setttl action reads the argument as seconds. A default timeout of 60s therefore dispatched every search job in Splunk with a lifespan of roughly 1902 years. Artifacts accumulated in the dispatch directory until parition filled and Splunk reported extreme search lag.

Converted the duration to whole seconds and added a tests for regression and lack of tests for this bug.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50940


#### Testing

- Added `TestSetSearchJobTTLByID ` to `scraper_test.go`. Table-driven over three timeouts: 60s -> 60, 11s -> 11, 2m -> 120
- Confirmed it genuinely catches the bug, with the original code the test catches `expected: "60"` `atcual: "60000000000"`.

#### Documentation
No documentation needed except comments.


#### Authorship

- [X] I, a human, wrote this pull request description myself.
