### PR TITLE
[processor/adaptive_tail_sampling] add shared_counters for fleet-wide goal_throughput

### DIFF
--- a/.chloggen/adaptivetailsampling-shared-counters.yaml
+++ b/.chloggen/adaptivetailsampling-shared-counters.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/adaptive_tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `shared_counters` to `adaptive_throughput` samplers, making `goal_throughput` a fleet-wide budget shared across collector instances via a sampler-state extension.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50577]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Throughput samplers now publish per-interval traffic counts to a counter store and recompute
+  rates from the merged totals. Without `shared_counters` the store is in-process and behavior
+  stays per-instance. With `shared_counters: {extension: <id>}` counts merge across every
+  instance sharing the extension, so `goal_throughput` becomes the combined budget for the
+  fleet. Store I/O runs on the adjustment tick only and fails open to per-instance counts.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/adaptivetailsampling-throughput-maxkeys.yaml
+++ b/.chloggen/adaptivetailsampling-throughput-maxkeys.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/adaptive_tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`adaptive_throughput` samplers now apply the initial sampling rate to keys beyond `max_keys` instead of keeping every trace for them."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [50538]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously a full key map meant new keys bypassed rate learning and sampled at 1 (keep
+  everything), silently blowing the throughput budget under key-cardinality pressure. Keys
+  that age out free capacity for new keys as before. `adaptive_percentage` is unchanged.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -357,6 +357,7 @@ sampler:
     - resource.attributes["service.name"]
   shared_counters:
     extension: my_sampler_state           # component ID of a sampler-state extension
+    sync_timeout: 5s                      # per round-trip bound; 0 or omitted = half the interval
 ```
 
 The named extension must implement the counter-store contract
@@ -366,10 +367,13 @@ same rule name, goal, algorithm, and intervals, since each instance recomputes
 rates from the merged counts independently.
 
 Store I/O happens once per adjustment interval on a background goroutine,
-never on the span-processing path. Store failures fail open: the sampler
-applies its own counts for that interval (per-instance behavior against the
-full goal, which over-samples fleet-wide) rather than stalling, logs a
-warning, and increments
+never on the span-processing path. Each round-trip is bounded by
+`sync_timeout` (default: half the effective interval), so a store slower than
+the interval, likely the moment a traffic burst is loading it, is abandoned
+rather than stalling the loop. Store failures and timeouts both fail open: the
+sampler applies its own counts for that interval (per-instance behavior
+against the full goal, which over-samples fleet-wide) rather than stalling,
+logs a warning, and increments
 `otelcol_processor_adaptive_tail_sampling_counter_sync_errors`.
 
 When `shared_counters` is unset, counts stay in process and behavior is

--- a/processor/adaptivetailsamplingprocessor/README.md
+++ b/processor/adaptivetailsamplingprocessor/README.md
@@ -322,7 +322,7 @@ sampler:
 ```
 
 > [!IMPORTANT]
-> `goal_throughput` is enforced **per collector instance**. Each instance targets the goal against the traffic it sees, so a fleet of N instances emits up to N times the configured throughput. Divide the backend budget by the instance count when sizing this value. See [Deployment considerations](#deployment-considerations).
+> Without `shared_counters`, `goal_throughput` is enforced **per collector instance**. Each instance targets the goal against the traffic it sees, so a fleet of N instances emits up to N times the configured throughput. Divide the backend budget by the instance count when sizing this value, or configure `shared_counters` to make the goal fleet-wide. See [Deployment considerations](#deployment-considerations).
 
 With `algorithm: windowed`, rate recalculation (`update_frequency`) is
 decoupled from the historical window used for the calculation
@@ -340,6 +340,43 @@ sampler:
   lookback_frequency: 30s                 # historical window; floored to a multiple of update_frequency
   max_keys: 500
 ```
+
+##### Sharing the throughput budget across instances
+
+`shared_counters` connects the sampler to a sampler-state extension that
+merges per-interval traffic counts across collector instances. Every instance
+publishes what it saw and reads back the fleet-wide totals, then recomputes
+the same rate table locally, making `goal_throughput` the combined budget for
+the fleet rather than a per-instance target:
+
+```yaml
+sampler:
+  type: adaptive_throughput
+  goal_throughput: 100                    # fleet-wide spans/sec with shared_counters
+  fingerprint_attributes:
+    - resource.attributes["service.name"]
+  shared_counters:
+    extension: my_sampler_state           # component ID of a sampler-state extension
+```
+
+The named extension must implement the counter-store contract
+(`AddCounts`/`ReadCounts`, see `internal/counterstore`); no such extension
+ships in this repository yet. All instances sharing a store must configure the
+same rule name, goal, algorithm, and intervals, since each instance recomputes
+rates from the merged counts independently.
+
+Store I/O happens once per adjustment interval on a background goroutine,
+never on the span-processing path. Store failures fail open: the sampler
+applies its own counts for that interval (per-instance behavior against the
+full goal, which over-samples fleet-wide) rather than stalling, logs a
+warning, and increments
+`otelcol_processor_adaptive_tail_sampling_counter_sync_errors`.
+
+When `shared_counters` is unset, counts stay in process and behavior is
+per-instance, unchanged from earlier releases with one exception: keys beyond
+`max_keys` now sample at the initial rate (1 in 10) instead of being kept
+wholesale (see
+[#50538](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50538)).
 
 ### Fingerprints
 
@@ -508,7 +545,7 @@ SDKs → Collectors (loadbalancing exporter, hash by traceID)
            → Backend
 ```
 
-Each processor instance runs its samplers independently against the traffic it sees; there is no coordination between instances. For `adaptive_throughput` (with either algorithm) this means `goal_throughput` is a **per-instance** target: a fleet of N instances emits up to N times the configured goal, so divide the backend's ingest budget by the instance count when sizing it. The percentage-based samplers (`adaptive_percentage`, `probabilistic`) are unaffected, since a target percentage composes across instances. Automatic cluster-size awareness for the throughput goal is not currently implemented.
+Each processor instance runs its samplers independently against the traffic it sees; there is no coordination between instances by default. For `adaptive_throughput` (with either algorithm) this means `goal_throughput` is a **per-instance** target: a fleet of N instances emits up to N times the configured goal, so divide the backend's ingest budget by the instance count when sizing it. Alternatively, configure `shared_counters` with a sampler-state extension to merge traffic counts across the fleet and make `goal_throughput` a fleet-wide budget (see the `adaptive_throughput` section). The percentage-based samplers (`adaptive_percentage`, `probabilistic`) are unaffected, since a target percentage composes across instances.
 
 ## Known limitations
 

--- a/processor/adaptivetailsamplingprocessor/config.go
+++ b/processor/adaptivetailsamplingprocessor/config.go
@@ -294,6 +294,14 @@ type SharedCountersConfig struct {
 	// counts to and read merged counts from. The extension must implement the
 	// counter-store interface (AddCounts/ReadCounts). Required.
 	Extension component.ID `mapstructure:"extension"`
+	// SyncTimeout bounds each store round-trip (publish and read) per interval
+	// tick. A call that exceeds it is abandoned and treated as a failure,
+	// failing open to this instance's own counts, so a store that cannot keep
+	// up with the traffic it is meant to control degrades responsiveness by a
+	// bounded amount instead of stalling the sync loop. Should be set well
+	// under the sampler's adjustment interval. 0 (or omitting the field) uses
+	// half the effective interval.
+	SyncTimeout time.Duration `mapstructure:"sync_timeout"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -475,8 +483,13 @@ func (s *SamplerConfig) validate(ruleName string) error {
 		if s.MaxKeys < 0 {
 			return fmt.Errorf("rule %q: max_keys must be non-negative", ruleName)
 		}
-		if s.SharedCounters != nil && s.SharedCounters.Extension == (component.ID{}) {
-			return fmt.Errorf("rule %q: shared_counters.extension is required", ruleName)
+		if s.SharedCounters != nil {
+			if s.SharedCounters.Extension == (component.ID{}) {
+				return fmt.Errorf("rule %q: shared_counters.extension is required", ruleName)
+			}
+			if s.SharedCounters.SyncTimeout < 0 {
+				return fmt.Errorf("rule %q: shared_counters.sync_timeout must be non-negative", ruleName)
+			}
 		}
 		switch s.effectiveAlgorithm() {
 		case AlgorithmEMA:

--- a/processor/adaptivetailsamplingprocessor/config.go
+++ b/processor/adaptivetailsamplingprocessor/config.go
@@ -274,6 +274,26 @@ type SamplerConfig struct {
 	// Used by: adaptive_throughput (algorithm: windowed).
 	LookbackFrequency time.Duration `mapstructure:"lookback_frequency"`
 
+	// SharedCounters publishes the sampler's per-interval traffic counts to a
+	// sampler-state extension shared by multiple collector instances, making
+	// GoalThroughput the combined budget for the fleet instead of a
+	// per-instance budget. Unset, counts stay in process and GoalThroughput
+	// is per-instance.
+	// Used by: adaptive_throughput.
+	SharedCounters *SharedCountersConfig `mapstructure:"shared_counters"`
+
+	// prevent unkeyed literal initialization
+	_ struct{}
+}
+
+// SharedCountersConfig connects an adaptive_throughput sampler to a
+// sampler-state extension that merges traffic counts across collector
+// instances.
+type SharedCountersConfig struct {
+	// Extension is the component ID of the sampler-state extension to publish
+	// counts to and read merged counts from. The extension must implement the
+	// counter-store interface (AddCounts/ReadCounts). Required.
+	Extension component.ID `mapstructure:"extension"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -455,6 +475,9 @@ func (s *SamplerConfig) validate(ruleName string) error {
 		if s.MaxKeys < 0 {
 			return fmt.Errorf("rule %q: max_keys must be non-negative", ruleName)
 		}
+		if s.SharedCounters != nil && s.SharedCounters.Extension == (component.ID{}) {
+			return fmt.Errorf("rule %q: shared_counters.extension is required", ruleName)
+		}
 		switch s.effectiveAlgorithm() {
 		case AlgorithmEMA:
 			if s.Weight < 0 || s.Weight >= 1 {
@@ -467,6 +490,7 @@ func (s *SamplerConfig) validate(ruleName string) error {
 				"max_keys":               true,
 				"adjustment_interval":    true,
 				"weight":                 true,
+				"shared_counters":        true,
 			})
 		case AlgorithmWindowed:
 			if s.UpdateFrequency < 0 {
@@ -482,6 +506,7 @@ func (s *SamplerConfig) validate(ruleName string) error {
 				"max_keys":               true,
 				"update_frequency":       true,
 				"lookback_frequency":     true,
+				"shared_counters":        true,
 			})
 		default:
 			return fmt.Errorf("rule %q: unknown algorithm %q (must be %q or %q)", ruleName, s.Algorithm, AlgorithmEMA, AlgorithmWindowed)
@@ -539,6 +564,9 @@ func (s *SamplerConfig) rejectUnusedFields(ruleName, typeName string, allowed ma
 		return err
 	}
 	if err := set("lookback_frequency", s.LookbackFrequency != 0); err != nil {
+		return err
+	}
+	if err := set("shared_counters", s.SharedCounters != nil); err != nil {
 		return err
 	}
 	return nil

--- a/processor/adaptivetailsamplingprocessor/config_test.go
+++ b/processor/adaptivetailsamplingprocessor/config_test.go
@@ -317,6 +317,19 @@ func TestConfig_Validate(t *testing.T) {
 			}),
 		},
 		{
+			name: "shared_counters_negative_sync_timeout",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                  AdaptiveThroughput,
+					GoalThroughput:        100,
+					FingerprintAttributes: []string{`resource.attributes["service.name"]`},
+					SharedCounters:        &SharedCountersConfig{Extension: component.MustNewID("redis_sampler_state"), SyncTimeout: -time.Second},
+				},
+			}),
+			wantErr: "shared_counters.sync_timeout must be non-negative",
+		},
+		{
 			name: "shared_counters_missing_extension",
 			cfg: baseCfg(RuleConfig{
 				Name: "r",

--- a/processor/adaptivetailsamplingprocessor/config_test.go
+++ b/processor/adaptivetailsamplingprocessor/config_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -289,6 +290,57 @@ func TestConfig_Validate(t *testing.T) {
 					LookbackFrequency:     30 * time.Second,
 				},
 			}),
+		},
+		{
+			name: "valid_shared_counters",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                  AdaptiveThroughput,
+					GoalThroughput:        100,
+					FingerprintAttributes: []string{`resource.attributes["service.name"]`},
+					SharedCounters:        &SharedCountersConfig{Extension: component.MustNewID("redis_sampler_state")},
+				},
+			}),
+		},
+		{
+			name: "valid_shared_counters_windowed",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                  AdaptiveThroughput,
+					Algorithm:             AlgorithmWindowed,
+					GoalThroughput:        100,
+					FingerprintAttributes: []string{`resource.attributes["service.name"]`},
+					SharedCounters:        &SharedCountersConfig{Extension: component.MustNewID("redis_sampler_state")},
+				},
+			}),
+		},
+		{
+			name: "shared_counters_missing_extension",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                  AdaptiveThroughput,
+					GoalThroughput:        100,
+					FingerprintAttributes: []string{`resource.attributes["service.name"]`},
+					SharedCounters:        &SharedCountersConfig{},
+				},
+			}),
+			wantErr: "shared_counters.extension is required",
+		},
+		{
+			name: "shared_counters_rejected_on_adaptive_percentage",
+			cfg: baseCfg(RuleConfig{
+				Name: "r",
+				Sampler: SamplerConfig{
+					Type:                  AdaptivePercentage,
+					GoalPercentage:        10,
+					FingerprintAttributes: []string{`resource.attributes["service.name"]`},
+					SharedCounters:        &SharedCountersConfig{Extension: component.MustNewID("redis_sampler_state")},
+				},
+			}),
+			wantErr: "adaptive_percentage does not use shared_counters",
 		},
 		{
 			name: "algorithm_rejected_on_probabilistic",

--- a/processor/adaptivetailsamplingprocessor/counter_sync.go
+++ b/processor/adaptivetailsamplingprocessor/counter_sync.go
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package adaptivetailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/counterstore"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/sampler"
+)
+
+// runCounterSync drives one throughput sampler's interval loop: every
+// adjustment interval it publishes this instance's counts to the counter
+// store, reads back the merged totals, and folds them into the rate engine.
+// Ticks are aligned to wall-clock interval boundaries so instances sharing a
+// store address the same bucket for the same time period and publish at
+// roughly the same moment.
+func (p *adaptiveTailSamplingProcessor) runCounterSync(ctx context.Context, name string, st *sampler.SharedThroughput, store counterstore.Store) {
+	defer p.syncWG.Done()
+	interval := st.Interval()
+	timer := time.NewTimer(time.Until(nextBoundary(time.Now(), interval)))
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-timer.C:
+			p.syncCounters(ctx, now, name, st, store)
+			timer.Reset(time.Until(nextBoundary(time.Now(), interval)))
+		}
+	}
+}
+
+// nextBoundary returns the first wall-clock multiple of interval after now.
+func nextBoundary(now time.Time, interval time.Duration) time.Time {
+	return now.Truncate(interval).Add(interval)
+}
+
+// syncCounters runs one tick: publish the counts accumulated over the
+// just-completed bucket, read the merged totals for that bucket, and apply
+// them. A peer publishing slightly later than this instance reads is missed
+// for that bucket; the engines smooth over that skew and it corrects on the
+// next tick.
+//
+// Store failures fail open: the local counts are applied instead, degrading
+// to per-instance rates against the full goal (over-sampling across the
+// fleet) rather than stalling the sampler. The decide path never touches the
+// store, so it is unaffected either way.
+func (p *adaptiveTailSamplingProcessor) syncCounters(ctx context.Context, now time.Time, name string, st *sampler.SharedThroughput, store counterstore.Store) {
+	interval := st.Interval()
+	// The tick fires at (or just after) a bucket boundary; stepping back half
+	// an interval indexes the bucket that just completed.
+	bucket := now.Add(-interval/2).UnixNano() / interval.Nanoseconds()
+	counts := st.SnapshotCounts()
+	if len(counts) > 0 {
+		if err := store.AddCounts(ctx, name, bucket, counts); err != nil {
+			p.recordCounterSyncError(ctx, name, "add", err)
+			st.ApplyMergedCounts(counts)
+			return
+		}
+	}
+	merged, err := store.ReadCounts(ctx, name, bucket)
+	if err != nil {
+		p.recordCounterSyncError(ctx, name, "read", err)
+		st.ApplyMergedCounts(counts)
+		return
+	}
+	st.ApplyMergedCounts(merged)
+}
+
+func (p *adaptiveTailSamplingProcessor) recordCounterSyncError(ctx context.Context, name, op string, err error) {
+	p.telemetry.ProcessorAdaptiveTailSamplingCounterSyncErrors.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("rule", name), attribute.String("op", op)))
+	p.logger.Warn("counter store sync failed; applying this instance's own counts",
+		zap.String("rule", name),
+		zap.String("op", op),
+		zap.Error(err))
+}

--- a/processor/adaptivetailsamplingprocessor/counter_sync.go
+++ b/processor/adaptivetailsamplingprocessor/counter_sync.go
@@ -21,9 +21,14 @@ import (
 // Ticks are aligned to wall-clock interval boundaries so instances sharing a
 // store address the same bucket for the same time period and publish at
 // roughly the same moment.
-func (p *adaptiveTailSamplingProcessor) runCounterSync(ctx context.Context, name string, st *sampler.SharedThroughput, store counterstore.Store) {
+func (p *adaptiveTailSamplingProcessor) runCounterSync(ctx context.Context, name string, st *sampler.SharedThroughput, store counterstore.Store, timeout time.Duration) {
 	defer p.syncWG.Done()
 	interval := st.Interval()
+	if timeout <= 0 {
+		// Default to half the interval: short enough that a stuck store cannot
+		// eat a whole tick, long enough to tolerate normal store latency.
+		timeout = interval / 2
+	}
 	timer := time.NewTimer(time.Until(nextBoundary(time.Now(), interval)))
 	defer timer.Stop()
 	for {
@@ -31,7 +36,7 @@ func (p *adaptiveTailSamplingProcessor) runCounterSync(ctx context.Context, name
 		case <-ctx.Done():
 			return
 		case now := <-timer.C:
-			p.syncCounters(ctx, now, name, st, store)
+			p.syncCounters(ctx, now, name, st, store, timeout)
 			timer.Reset(time.Until(nextBoundary(time.Now(), interval)))
 		}
 	}
@@ -50,28 +55,44 @@ func nextBoundary(now time.Time, interval time.Duration) time.Time {
 //
 // Store failures fail open: the local counts are applied instead, degrading
 // to per-instance rates against the full goal (over-sampling across the
-// fleet) rather than stalling the sampler. The decide path never touches the
+// fleet) rather than stalling the sampler. Each store call is bounded by
+// timeout, so a store slower than the interval routes into the same fail-open
+// path rather than blocking the loop. The decide path never touches the
 // store, so it is unaffected either way.
-func (p *adaptiveTailSamplingProcessor) syncCounters(ctx context.Context, now time.Time, name string, st *sampler.SharedThroughput, store counterstore.Store) {
+func (p *adaptiveTailSamplingProcessor) syncCounters(ctx context.Context, now time.Time, name string, st *sampler.SharedThroughput, store counterstore.Store, timeout time.Duration) {
 	interval := st.Interval()
 	// The tick fires at (or just after) a bucket boundary; stepping back half
 	// an interval indexes the bucket that just completed.
 	bucket := now.Add(-interval/2).UnixNano() / interval.Nanoseconds()
 	counts := st.SnapshotCounts()
 	if len(counts) > 0 {
-		if err := store.AddCounts(ctx, name, bucket, counts); err != nil {
+		if err := p.withTimeout(ctx, timeout, func(cctx context.Context) error {
+			return store.AddCounts(cctx, name, bucket, counts)
+		}); err != nil {
 			p.recordCounterSyncError(ctx, name, "add", err)
 			st.ApplyMergedCounts(counts)
 			return
 		}
 	}
-	merged, err := store.ReadCounts(ctx, name, bucket)
-	if err != nil {
+	var merged map[string]float64
+	if err := p.withTimeout(ctx, timeout, func(cctx context.Context) error {
+		var err error
+		merged, err = store.ReadCounts(cctx, name, bucket)
+		return err
+	}); err != nil {
 		p.recordCounterSyncError(ctx, name, "read", err)
 		st.ApplyMergedCounts(counts)
 		return
 	}
 	st.ApplyMergedCounts(merged)
+}
+
+// withTimeout runs fn under a child context bounded by timeout so a slow store
+// call is abandoned rather than stalling the sync loop.
+func (*adaptiveTailSamplingProcessor) withTimeout(ctx context.Context, timeout time.Duration, fn func(context.Context) error) error {
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return fn(cctx)
 }
 
 func (p *adaptiveTailSamplingProcessor) recordCounterSyncError(ctx context.Context, name, op string, err error) {

--- a/processor/adaptivetailsamplingprocessor/counter_sync_test.go
+++ b/processor/adaptivetailsamplingprocessor/counter_sync_test.go
@@ -172,7 +172,7 @@ func TestSyncCounters_AppliesMergedCounts(t *testing.T) {
 	st.GetSampleRate("svc-a", 500000)
 	require.Equal(t, 10, st.GetSampleRate("svc-a", 1), "bootstrap rate before the first sync")
 
-	p.syncCounters(t.Context(), time.Unix(3600, 0), "default", st, store)
+	p.syncCounters(t.Context(), time.Unix(3600, 0), "default", st, store, time.Second)
 	assert.NotEqual(t, 10, st.GetSampleRate("svc-a", 1), "sync must apply a computed table")
 }
 
@@ -197,8 +197,8 @@ func TestSyncCounters_MergesAcrossInstances(t *testing.T) {
 	// publish/read interleaving (which real instances race on).
 	require.NoError(t, store.AddCounts(t.Context(), "default", 0, a.SnapshotCounts()))
 	require.NoError(t, store.AddCounts(t.Context(), "default", 0, b.SnapshotCounts()))
-	pa.syncCounters(t.Context(), tick, "default", a, store)
-	pa.syncCounters(t.Context(), tick, "default", b, store)
+	pa.syncCounters(t.Context(), tick, "default", a, store, time.Second)
+	pa.syncCounters(t.Context(), tick, "default", b, store, time.Second)
 
 	for _, key := range []string{"svc-a", "svc-b"} {
 		assert.Equal(t, a.GetSampleRate(key, 1), b.GetSampleRate(key, 1),
@@ -248,10 +248,82 @@ func TestSyncCounters_FailsOpenOnStoreErrors(t *testing.T) {
 			st := p.rules[0].sampler.(*sampler.SharedThroughput)
 
 			st.GetSampleRate("svc-a", 500000)
-			p.syncCounters(t.Context(), time.Unix(3600, 0), "default", st, tc.store)
+			p.syncCounters(t.Context(), time.Unix(3600, 0), "default", st, tc.store, time.Second)
 
 			assert.NotEqual(t, 10, st.GetSampleRate("svc-a", 1),
 				"store failure must fail open: local counts still produce a table")
+			metadatatest.AssertEqualProcessorAdaptiveTailSamplingCounterSyncErrors(t, tt,
+				[]metricdata.DataPoint[int64]{{
+					Value: 1,
+					Attributes: attribute.NewSet(
+						attribute.String("rule", "default"),
+						attribute.String("op", tc.op),
+					),
+				}},
+				metricdatatest.IgnoreTimestamp(),
+				metricdatatest.IgnoreExemplars(),
+			)
+		})
+	}
+}
+
+// blockingStore hangs on the chosen operation until its context is cancelled,
+// standing in for a store slower than the sync timeout.
+type blockingStore struct {
+	blockAdd  bool
+	blockRead bool
+	inner     *counterstore.Memory
+}
+
+func (s *blockingStore) AddCounts(ctx context.Context, samplerID string, bucket int64, counts map[string]float64) error {
+	if s.blockAdd {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return s.inner.AddCounts(ctx, samplerID, bucket, counts)
+}
+
+func (s *blockingStore) ReadCounts(ctx context.Context, samplerID string, bucket int64) (map[string]float64, error) {
+	if s.blockRead {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return s.inner.ReadCounts(ctx, samplerID, bucket)
+}
+
+func TestSyncCounters_TimeoutFailsOpen(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		store *blockingStore
+		op    string
+	}{
+		{name: "add times out", store: &blockingStore{blockAdd: true, inner: counterstore.NewMemory()}, op: "add"},
+		{name: "read times out", store: &blockingStore{blockRead: true, inner: counterstore.NewMemory()}, op: "read"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tt := componenttest.NewTelemetry()
+			t.Cleanup(func() {
+				require.NoError(t, tt.Shutdown(context.Background())) //nolint:usetesting // cleanup after ctx cancel
+			})
+			p, err := newProcessor(metadatatest.NewSettings(tt), throughputTestConfig(nil), &consumertest.TracesSink{})
+			require.NoError(t, err)
+			st := p.rules[0].sampler.(*sampler.SharedThroughput)
+
+			st.GetSampleRate("svc-a", 500000)
+			done := make(chan struct{})
+			go func() {
+				// A hung store must not stall the caller past the timeout.
+				p.syncCounters(t.Context(), time.Unix(3600, 0), "default", st, tc.store, 20*time.Millisecond)
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("syncCounters did not return; timeout was not enforced")
+			}
+
+			assert.NotEqual(t, 10, st.GetSampleRate("svc-a", 1),
+				"a store that times out must fail open to local counts")
 			metadatatest.AssertEqualProcessorAdaptiveTailSamplingCounterSyncErrors(t, tt,
 				[]metricdata.DataPoint[int64]{{
 					Value: 1,

--- a/processor/adaptivetailsamplingprocessor/counter_sync_test.go
+++ b/processor/adaptivetailsamplingprocessor/counter_sync_test.go
@@ -1,0 +1,277 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package adaptivetailsamplingprocessor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/processor/processortest"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/counterstore"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/metadatatest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/sampler"
+)
+
+// fakeHost supplies extensions to Start without a full collector runtime.
+type fakeHost struct {
+	exts map[component.ID]component.Component
+}
+
+func (h *fakeHost) GetExtensions() map[component.ID]component.Component { return h.exts }
+
+// fakeCounterExtension satisfies counterstore.Store structurally (the way a
+// real sampler-state extension would, without importing the processor) plus
+// the component lifecycle.
+type fakeCounterExtension struct {
+	store *counterstore.Memory
+}
+
+func (*fakeCounterExtension) Start(context.Context, component.Host) error { return nil }
+func (*fakeCounterExtension) Shutdown(context.Context) error              { return nil }
+
+func (e *fakeCounterExtension) AddCounts(ctx context.Context, samplerID string, bucket int64, counts map[string]float64) error {
+	return e.store.AddCounts(ctx, samplerID, bucket, counts)
+}
+
+func (e *fakeCounterExtension) ReadCounts(ctx context.Context, samplerID string, bucket int64) (map[string]float64, error) {
+	return e.store.ReadCounts(ctx, samplerID, bucket)
+}
+
+// notAStoreExtension has the lifecycle methods but not the counter methods.
+type notAStoreExtension struct{}
+
+func (notAStoreExtension) Start(context.Context, component.Host) error { return nil }
+func (notAStoreExtension) Shutdown(context.Context) error              { return nil }
+
+func TestResolveCounterStore(t *testing.T) {
+	extID := component.MustNewID("redis_sampler_state")
+
+	t.Run("unset config defaults to in-memory", func(t *testing.T) {
+		store, err := resolveCounterStore(nil, nil)
+		require.NoError(t, err)
+		assert.IsType(t, &counterstore.Memory{}, store)
+	})
+
+	t.Run("extension resolved structurally", func(t *testing.T) {
+		host := &fakeHost{exts: map[component.ID]component.Component{
+			extID: &fakeCounterExtension{store: counterstore.NewMemory()},
+		}}
+		store, err := resolveCounterStore(host, &SharedCountersConfig{Extension: extID})
+		require.NoError(t, err)
+		assert.IsType(t, &fakeCounterExtension{}, store)
+	})
+
+	t.Run("missing extension errors", func(t *testing.T) {
+		host := &fakeHost{exts: map[component.ID]component.Component{}}
+		_, err := resolveCounterStore(host, &SharedCountersConfig{Extension: extID})
+		assert.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("wrong-type extension errors", func(t *testing.T) {
+		host := &fakeHost{exts: map[component.ID]component.Component{
+			extID: notAStoreExtension{},
+		}}
+		_, err := resolveCounterStore(host, &SharedCountersConfig{Extension: extID})
+		assert.ErrorContains(t, err, "does not implement")
+	})
+
+	t.Run("nil host with config errors", func(t *testing.T) {
+		_, err := resolveCounterStore(nil, &SharedCountersConfig{Extension: extID})
+		assert.Error(t, err)
+	})
+}
+
+func TestProcessorStart_SharedCountersExtensionMissing(t *testing.T) {
+	cfg := &Config{
+		TraceTimeout:  time.Hour,
+		DecisionDelay: time.Millisecond,
+		NumTraces:     10,
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{
+				Type:                  AdaptiveThroughput,
+				GoalThroughput:        100,
+				FingerprintAttributes: []string{`resource.attributes["service.name"]`},
+				SharedCounters:        &SharedCountersConfig{Extension: component.MustNewID("redis_sampler_state")},
+			}},
+		},
+	}
+	require.NoError(t, cfg.Validate())
+	p, err := newProcessor(processortest.NewNopSettings(metadata.Type), cfg, &consumertest.TracesSink{})
+	require.NoError(t, err)
+	err = p.Start(t.Context(), &fakeHost{exts: map[component.ID]component.Component{}})
+	require.ErrorContains(t, err, "not found")
+}
+
+func TestProcessor_SharedCountersEndToEnd(t *testing.T) {
+	extID := component.MustNewID("redis_sampler_state")
+	ext := &fakeCounterExtension{store: counterstore.NewMemory()}
+	sink := &consumertest.TracesSink{}
+	cfg := throughputTestConfig(&SharedCountersConfig{Extension: extID})
+	require.NoError(t, cfg.Validate())
+	p, err := newProcessor(processortest.NewNopSettings(metadata.Type), cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, p.Start(t.Context(), &fakeHost{exts: map[component.ID]component.Component{extID: ext}}))
+	t.Cleanup(func() {
+		require.NoError(t, p.Shutdown(context.Background())) //nolint:usetesting // cleanup after ctx cancel
+	})
+
+	// Max randomness so the trace is kept at the bootstrap rate; pins that the
+	// decide path works while the sampler is wired to an extension store.
+	id := [16]byte{0xAB}
+	for j := 9; j < 16; j++ {
+		id[j] = 0xFF
+	}
+	td := newRootTrace(pcommon.TraceID(id))
+	td.ResourceSpans().At(0).Resource().Attributes().PutStr("service.name", "svc")
+	require.NoError(t, p.ConsumeTraces(t.Context(), td))
+	assert.Eventually(t, func() bool { return sink.SpanCount() == 1 }, time.Second, 10*time.Millisecond)
+}
+
+// throughputTestConfig returns a single-rule adaptive_throughput config with a
+// long enough interval that the background sync loop never ticks during the
+// test; syncCounters is driven by hand.
+func throughputTestConfig(shared *SharedCountersConfig) *Config {
+	return &Config{
+		TraceTimeout:  time.Hour,
+		DecisionDelay: time.Millisecond,
+		NumTraces:     10,
+		Rules: []RuleConfig{
+			{Name: "default", Sampler: SamplerConfig{
+				Type:                  AdaptiveThroughput,
+				GoalThroughput:        100,
+				AdjustmentInterval:    time.Hour,
+				FingerprintAttributes: []string{`resource.attributes["service.name"]`},
+				SharedCounters:        shared,
+			}},
+		},
+	}
+}
+
+func TestSyncCounters_AppliesMergedCounts(t *testing.T) {
+	p, err := newProcessor(processortest.NewNopSettings(metadata.Type), throughputTestConfig(nil), &consumertest.TracesSink{})
+	require.NoError(t, err)
+	st := p.rules[0].sampler.(*sampler.SharedThroughput)
+	store := counterstore.NewMemory()
+
+	// Heavy traffic on one key: after a sync tick the rate must move off the
+	// bootstrap value of 10.
+	st.GetSampleRate("svc-a", 500000)
+	require.Equal(t, 10, st.GetSampleRate("svc-a", 1), "bootstrap rate before the first sync")
+
+	p.syncCounters(t.Context(), time.Unix(3600, 0), "default", st, store)
+	assert.NotEqual(t, 10, st.GetSampleRate("svc-a", 1), "sync must apply a computed table")
+}
+
+func TestSyncCounters_MergesAcrossInstances(t *testing.T) {
+	sink := &consumertest.TracesSink{}
+	newInstance := func() *sampler.SharedThroughput {
+		p, err := newProcessor(processortest.NewNopSettings(metadata.Type), throughputTestConfig(nil), sink)
+		require.NoError(t, err)
+		return p.rules[0].sampler.(*sampler.SharedThroughput)
+	}
+	a, b := newInstance(), newInstance()
+	store := counterstore.NewMemory()
+	pa, err := newProcessor(processortest.NewNopSettings(metadata.Type), throughputTestConfig(nil), sink)
+	require.NoError(t, err)
+
+	// Each instance sees a different key; after both publish into the shared
+	// store and read back, both hold rates for both keys.
+	tick := time.Unix(3600, 0)
+	a.GetSampleRate("svc-a", 400000)
+	b.GetSampleRate("svc-b", 400000)
+	// Publish both before either reads: pin only the merged outcome, not
+	// publish/read interleaving (which real instances race on).
+	require.NoError(t, store.AddCounts(t.Context(), "default", 0, a.SnapshotCounts()))
+	require.NoError(t, store.AddCounts(t.Context(), "default", 0, b.SnapshotCounts()))
+	pa.syncCounters(t.Context(), tick, "default", a, store)
+	pa.syncCounters(t.Context(), tick, "default", b, store)
+
+	for _, key := range []string{"svc-a", "svc-b"} {
+		assert.Equal(t, a.GetSampleRate(key, 1), b.GetSampleRate(key, 1),
+			"both instances must compute identical rates for %s from the merged counts", key)
+		assert.NotEqual(t, 10, a.GetSampleRate(key, 1),
+			"rates for %s must come from the merged table, not bootstrap", key)
+	}
+}
+
+// erroringStore fails the chosen operations.
+type erroringStore struct {
+	failAdd  bool
+	failRead bool
+	inner    *counterstore.Memory
+}
+
+func (s *erroringStore) AddCounts(ctx context.Context, samplerID string, bucket int64, counts map[string]float64) error {
+	if s.failAdd {
+		return errors.New("add refused")
+	}
+	return s.inner.AddCounts(ctx, samplerID, bucket, counts)
+}
+
+func (s *erroringStore) ReadCounts(ctx context.Context, samplerID string, bucket int64) (map[string]float64, error) {
+	if s.failRead {
+		return nil, errors.New("read refused")
+	}
+	return s.inner.ReadCounts(ctx, samplerID, bucket)
+}
+
+func TestSyncCounters_FailsOpenOnStoreErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		store *erroringStore
+		op    string
+	}{
+		{name: "add fails", store: &erroringStore{failAdd: true, inner: counterstore.NewMemory()}, op: "add"},
+		{name: "read fails", store: &erroringStore{failRead: true, inner: counterstore.NewMemory()}, op: "read"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tt := componenttest.NewTelemetry()
+			t.Cleanup(func() {
+				require.NoError(t, tt.Shutdown(context.Background())) //nolint:usetesting // cleanup after ctx cancel
+			})
+			p, err := newProcessor(metadatatest.NewSettings(tt), throughputTestConfig(nil), &consumertest.TracesSink{})
+			require.NoError(t, err)
+			st := p.rules[0].sampler.(*sampler.SharedThroughput)
+
+			st.GetSampleRate("svc-a", 500000)
+			p.syncCounters(t.Context(), time.Unix(3600, 0), "default", st, tc.store)
+
+			assert.NotEqual(t, 10, st.GetSampleRate("svc-a", 1),
+				"store failure must fail open: local counts still produce a table")
+			metadatatest.AssertEqualProcessorAdaptiveTailSamplingCounterSyncErrors(t, tt,
+				[]metricdata.DataPoint[int64]{{
+					Value: 1,
+					Attributes: attribute.NewSet(
+						attribute.String("rule", "default"),
+						attribute.String("op", tc.op),
+					),
+				}},
+				metricdatatest.IgnoreTimestamp(),
+				metricdatatest.IgnoreExemplars(),
+			)
+		})
+	}
+}
+
+func TestNextBoundary(t *testing.T) {
+	interval := 15 * time.Second
+	now := time.Unix(100, 500)
+	next := nextBoundary(now, interval)
+	assert.Equal(t, time.Unix(105, 0), next)
+	assert.Equal(t, time.Unix(120, 0), nextBoundary(next, interval),
+		"a tick exactly on a boundary schedules the following boundary, not itself")
+}

--- a/processor/adaptivetailsamplingprocessor/documentation.md
+++ b/processor/adaptivetailsamplingprocessor/documentation.md
@@ -6,6 +6,14 @@
 
 The following telemetry is emitted by this component.
 
+### otelcol_processor_adaptive_tail_sampling_counter_sync_errors
+
+Number of counter store sync failures for adaptive_throughput samplers, labelled by rule and operation (add, read). Each failure fails open to this instance's own counts for that interval.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {errors} | Sum | Int | true | Development |
+
 ### otelcol_processor_adaptive_tail_sampling_decision_sample_rate
 
 Distribution of effective sample rates produced per rule. Useful for detecting adaptive samplers settling at unexpected rates.

--- a/processor/adaptivetailsamplingprocessor/internal/counterstore/counterstore.go
+++ b/processor/adaptivetailsamplingprocessor/internal/counterstore/counterstore.go
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package counterstore defines the counter-sharing contract that lets
+// adaptive_throughput samplers on multiple collector instances observe the
+// fleet's combined traffic. Instances publish their per-interval key counts
+// additively and read back the merged totals; every instance then recomputes
+// the same rate table from the same merged input, so no leader or rate
+// distribution is needed.
+package counterstore // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/counterstore"
+
+import "context"
+
+// Store is the interface a sampler-state backend implements. External
+// backends are collector extensions that satisfy it structurally; the
+// processor resolves them from the host by component ID and type-asserts.
+//
+// Buckets are interval indexes (floor of wall-clock time over the sampler's
+// adjustment interval), so instances with synchronized clocks address the
+// same bucket for the same time period without coordinating. samplerID
+// namespaces buckets per sampler (the processor uses the rule name); callers
+// on different instances must configure the same samplerID and interval for
+// their counts to merge.
+//
+// Implementations must be safe for concurrent use. They must not retain the
+// counts map passed to AddCounts, and ReadCounts must return a map the caller
+// owns. Backends should expire buckets after a few intervals; the processor
+// only ever reads the bucket it just published.
+type Store interface {
+	// AddCounts folds this instance's counts for one interval bucket into the
+	// shared totals. Additions must be atomic per (samplerID, bucket, key) so
+	// concurrent instances' contributions merge without loss.
+	AddCounts(ctx context.Context, samplerID string, bucket int64, counts map[string]float64) error
+	// ReadCounts returns the merged counts published for the bucket so far. A
+	// bucket nobody has written is an empty map, not an error.
+	ReadCounts(ctx context.Context, samplerID string, bucket int64) (map[string]float64, error)
+}

--- a/processor/adaptivetailsamplingprocessor/internal/counterstore/memory.go
+++ b/processor/adaptivetailsamplingprocessor/internal/counterstore/memory.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package counterstore // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/counterstore"
+
+import (
+	"context"
+	"maps"
+	"sync"
+)
+
+// retainedBuckets bounds how many interval buckets Memory keeps per sampler.
+// The sync loop reads the bucket it just wrote, so anything older is garbage;
+// a small margin tolerates a reader that lags a tick.
+const retainedBuckets = 3
+
+// Memory is the in-process Store used when no extension is configured. It
+// gives a single instance the exact per-instance behavior (this instance's
+// counts are the merged counts) through the same code path the shared
+// backends use.
+type Memory struct {
+	mu sync.Mutex
+	// buckets maps samplerID -> bucket index -> merged counts.
+	buckets map[string]map[int64]map[string]float64
+}
+
+var _ Store = (*Memory)(nil)
+
+// NewMemory returns an empty in-process store.
+func NewMemory() *Memory {
+	return &Memory{buckets: make(map[string]map[int64]map[string]float64)}
+}
+
+// AddCounts implements Store.
+func (m *Memory) AddCounts(_ context.Context, samplerID string, bucket int64, counts map[string]float64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	perSampler := m.buckets[samplerID]
+	if perSampler == nil {
+		perSampler = make(map[int64]map[string]float64)
+		m.buckets[samplerID] = perSampler
+	}
+	merged := perSampler[bucket]
+	if merged == nil {
+		merged = make(map[string]float64, len(counts))
+		perSampler[bucket] = merged
+	}
+	for k, v := range counts {
+		merged[k] += v
+	}
+	for b := range perSampler {
+		if b <= bucket-retainedBuckets {
+			delete(perSampler, b)
+		}
+	}
+	return nil
+}
+
+// ReadCounts implements Store.
+func (m *Memory) ReadCounts(_ context.Context, samplerID string, bucket int64) (map[string]float64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	merged := m.buckets[samplerID][bucket]
+	out := make(map[string]float64, len(merged))
+	maps.Copy(out, merged)
+	return out, nil
+}

--- a/processor/adaptivetailsamplingprocessor/internal/counterstore/memory_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/counterstore/memory_test.go
@@ -1,0 +1,86 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package counterstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemory_AddMergesAdditively(t *testing.T) {
+	m := NewMemory()
+	ctx := t.Context()
+
+	// Two writers (instances) into the same sampler and bucket.
+	require.NoError(t, m.AddCounts(ctx, "rule-a", 100, map[string]float64{"svc-1": 10, "svc-2": 5}))
+	require.NoError(t, m.AddCounts(ctx, "rule-a", 100, map[string]float64{"svc-1": 7, "svc-3": 2}))
+
+	merged, err := m.ReadCounts(ctx, "rule-a", 100)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]float64{"svc-1": 17, "svc-2": 5, "svc-3": 2}, merged)
+}
+
+func TestMemory_BucketsAndSamplersAreIsolated(t *testing.T) {
+	m := NewMemory()
+	ctx := t.Context()
+
+	require.NoError(t, m.AddCounts(ctx, "rule-a", 100, map[string]float64{"svc-1": 10}))
+	require.NoError(t, m.AddCounts(ctx, "rule-a", 101, map[string]float64{"svc-1": 3}))
+	require.NoError(t, m.AddCounts(ctx, "rule-b", 100, map[string]float64{"svc-1": 99}))
+
+	merged, err := m.ReadCounts(ctx, "rule-a", 100)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]float64{"svc-1": 10}, merged)
+	merged, err = m.ReadCounts(ctx, "rule-a", 101)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]float64{"svc-1": 3}, merged)
+}
+
+func TestMemory_UnwrittenBucketReadsEmpty(t *testing.T) {
+	m := NewMemory()
+	merged, err := m.ReadCounts(t.Context(), "rule-a", 42)
+	require.NoError(t, err)
+	assert.Empty(t, merged)
+	assert.NotNil(t, merged)
+}
+
+func TestMemory_ReadReturnsCallerOwnedCopy(t *testing.T) {
+	m := NewMemory()
+	ctx := t.Context()
+	require.NoError(t, m.AddCounts(ctx, "rule-a", 100, map[string]float64{"svc-1": 10}))
+
+	first, err := m.ReadCounts(ctx, "rule-a", 100)
+	require.NoError(t, err)
+	first["svc-1"] = 0
+	delete(first, "svc-1")
+
+	second, err := m.ReadCounts(ctx, "rule-a", 100)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]float64{"svc-1": 10}, second, "mutating a read result must not affect the store")
+}
+
+func TestMemory_DoesNotRetainCallerMap(t *testing.T) {
+	m := NewMemory()
+	ctx := t.Context()
+	counts := map[string]float64{"svc-1": 10}
+	require.NoError(t, m.AddCounts(ctx, "rule-a", 100, counts))
+	counts["svc-1"] = 999
+
+	merged, err := m.ReadCounts(ctx, "rule-a", 100)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]float64{"svc-1": 10}, merged, "mutating the input map must not affect the store")
+}
+
+func TestMemory_PrunesOldBuckets(t *testing.T) {
+	m := NewMemory()
+	ctx := t.Context()
+	require.NoError(t, m.AddCounts(ctx, "rule-a", 100, map[string]float64{"svc-1": 1}))
+	require.NoError(t, m.AddCounts(ctx, "rule-a", 100+retainedBuckets, map[string]float64{"svc-1": 1}))
+
+	merged, err := m.ReadCounts(ctx, "rule-a", 100)
+	require.NoError(t, err)
+	assert.Empty(t, merged, "buckets older than the retention margin are dropped")
+}

--- a/processor/adaptivetailsamplingprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/adaptivetailsamplingprocessor/internal/metadata/generated_telemetry.go
@@ -25,6 +25,7 @@ type TelemetryBuilder struct {
 	meter                                                      metric.Meter
 	mu                                                         sync.Mutex
 	registrations                                              []metric.Registration
+	ProcessorAdaptiveTailSamplingCounterSyncErrors             metric.Int64Counter
 	ProcessorAdaptiveTailSamplingDecisionSampleRate            metric.Int64Histogram
 	ProcessorAdaptiveTailSamplingDecisionTriggers              metric.Int64Counter
 	ProcessorAdaptiveTailSamplingFingerprintDuration           metric.Int64Histogram
@@ -66,6 +67,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
+	builder.ProcessorAdaptiveTailSamplingCounterSyncErrors, err = builder.meter.Int64Counter(
+		"otelcol_processor_adaptive_tail_sampling_counter_sync_errors",
+		metric.WithDescription("Number of counter store sync failures for adaptive_throughput samplers, labelled by rule and operation (add, read). Each failure fails open to this instance's own counts for that interval. [Development]"),
+		metric.WithUnit("{errors}"),
+	)
+	errs = errors.Join(errs, err)
 	builder.ProcessorAdaptiveTailSamplingDecisionSampleRate, err = builder.meter.Int64Histogram(
 		"otelcol_processor_adaptive_tail_sampling_decision_sample_rate",
 		metric.WithDescription("Distribution of effective sample rates produced per rule. Useful for detecting adaptive samplers settling at unexpected rates. [Development]"),

--- a/processor/adaptivetailsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/adaptivetailsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -21,6 +21,22 @@ func NewSettings(tt *componenttest.Telemetry) processor.Settings {
 	return set
 }
 
+func AssertEqualProcessorAdaptiveTailSamplingCounterSyncErrors(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_processor_adaptive_tail_sampling_counter_sync_errors",
+		Description: "Number of counter store sync failures for adaptive_throughput samplers, labelled by rule and operation (add, read). Each failure fails open to this instance's own counts for that interval. [Development]",
+		Unit:        "{errors}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_processor_adaptive_tail_sampling_counter_sync_errors")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualProcessorAdaptiveTailSamplingDecisionSampleRate(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_adaptive_tail_sampling_decision_sample_rate",

--- a/processor/adaptivetailsamplingprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -19,6 +19,7 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
+	tb.ProcessorAdaptiveTailSamplingCounterSyncErrors.Add(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingDecisionSampleRate.Record(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingDecisionTriggers.Add(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingFingerprintDuration.Record(context.Background(), 1)
@@ -29,6 +30,9 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ProcessorAdaptiveTailSamplingTracesDropped.Add(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingTracesEvicted.Add(context.Background(), 1)
 	tb.ProcessorAdaptiveTailSamplingTracesSampled.Add(context.Background(), 1)
+	AssertEqualProcessorAdaptiveTailSamplingCounterSyncErrors(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorAdaptiveTailSamplingDecisionSampleRate(t, testTel,
 		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/allocation.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/allocation.go
@@ -26,11 +26,17 @@ type emaState struct {
 	weight float64
 	// ageOutValue drops keys whose average decays below it, bounding the map.
 	ageOutValue float64
+	// maxKeys bounds the tracked keys; 0 means unbounded. New keys beyond
+	// the cap are dropped at observe time in sorted order, so instances
+	// applying identical merged counts stay in agreement; age-out frees
+	// slots. Keys beyond the cap fall back to the caller's bootstrap rate,
+	// unlike dynsampler's keep-everything overflow (see contrib #50538).
+	maxKeys int
 }
 
 // newEMAState mirrors dynsampler-go's defaults: weight 0.5 when unset, and
 // ageOutValue defaulting to the weight.
-func newEMAState(weight float64) *emaState {
+func newEMAState(weight float64, maxKeys int) *emaState {
 	if weight == 0 {
 		weight = 0.5
 	}
@@ -38,6 +44,7 @@ func newEMAState(weight float64) *emaState {
 		movingAverage: make(map[string]float64),
 		weight:        weight,
 		ageOutValue:   weight,
+		maxKeys:       maxKeys,
 	}
 }
 
@@ -66,7 +73,15 @@ func (s *emaState) observe(counts map[string]float64) {
 		}
 		delete(counts, key)
 	}
+	newKeys := make([]string, 0, len(counts))
 	for key := range counts {
+		newKeys = append(newKeys, key)
+	}
+	sort.Strings(newKeys)
+	for _, key := range newKeys {
+		if s.maxKeys > 0 && len(s.movingAverage) >= s.maxKeys {
+			break
+		}
 		newAvg := adjustAverage(0, counts[key], s.weight)
 		if newAvg >= s.ageOutValue {
 			s.movingAverage[key] = newAvg

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/allocation.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/allocation.go
@@ -1,0 +1,138 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sampler // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/sampler"
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+// This file ports the EMA throughput rate math from dynsampler-go v0.6.4
+// (EMAThroughput.updateMaps, EMAThroughput.updateEMA, adjustAverage, and
+// calculateSampleRates) so rates can be computed over externally merged
+// counts, which the library cannot ingest. Golden tests in allocation_test.go
+// pin parity against the library's own test vectors. Burst detection is
+// deliberately not ported: the shared-counter sync runs on fixed interval
+// ticks, so there is no early-adjustment path to trigger.
+
+// emaState holds the per-key exponential moving averages a throughput sampler
+// derives from a sequence of per-interval raw counts. It is not safe for
+// concurrent use; callers serialize access.
+type emaState struct {
+	movingAverage map[string]float64
+	// weight is the EMA alpha in (0, 1): larger values adapt faster.
+	weight float64
+	// ageOutValue drops keys whose average decays below it, bounding the map.
+	ageOutValue float64
+}
+
+// newEMAState mirrors dynsampler-go's defaults: weight 0.5 when unset, and
+// ageOutValue defaulting to the weight.
+func newEMAState(weight float64) *emaState {
+	if weight == 0 {
+		weight = 0.5
+	}
+	return &emaState{
+		movingAverage: make(map[string]float64),
+		weight:        weight,
+		ageOutValue:   weight,
+	}
+}
+
+// observe folds one completed interval of raw counts into the moving
+// averages, consuming counts. An empty interval leaves the averages untouched
+// (mirroring the library: traffic gaps must not decay the averages).
+func (s *emaState) observe(counts map[string]float64) {
+	if len(counts) == 0 {
+		return
+	}
+	keysToUpdate := make([]string, 0, len(s.movingAverage))
+	for key := range s.movingAverage {
+		keysToUpdate = append(keysToUpdate, key)
+	}
+	for _, key := range keysToUpdate {
+		var newAvg float64
+		if val, found := counts[key]; found {
+			newAvg = adjustAverage(s.movingAverage[key], val, s.weight)
+		} else {
+			newAvg = adjustAverage(s.movingAverage[key], 0, s.weight)
+		}
+		if newAvg < s.ageOutValue {
+			delete(s.movingAverage, key)
+		} else {
+			s.movingAverage[key] = newAvg
+		}
+		delete(counts, key)
+	}
+	for key := range counts {
+		newAvg := adjustAverage(0, counts[key], s.weight)
+		if newAvg >= s.ageOutValue {
+			s.movingAverage[key] = newAvg
+		}
+	}
+}
+
+// rates computes per-key sample rates targeting goalThroughputPerSec over the
+// adjustment interval. Returns nil when no averages exist yet, so callers keep
+// their bootstrap rates until the first non-empty interval is observed.
+func (s *emaState) rates(goalThroughputPerSec float64, interval time.Duration) map[string]int {
+	if len(s.movingAverage) == 0 {
+		return nil
+	}
+	goalCount := goalThroughputPerSec * interval.Seconds()
+	var logSum float64
+	for _, count := range s.movingAverage {
+		// max(1, count) because count*weight can be < 1 for very small
+		// counts, which throws off the logSum at low throughput.
+		logSum += math.Log10(math.Max(1, count))
+	}
+	goalRatio := goalCount / logSum
+	return calculateSampleRates(goalRatio, s.movingAverage)
+}
+
+// calculateSampleRates is a verbatim port of dynsampler-go v0.6.4's shared
+// key-allocation logic: each key gets a log10 share of the goal, keys under
+// their share are kept whole (rate 1) and pass their surplus to the remaining
+// keys, iterated in sorted order so rounding is deterministic.
+func calculateSampleRates(goalRatio float64, buckets map[string]float64) map[string]int {
+	keys := make([]string, len(buckets))
+	var i int
+	for k := range buckets {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+
+	newSampleRates := make(map[string]int)
+	keysRemaining := len(buckets)
+	var extra float64
+	for _, key := range keys {
+		count := math.Max(1, buckets[key])
+		goalForKey := math.Max(1, math.Log10(count)*goalRatio)
+		extraForKey := extra / float64(keysRemaining)
+		goalForKey += extraForKey
+		extra -= extraForKey
+		keysRemaining--
+		if count <= goalForKey {
+			newSampleRates[key] = 1
+			extra += goalForKey - count
+		} else {
+			rate := math.Ceil(count / goalForKey)
+			// goalForKey can be +Inf for tiny counts, making rate NaN.
+			if math.IsNaN(rate) {
+				newSampleRates[key] = 1
+			} else {
+				newSampleRates[key] = int(rate)
+			}
+			extra += goalForKey - (count / float64(newSampleRates[key]))
+		}
+	}
+	return newSampleRates
+}
+
+// adjustAverage folds value into oldAvg with EMA weighting alpha.
+func adjustAverage(oldAvg, value, alpha float64) float64 {
+	return value*alpha + (1.0-alpha)*oldAvg
+}

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/allocation_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/allocation_test.go
@@ -5,8 +5,9 @@ package sampler
 
 import (
 	"fmt"
+	"maps"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -23,11 +24,11 @@ import (
 // for goal 10 events/sec over 1s intervals with weight 0.2.
 func TestEMAState_GoldenSparseCounts(t *testing.T) {
 	s := newEMAState(0.2)
-	rng := rand.New(rand.NewSource(1))
+	rng := rand.New(rand.NewPCG(1, 2))
 	var table map[string]int
 	for i := 0; i <= 100; i++ {
 		input := map[string]float64{"largest_count": 40}
-		for j := 0; j < 5; j++ {
+		for range 5 {
 			input[fmt.Sprintf("sporadic-%d-%d", i, rng.Int())] = 1
 		}
 		s.observe(input)
@@ -42,13 +43,13 @@ func TestEMAState_GoldenSparseCounts(t *testing.T) {
 // a steady key converges on its true count.
 func TestEMAState_GoldenAgesOutSmallValues(t *testing.T) {
 	s := newEMAState(0.2)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		s.observe(map[string]float64{"foo": 500})
 	}
 	require.Len(t, s.movingAverage, 1)
 	assert.Equal(t, float64(500), math.Round(s.movingAverage["foo"]))
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		s.observe(map[string]float64{"asdf": 1})
 	}
 	_, found := s.movingAverage["foo"]
@@ -77,11 +78,9 @@ func TestEMAState_RateProperties(t *testing.T) {
 		"huge": 100000, "big": 10000, "mid": 1000, "small": 100, "tiny": 1,
 	}
 	// Feed the same distribution repeatedly so averages converge to it.
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		in := make(map[string]float64, len(counts))
-		for k, v := range counts {
-			in[k] = v
-		}
+		maps.Copy(in, counts)
 		s.observe(in)
 	}
 	const goalPerSec = 100.0

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/allocation_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/allocation_test.go
@@ -23,7 +23,7 @@ import (
 // at 40 events/interval among churning single-count keys settles at rate 4
 // for goal 10 events/sec over 1s intervals with weight 0.2.
 func TestEMAState_GoldenSparseCounts(t *testing.T) {
-	s := newEMAState(0.2)
+	s := newEMAState(0.2, 0)
 	rng := rand.New(rand.NewPCG(1, 2))
 	var table map[string]int
 	for i := 0; i <= 100; i++ {
@@ -42,7 +42,7 @@ func TestEMAState_GoldenSparseCounts(t *testing.T) {
 // appearing decays below the age-out threshold and is dropped; the average of
 // a steady key converges on its true count.
 func TestEMAState_GoldenAgesOutSmallValues(t *testing.T) {
-	s := newEMAState(0.2)
+	s := newEMAState(0.2, 0)
 	for range 100 {
 		s.observe(map[string]float64{"foo": 500})
 	}
@@ -61,7 +61,7 @@ func TestEMAState_GoldenAgesOutSmallValues(t *testing.T) {
 // An empty interval must not decay the averages (the library deliberately
 // skips updates when there was no traffic).
 func TestEMAState_EmptyIntervalDoesNotDecay(t *testing.T) {
-	s := newEMAState(0.5)
+	s := newEMAState(0.5, 0)
 	s.observe(map[string]float64{"foo": 100})
 	before := s.movingAverage["foo"]
 	s.observe(map[string]float64{})
@@ -73,7 +73,7 @@ func TestEMAState_EmptyIntervalDoesNotDecay(t *testing.T) {
 // quieter one), and the expected kept volume is close to the goal when the
 // goal is achievable.
 func TestEMAState_RateProperties(t *testing.T) {
-	s := newEMAState(0.5)
+	s := newEMAState(0.5, 0)
 	counts := map[string]float64{
 		"huge": 100000, "big": 10000, "mid": 1000, "small": 100, "tiny": 1,
 	}

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/allocation_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/allocation_test.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sampler
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file pin the ported math to dynsampler-go v0.6.4 using
+// the library's own test vectors (emathroughput_test.go), so parity is
+// verifiable without driving the library's private, timer-based update path.
+
+// Golden vector: TestEMAThroughputSampleUpdateMapsSparseCounts. A steady key
+// at 40 events/interval among churning single-count keys settles at rate 4
+// for goal 10 events/sec over 1s intervals with weight 0.2.
+func TestEMAState_GoldenSparseCounts(t *testing.T) {
+	s := newEMAState(0.2)
+	rng := rand.New(rand.NewSource(1))
+	var table map[string]int
+	for i := 0; i <= 100; i++ {
+		input := map[string]float64{"largest_count": 40}
+		for j := 0; j < 5; j++ {
+			input[fmt.Sprintf("sporadic-%d-%d", i, rng.Int())] = 1
+		}
+		s.observe(input)
+		table = s.rates(10, time.Second)
+	}
+	require.NotNil(t, table)
+	assert.Equal(t, 4, table["largest_count"])
+}
+
+// Golden vector: TestEMAThroughputAgesOutSmallValues. A key that stops
+// appearing decays below the age-out threshold and is dropped; the average of
+// a steady key converges on its true count.
+func TestEMAState_GoldenAgesOutSmallValues(t *testing.T) {
+	s := newEMAState(0.2)
+	for i := 0; i < 100; i++ {
+		s.observe(map[string]float64{"foo": 500})
+	}
+	require.Len(t, s.movingAverage, 1)
+	assert.Equal(t, float64(500), math.Round(s.movingAverage["foo"]))
+
+	for i := 0; i < 100; i++ {
+		s.observe(map[string]float64{"asdf": 1})
+	}
+	_, found := s.movingAverage["foo"]
+	assert.False(t, found, "unseen key must age out")
+	_, found = s.movingAverage["asdf"]
+	assert.True(t, found)
+}
+
+// An empty interval must not decay the averages (the library deliberately
+// skips updates when there was no traffic).
+func TestEMAState_EmptyIntervalDoesNotDecay(t *testing.T) {
+	s := newEMAState(0.5)
+	s.observe(map[string]float64{"foo": 100})
+	before := s.movingAverage["foo"]
+	s.observe(map[string]float64{})
+	assert.Equal(t, before, s.movingAverage["foo"])
+}
+
+// Allocation properties that hold for any input: every rate is >= 1, rates
+// are monotone in counts (a busier key is never sampled more gently than a
+// quieter one), and the expected kept volume is close to the goal when the
+// goal is achievable.
+func TestEMAState_RateProperties(t *testing.T) {
+	s := newEMAState(0.5)
+	counts := map[string]float64{
+		"huge": 100000, "big": 10000, "mid": 1000, "small": 100, "tiny": 1,
+	}
+	// Feed the same distribution repeatedly so averages converge to it.
+	for i := 0; i < 50; i++ {
+		in := make(map[string]float64, len(counts))
+		for k, v := range counts {
+			in[k] = v
+		}
+		s.observe(in)
+	}
+	const goalPerSec = 100.0
+	table := s.rates(goalPerSec, time.Second)
+	require.NotNil(t, table)
+
+	assert.GreaterOrEqual(t, table["tiny"], 1)
+	assert.GreaterOrEqual(t, table["huge"], table["big"])
+	assert.GreaterOrEqual(t, table["big"], table["mid"])
+	assert.GreaterOrEqual(t, table["mid"], table["small"])
+
+	var kept float64
+	for k, v := range counts {
+		kept += v / float64(table[k])
+	}
+	assert.InDelta(t, goalPerSec, kept, goalPerSec*0.35,
+		"expected kept volume should be near the goal (log allocation is approximate)")
+}

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/sampler.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/sampler.go
@@ -129,53 +129,7 @@ func NewEMAPercentage(cfg EMAPercentageConfig) (Sampler, error) {
 	}, nil
 }
 
-// EMAThroughputConfig configures the EMA throughput sampler, which targets a
-// fixed spans-per-second rate while preserving per-key proportions via EMA.
-type EMAThroughputConfig struct {
-	GoalThroughputPerSec int
-	InitialSamplingRate  int
-	AdjustmentInterval   time.Duration
-	Weight               float64
-	MaxKeys              int
-}
-
-// NewEMAThroughput constructs an EMA throughput sampler.
-func NewEMAThroughput(cfg EMAThroughputConfig) (Sampler, error) {
-	if cfg.GoalThroughputPerSec <= 0 {
-		return nil, errors.New("adaptive_throughput (ema) sampler: goal_throughput must be greater than zero")
-	}
-	return &dynsamplerWrapper{
-		inner: &dynsampler.EMAThroughput{
-			GoalThroughputPerSec: cfg.GoalThroughputPerSec,
-			InitialSampleRate:    cfg.InitialSamplingRate,
-			AdjustmentInterval:   cfg.AdjustmentInterval,
-			Weight:               cfg.Weight,
-			MaxKeys:              cfg.MaxKeys,
-		},
-	}, nil
-}
-
-// WindowedThroughputConfig configures the windowed throughput sampler, which
-// adjusts rates faster than EMA by decoupling the update frequency from the
-// lookback window.
-type WindowedThroughputConfig struct {
-	GoalThroughputPerSec float64
-	UpdateFrequency      time.Duration
-	LookbackFrequency    time.Duration
-	MaxKeys              int
-}
-
-// NewWindowedThroughput constructs a windowed throughput sampler.
-func NewWindowedThroughput(cfg WindowedThroughputConfig) (Sampler, error) {
-	if cfg.GoalThroughputPerSec <= 0 {
-		return nil, errors.New("adaptive_throughput (windowed) sampler: goal_throughput must be greater than zero")
-	}
-	return &dynsamplerWrapper{
-		inner: &dynsampler.WindowedThroughput{
-			GoalThroughputPerSec:      cfg.GoalThroughputPerSec,
-			UpdateFrequencyDuration:   cfg.UpdateFrequency,
-			LookbackFrequencyDuration: cfg.LookbackFrequency,
-			MaxKeys:                   cfg.MaxKeys,
-		},
-	}, nil
-}
+// Throughput samplers (adaptive_throughput) do not live here: they run
+// through SharedThroughput (shared_throughput.go), which recomputes rates
+// from counter-store merged counts rather than dynsampler-go's internal
+// update loop.

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/sampler_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/sampler_test.go
@@ -71,63 +71,10 @@ func TestEMAPercentage_InvalidPercentage(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestEMAThroughput_ReturnsPositiveRate(t *testing.T) {
-	s, err := NewEMAThroughput(EMAThroughputConfig{
-		GoalThroughputPerSec: 100,
-		AdjustmentInterval:   15 * time.Second,
-		Weight:               0.5,
-	})
-	require.NoError(t, err)
-	require.NoError(t, s.Start())
-	t.Cleanup(func() { _ = s.Stop() })
-
-	rate := s.GetSampleRate("svc-a", 1)
-	assert.GreaterOrEqual(t, rate, 1)
-}
-
-func TestEMAThroughput_InvalidGoal(t *testing.T) {
-	_, err := NewEMAThroughput(EMAThroughputConfig{GoalThroughputPerSec: 0})
-	assert.Error(t, err)
-	_, err = NewEMAThroughput(EMAThroughputConfig{GoalThroughputPerSec: -10})
-	assert.Error(t, err)
-}
-
-func TestWindowedThroughput_ReturnsPositiveRate(t *testing.T) {
-	s, err := NewWindowedThroughput(WindowedThroughputConfig{
-		GoalThroughputPerSec: 100,
-		UpdateFrequency:      1 * time.Second,
-		LookbackFrequency:    30 * time.Second,
-	})
-	require.NoError(t, err)
-	require.NoError(t, s.Start())
-	t.Cleanup(func() { _ = s.Stop() })
-
-	rate := s.GetSampleRate("svc-a", 1)
-	assert.GreaterOrEqual(t, rate, 1)
-}
-
-func TestWindowedThroughput_InvalidGoal(t *testing.T) {
-	_, err := NewWindowedThroughput(WindowedThroughputConfig{GoalThroughputPerSec: 0})
-	assert.Error(t, err)
-}
-
 func TestDynsamplerWrapper_StopIsIdempotent(t *testing.T) {
-	samplers := []func() (Sampler, error){
-		func() (Sampler, error) {
-			return NewEMAPercentage(EMAPercentageConfig{GoalSamplingPercentage: 10, AdjustmentInterval: 15 * time.Second, Weight: 0.5})
-		},
-		func() (Sampler, error) {
-			return NewEMAThroughput(EMAThroughputConfig{GoalThroughputPerSec: 100, AdjustmentInterval: 15 * time.Second, Weight: 0.5})
-		},
-		func() (Sampler, error) {
-			return NewWindowedThroughput(WindowedThroughputConfig{GoalThroughputPerSec: 100, UpdateFrequency: time.Second, LookbackFrequency: 30 * time.Second})
-		},
-	}
-	for _, build := range samplers {
-		s, err := build()
-		require.NoError(t, err)
-		require.NoError(t, s.Start())
-		require.NoError(t, s.Stop())
-		require.NoError(t, s.Stop())
-	}
+	s, err := NewEMAPercentage(EMAPercentageConfig{GoalSamplingPercentage: 10, AdjustmentInterval: 15 * time.Second, Weight: 0.5})
+	require.NoError(t, err)
+	require.NoError(t, s.Start())
+	require.NoError(t, s.Stop())
+	require.NoError(t, s.Stop())
 }

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput.go
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sampler // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/sampler"
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// SharedThroughputConfig configures a throughput sampler whose per-key rates
+// are computed over externally merged counts (fleet-wide observations), so
+// GoalThroughputPerSec is the fleet budget rather than a per-instance one.
+type SharedThroughputConfig struct {
+	GoalThroughputPerSec float64
+	// InitialSamplingRate applies to every key until the first merged
+	// interval produces a rate table, and to keys absent from the table.
+	InitialSamplingRate int
+	AdjustmentInterval  time.Duration
+	Weight              float64
+}
+
+// SharedThroughput implements Sampler over a rate table computed from merged
+// fleet counts. It accumulates this instance's observations per interval; the
+// sync loop (owned by the processor) drains them with SnapshotCounts,
+// publishes them to the counter store, and applies the merged fleet counts
+// back with ApplyMergedCounts. The decide path only touches the local counts
+// map and an atomically swapped rate table, never the store.
+type SharedThroughput struct {
+	goalPerSec  float64
+	interval    time.Duration
+	initialRate int
+
+	// mu guards counts, the current interval's local accumulation.
+	mu     sync.Mutex
+	counts map[string]float64
+
+	// rates is the active table, swapped whole by ApplyMergedCounts.
+	rates atomic.Pointer[map[string]int]
+
+	// ema is only touched by ApplyMergedCounts; the sync loop serializes it.
+	ema *emaState
+}
+
+// NewSharedThroughput constructs the sampler. The sync loop wiring happens in
+// the processor; the sampler itself has no background work.
+func NewSharedThroughput(cfg SharedThroughputConfig) (*SharedThroughput, error) {
+	if cfg.GoalThroughputPerSec <= 0 {
+		return nil, errors.New("adaptive_throughput (shared) sampler: goal_throughput must be greater than zero")
+	}
+	interval := cfg.AdjustmentInterval
+	if interval == 0 {
+		interval = 15 * time.Second
+	}
+	initialRate := cfg.InitialSamplingRate
+	if initialRate < 1 {
+		initialRate = 10
+	}
+	return &SharedThroughput{
+		goalPerSec:  cfg.GoalThroughputPerSec,
+		interval:    interval,
+		initialRate: initialRate,
+		counts:      make(map[string]float64),
+		ema:         newEMAState(cfg.Weight),
+	}, nil
+}
+
+// GetSampleRate implements Sampler. It records the observation locally and
+// answers from the current merged rate table, falling back to the bootstrap
+// rate for keys the table does not cover yet.
+func (s *SharedThroughput) GetSampleRate(key string, spanCount int) int {
+	if spanCount <= 0 {
+		spanCount = 1
+	}
+	s.mu.Lock()
+	s.counts[key] += float64(spanCount)
+	s.mu.Unlock()
+
+	if table := s.rates.Load(); table != nil {
+		if rate, ok := (*table)[key]; ok {
+			return max(rate, 1)
+		}
+	}
+	return s.initialRate
+}
+
+// SnapshotCounts returns and resets this instance's accumulated counts for
+// the interval that just completed. Called by the sync loop once per tick.
+func (s *SharedThroughput) SnapshotCounts() map[string]float64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.counts
+	s.counts = make(map[string]float64, len(out))
+	return out
+}
+
+// ApplyMergedCounts folds one completed interval of merged fleet counts into
+// the moving averages and swaps in the recomputed rate table. An empty
+// interval leaves both untouched. merged is consumed. Only the sync loop may
+// call this; it is not safe for concurrent use with itself.
+func (s *SharedThroughput) ApplyMergedCounts(merged map[string]float64) {
+	s.ema.observe(merged)
+	if table := s.ema.rates(s.goalPerSec, s.interval); table != nil {
+		s.rates.Store(&table)
+	}
+}
+
+// Interval returns the adjustment interval the sync loop should tick on.
+func (s *SharedThroughput) Interval() time.Duration { return s.interval }
+
+// Start implements Sampler.
+func (*SharedThroughput) Start() error { return nil }
+
+// Stop implements Sampler.
+func (*SharedThroughput) Stop() error { return nil }

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput.go
@@ -55,7 +55,7 @@ func (e *windowEngine) interval() time.Duration { return e.update }
 // SharedThroughputConfig configures a throughput sampler whose per-key rates
 // are computed over merged counts from a counter store, so
 // GoalThroughputPerSec is the fleet budget when the store spans instances
-// (and plain per-instance behaviour with the in-memory store).
+// (and plain per-instance behavior with the in-memory store).
 type SharedThroughputConfig struct {
 	GoalThroughputPerSec float64
 	// InitialSamplingRate applies to every key until the first table exists,

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput.go
@@ -10,27 +10,73 @@ import (
 	"time"
 )
 
+// rateEngine computes per-key rate tables from a sequence of completed
+// interval buckets. Engines are driven by the sync loop only and are not safe
+// for concurrent use.
+type rateEngine interface {
+	// apply folds one completed interval bucket (consumed) and returns the
+	// recomputed table plus whether to swap it in. The ema engine keeps the
+	// previous table on empty intervals (traffic gaps must not decay
+	// averages); the windowed engine always swaps, including to an empty
+	// table, which sends every key to the bootstrap rate.
+	apply(bucket map[string]float64) (map[string]int, bool)
+	// interval is the cadence the sync loop should tick on.
+	interval() time.Duration
+}
+
+type emaEngine struct {
+	state      *emaState
+	goalPerSec float64
+	ival       time.Duration
+}
+
+func (e *emaEngine) apply(bucket map[string]float64) (map[string]int, bool) {
+	e.state.observe(bucket)
+	table := e.state.rates(e.goalPerSec, e.ival)
+	return table, table != nil
+}
+
+func (e *emaEngine) interval() time.Duration { return e.ival }
+
+type windowEngine struct {
+	state      *windowState
+	goalPerSec float64
+	update     time.Duration
+	lookback   time.Duration
+}
+
+func (e *windowEngine) apply(bucket map[string]float64) (map[string]int, bool) {
+	e.state.push(bucket)
+	return e.state.rates(e.goalPerSec, e.lookback), true
+}
+
+func (e *windowEngine) interval() time.Duration { return e.update }
+
 // SharedThroughputConfig configures a throughput sampler whose per-key rates
-// are computed over externally merged counts (fleet-wide observations), so
-// GoalThroughputPerSec is the fleet budget rather than a per-instance one.
+// are computed over merged counts from a counter store, so
+// GoalThroughputPerSec is the fleet budget when the store spans instances
+// (and plain per-instance behaviour with the in-memory store).
 type SharedThroughputConfig struct {
 	GoalThroughputPerSec float64
-	// InitialSamplingRate applies to every key until the first merged
-	// interval produces a rate table, and to keys absent from the table.
+	// InitialSamplingRate applies to every key until the first table exists,
+	// to keys absent from the table, and to keys beyond MaxKeys.
 	InitialSamplingRate int
-	AdjustmentInterval  time.Duration
-	Weight              float64
+	MaxKeys             int
+	// AdjustmentInterval and Weight configure the ema engine.
+	AdjustmentInterval time.Duration
+	Weight             float64
+	// UpdateFrequency and LookbackFrequency configure the windowed engine.
+	UpdateFrequency   time.Duration
+	LookbackFrequency time.Duration
 }
 
 // SharedThroughput implements Sampler over a rate table computed from merged
-// fleet counts. It accumulates this instance's observations per interval; the
-// sync loop (owned by the processor) drains them with SnapshotCounts,
-// publishes them to the counter store, and applies the merged fleet counts
-// back with ApplyMergedCounts. The decide path only touches the local counts
-// map and an atomically swapped rate table, never the store.
+// counts. It accumulates this instance's observations per interval; the sync
+// loop (owned by the processor) drains them with SnapshotCounts, publishes
+// them to the counter store, and applies the merged counts back with
+// ApplyMergedCounts. The decide path only touches the local counts map and an
+// atomically swapped rate table, never the store.
 type SharedThroughput struct {
-	goalPerSec  float64
-	interval    time.Duration
 	initialRate int
 
 	// mu guards counts, the current interval's local accumulation.
@@ -40,36 +86,68 @@ type SharedThroughput struct {
 	// rates is the active table, swapped whole by ApplyMergedCounts.
 	rates atomic.Pointer[map[string]int]
 
-	// ema is only touched by ApplyMergedCounts; the sync loop serializes it.
-	ema *emaState
+	// engine is only touched by ApplyMergedCounts; the sync loop serializes it.
+	engine rateEngine
 }
 
-// NewSharedThroughput constructs the sampler. The sync loop wiring happens in
-// the processor; the sampler itself has no background work.
-func NewSharedThroughput(cfg SharedThroughputConfig) (*SharedThroughput, error) {
+// NewSharedEMAThroughput constructs the sampler with the ema engine,
+// mirroring dynsampler-go's defaults (interval 15s, weight 0.5, age-out =
+// weight).
+func NewSharedEMAThroughput(cfg SharedThroughputConfig) (*SharedThroughput, error) {
 	if cfg.GoalThroughputPerSec <= 0 {
-		return nil, errors.New("adaptive_throughput (shared) sampler: goal_throughput must be greater than zero")
+		return nil, errors.New("adaptive_throughput (ema) sampler: goal_throughput must be greater than zero")
 	}
 	interval := cfg.AdjustmentInterval
 	if interval == 0 {
 		interval = 15 * time.Second
 	}
+	return newSharedThroughput(cfg, &emaEngine{
+		state:      newEMAState(cfg.Weight, cfg.MaxKeys),
+		goalPerSec: cfg.GoalThroughputPerSec,
+		ival:       interval,
+	}), nil
+}
+
+// NewSharedWindowedThroughput constructs the sampler with the windowed
+// engine, mirroring dynsampler-go's defaults (update 1s, lookback 30x update,
+// lookback floored to a multiple of the update frequency).
+func NewSharedWindowedThroughput(cfg SharedThroughputConfig) (*SharedThroughput, error) {
+	if cfg.GoalThroughputPerSec <= 0 {
+		return nil, errors.New("adaptive_throughput (windowed) sampler: goal_throughput must be greater than zero")
+	}
+	update := cfg.UpdateFrequency
+	if update == 0 {
+		update = time.Second
+	}
+	lookback := cfg.LookbackFrequency
+	if lookback == 0 {
+		lookback = 30 * update
+	}
+	lookback = update * (lookback / update)
+	ticks := int(lookback / update)
+	return newSharedThroughput(cfg, &windowEngine{
+		state:      newWindowState(ticks, cfg.MaxKeys),
+		goalPerSec: cfg.GoalThroughputPerSec,
+		update:     update,
+		lookback:   lookback,
+	}), nil
+}
+
+func newSharedThroughput(cfg SharedThroughputConfig, engine rateEngine) *SharedThroughput {
 	initialRate := cfg.InitialSamplingRate
 	if initialRate < 1 {
 		initialRate = 10
 	}
 	return &SharedThroughput{
-		goalPerSec:  cfg.GoalThroughputPerSec,
-		interval:    interval,
 		initialRate: initialRate,
 		counts:      make(map[string]float64),
-		ema:         newEMAState(cfg.Weight),
-	}, nil
+		engine:      engine,
+	}
 }
 
 // GetSampleRate implements Sampler. It records the observation locally and
-// answers from the current merged rate table, falling back to the bootstrap
-// rate for keys the table does not cover yet.
+// answers from the current rate table, falling back to the bootstrap rate for
+// keys the table does not cover.
 func (s *SharedThroughput) GetSampleRate(key string, spanCount int) int {
 	if spanCount <= 0 {
 		spanCount = 1
@@ -96,19 +174,18 @@ func (s *SharedThroughput) SnapshotCounts() map[string]float64 {
 	return out
 }
 
-// ApplyMergedCounts folds one completed interval of merged fleet counts into
-// the moving averages and swaps in the recomputed rate table. An empty
-// interval leaves both untouched. merged is consumed. Only the sync loop may
-// call this; it is not safe for concurrent use with itself.
+// ApplyMergedCounts folds one completed interval of merged counts into the
+// engine and swaps in the recomputed rate table when the engine produces one.
+// merged is consumed. Only the sync loop may call this; it is not safe for
+// concurrent use with itself.
 func (s *SharedThroughput) ApplyMergedCounts(merged map[string]float64) {
-	s.ema.observe(merged)
-	if table := s.ema.rates(s.goalPerSec, s.interval); table != nil {
+	if table, swap := s.engine.apply(merged); swap {
 		s.rates.Store(&table)
 	}
 }
 
-// Interval returns the adjustment interval the sync loop should tick on.
-func (s *SharedThroughput) Interval() time.Duration { return s.interval }
+// Interval returns the cadence the sync loop should tick on.
+func (s *SharedThroughput) Interval() time.Duration { return s.engine.interval() }
 
 // Start implements Sampler.
 func (*SharedThroughput) Start() error { return nil }

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSharedThroughput_BootstrapUntilFirstTable(t *testing.T) {
-	s, err := NewSharedThroughput(SharedThroughputConfig{
+	s, err := NewSharedEMAThroughput(SharedThroughputConfig{
 		GoalThroughputPerSec: 100,
 		InitialSamplingRate:  10,
 	})
@@ -28,7 +28,7 @@ func TestSharedThroughput_BootstrapUntilFirstTable(t *testing.T) {
 }
 
 func TestSharedThroughput_SnapshotDrainsCounts(t *testing.T) {
-	s, err := NewSharedThroughput(SharedThroughputConfig{GoalThroughputPerSec: 100})
+	s, err := NewSharedEMAThroughput(SharedThroughputConfig{GoalThroughputPerSec: 100})
 	require.NoError(t, err)
 
 	s.GetSampleRate("svc-a", 3)
@@ -41,7 +41,7 @@ func TestSharedThroughput_SnapshotDrainsCounts(t *testing.T) {
 }
 
 func TestSharedThroughput_EmptyMergedIntervalKeepsTable(t *testing.T) {
-	s, err := NewSharedThroughput(SharedThroughputConfig{GoalThroughputPerSec: 100})
+	s, err := NewSharedEMAThroughput(SharedThroughputConfig{GoalThroughputPerSec: 100})
 	require.NoError(t, err)
 
 	s.ApplyMergedCounts(map[string]float64{"svc-a": 50000})
@@ -54,7 +54,7 @@ func TestSharedThroughput_EmptyMergedIntervalKeepsTable(t *testing.T) {
 // core leaderless property: shared inputs, deterministic computation.
 func TestSharedThroughput_TwoInstancesConverge(t *testing.T) {
 	newS := func() *SharedThroughput {
-		s, err := NewSharedThroughput(SharedThroughputConfig{
+		s, err := NewSharedEMAThroughput(SharedThroughputConfig{
 			GoalThroughputPerSec: 200,
 			AdjustmentInterval:   15 * time.Second,
 			Weight:               0.5,
@@ -80,6 +80,6 @@ func TestSharedThroughput_TwoInstancesConverge(t *testing.T) {
 }
 
 func TestSharedThroughput_InvalidGoal(t *testing.T) {
-	_, err := NewSharedThroughput(SharedThroughputConfig{GoalThroughputPerSec: 0})
+	_, err := NewSharedEMAThroughput(SharedThroughputConfig{GoalThroughputPerSec: 0})
 	assert.Error(t, err)
 }

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput_test.go
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sampler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedThroughput_BootstrapUntilFirstTable(t *testing.T) {
+	s, err := NewSharedThroughput(SharedThroughputConfig{
+		GoalThroughputPerSec: 100,
+		InitialSamplingRate:  10,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 10, s.GetSampleRate("svc-a", 1), "no table yet: bootstrap rate applies")
+
+	// One merged interval produces a table; known keys answer from it,
+	// unknown keys keep the bootstrap.
+	s.ApplyMergedCounts(map[string]float64{"svc-a": 50000})
+	assert.NotEqual(t, 10, s.GetSampleRate("svc-a", 1), "table rate replaces bootstrap")
+	assert.Equal(t, 10, s.GetSampleRate("svc-new", 1), "keys absent from the table use the bootstrap")
+}
+
+func TestSharedThroughput_SnapshotDrainsCounts(t *testing.T) {
+	s, err := NewSharedThroughput(SharedThroughputConfig{GoalThroughputPerSec: 100})
+	require.NoError(t, err)
+
+	s.GetSampleRate("svc-a", 3)
+	s.GetSampleRate("svc-a", 2)
+	s.GetSampleRate("svc-b", 0) // non-positive span counts observe as 1
+
+	counts := s.SnapshotCounts()
+	assert.Equal(t, map[string]float64{"svc-a": 5, "svc-b": 1}, counts)
+	assert.Empty(t, s.SnapshotCounts(), "snapshot resets the accumulator")
+}
+
+func TestSharedThroughput_EmptyMergedIntervalKeepsTable(t *testing.T) {
+	s, err := NewSharedThroughput(SharedThroughputConfig{GoalThroughputPerSec: 100})
+	require.NoError(t, err)
+
+	s.ApplyMergedCounts(map[string]float64{"svc-a": 50000})
+	rate := s.GetSampleRate("svc-a", 1)
+	s.ApplyMergedCounts(map[string]float64{})
+	assert.Equal(t, rate, s.GetSampleRate("svc-a", 1), "empty interval must not change or drop the table")
+}
+
+// Two samplers fed the same merged counts converge on identical tables, the
+// core leaderless property: shared inputs, deterministic computation.
+func TestSharedThroughput_TwoInstancesConverge(t *testing.T) {
+	newS := func() *SharedThroughput {
+		s, err := NewSharedThroughput(SharedThroughputConfig{
+			GoalThroughputPerSec: 200,
+			AdjustmentInterval:   15 * time.Second,
+			Weight:               0.5,
+		})
+		require.NoError(t, err)
+		return s
+	}
+	a, b := newS(), newS()
+
+	// Instance A sees svc-1 heavy, instance B sees svc-2 heavy; the merged
+	// view is identical for both.
+	for i := 0; i < 20; i++ {
+		merged := map[string]float64{"svc-1": 90000, "svc-2": 60000, "svc-3": 300}
+		mergedCopy := map[string]float64{"svc-1": 90000, "svc-2": 60000, "svc-3": 300}
+		a.ApplyMergedCounts(merged)
+		b.ApplyMergedCounts(mergedCopy)
+	}
+
+	for _, key := range []string{"svc-1", "svc-2", "svc-3"} {
+		assert.Equal(t, a.GetSampleRate(key, 1), b.GetSampleRate(key, 1),
+			"instances with the same merged counts must produce identical rates for %s", key)
+	}
+}
+
+func TestSharedThroughput_InvalidGoal(t *testing.T) {
+	_, err := NewSharedThroughput(SharedThroughputConfig{GoalThroughputPerSec: 0})
+	assert.Error(t, err)
+}

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/shared_throughput_test.go
@@ -66,7 +66,7 @@ func TestSharedThroughput_TwoInstancesConverge(t *testing.T) {
 
 	// Instance A sees svc-1 heavy, instance B sees svc-2 heavy; the merged
 	// view is identical for both.
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		merged := map[string]float64{"svc-1": 90000, "svc-2": 60000, "svc-3": 300}
 		mergedCopy := map[string]float64{"svc-1": 90000, "svc-2": 60000, "svc-3": 300}
 		a.ApplyMergedCounts(merged)

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/window.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/window.go
@@ -1,0 +1,101 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sampler // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/sampler"
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+// windowState ports the windowed throughput math from dynsampler-go v0.6.4
+// (WindowedThroughput.updateMaps over a BlockList): per-update-tick count
+// buckets over a lookback window, aggregated by summation, with the lookback
+// goal split equally across the keys present in the window. Golden tests in
+// window_test.go pin parity against the library's own test vectors. Not safe
+// for concurrent use; callers serialize access.
+type windowState struct {
+	// buckets is a ring of completed tick buckets, length = lookback ticks.
+	buckets []map[string]float64
+	pos     int
+	// maxKeys bounds the distinct keys tracked across the window; 0 means
+	// unbounded. Keys beyond the cap are dropped at insertion, in sorted
+	// order so instances applying identical merged buckets stay in
+	// agreement. active tracks per-key presence across ring buckets.
+	maxKeys int
+	active  map[string]int
+}
+
+func newWindowState(lookbackTicks, maxKeys int) *windowState {
+	if lookbackTicks < 1 {
+		lookbackTicks = 1
+	}
+	return &windowState{
+		buckets: make([]map[string]float64, lookbackTicks),
+		maxKeys: maxKeys,
+		active:  make(map[string]int),
+	}
+}
+
+// push installs the just-completed tick bucket, evicting the oldest. bucket
+// is consumed. When maxKeys is set, keys not already tracked are admitted in
+// sorted order until the cap; the rest are dropped (the library's bounded
+// BlockList rejects new keys the same way, by arrival order).
+func (w *windowState) push(bucket map[string]float64) {
+	if old := w.buckets[w.pos]; old != nil {
+		for k := range old {
+			if w.active[k]--; w.active[k] <= 0 {
+				delete(w.active, k)
+			}
+		}
+	}
+	if w.maxKeys > 0 {
+		keys := make([]string, 0, len(bucket))
+		for k := range bucket {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if _, tracked := w.active[k]; tracked {
+				w.active[k]++
+				continue
+			}
+			if len(w.active) >= w.maxKeys {
+				delete(bucket, k)
+				continue
+			}
+			w.active[k]++
+		}
+	} else {
+		for k := range bucket {
+			w.active[k]++
+		}
+	}
+	w.buckets[w.pos] = bucket
+	w.pos = (w.pos + 1) % len(w.buckets)
+}
+
+// rates computes the equal-split allocation over the aggregated window.
+// Unlike the EMA engine it always returns a non-nil table: windowed
+// semantics reset rates to empty when the window has no traffic, and the
+// caller's bootstrap fallback covers every key.
+func (w *windowState) rates(goalPerSec float64, lookback time.Duration) map[string]int {
+	agg := make(map[string]float64)
+	for _, b := range w.buckets {
+		for k, v := range b {
+			agg[k] += v
+		}
+	}
+	table := make(map[string]int, len(agg))
+	if len(agg) == 0 {
+		return table
+	}
+	totalGoal := goalPerSec * lookback.Seconds()
+	perKey := totalGoal / float64(len(agg))
+	for k, v := range agg {
+		// int truncation, not Ceil: the library truncates here.
+		table[k] = int(math.Max(1, v/perKey))
+	}
+	return table
+}

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/window.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/window.go
@@ -45,7 +45,8 @@ func newWindowState(lookbackTicks, maxKeys int) *windowState {
 func (w *windowState) push(bucket map[string]float64) {
 	if old := w.buckets[w.pos]; old != nil {
 		for k := range old {
-			if w.active[k]--; w.active[k] <= 0 {
+			w.active[k]--
+			if w.active[k] <= 0 {
 				delete(w.active, k)
 			}
 		}

--- a/processor/adaptivetailsamplingprocessor/internal/sampler/window_test.go
+++ b/processor/adaptivetailsamplingprocessor/internal/sampler/window_test.go
@@ -1,0 +1,121 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sampler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Golden vector: dynsampler-go v0.6.4 TestHappyPath. Goal 2/s, 1s update, 5s
+// lookback; buckets of 20, 10, 50, then three empty, then 40 produce rates
+// 2, 3, 8, 6 (after the gap) and 9, matching the library's expected sequence
+// at each tick.
+func TestWindowState_GoldenHappyPath(t *testing.T) {
+	s, err := NewSharedWindowedThroughput(SharedThroughputConfig{
+		GoalThroughputPerSec: 2,
+		InitialSamplingRate:  10,
+		UpdateFrequency:      time.Second,
+		LookbackFrequency:    5 * time.Second,
+	})
+	require.NoError(t, err)
+	const key = "test_key"
+
+	// No table yet: bootstrap.
+	assert.Equal(t, 10, s.GetSampleRate(key, 1))
+
+	s.ApplyMergedCounts(map[string]float64{key: 20})
+	assert.Equal(t, 2, s.GetSampleRate(key, 1))
+
+	s.ApplyMergedCounts(map[string]float64{key: 10})
+	assert.Equal(t, 3, s.GetSampleRate(key, 1))
+
+	s.ApplyMergedCounts(map[string]float64{key: 50})
+	assert.Equal(t, 8, s.GetSampleRate(key, 1))
+
+	// Three empty ticks: at the third, the window is 10+50 = 60 -> rate 6.
+	s.ApplyMergedCounts(map[string]float64{})
+	s.ApplyMergedCounts(map[string]float64{})
+	s.ApplyMergedCounts(map[string]float64{})
+	assert.Equal(t, 6, s.GetSampleRate(key, 1))
+
+	s.ApplyMergedCounts(map[string]float64{key: 40})
+	assert.Equal(t, 9, s.GetSampleRate(key, 1))
+}
+
+// Golden vector: dynsampler-go v0.6.4 TestDropsOldBlocks. Once the only
+// traffic falls out of the lookback window, the table resets and keys return
+// to the bootstrap rate (the library returns 0 there; the sampler maps that
+// to the bootstrap).
+func TestWindowState_GoldenDropsOldBlocks(t *testing.T) {
+	s, err := NewSharedWindowedThroughput(SharedThroughputConfig{
+		GoalThroughputPerSec: 2,
+		InitialSamplingRate:  10,
+		UpdateFrequency:      time.Second,
+		LookbackFrequency:    5 * time.Second,
+	})
+	require.NoError(t, err)
+	const key = "test_key"
+
+	s.ApplyMergedCounts(map[string]float64{key: 20})
+	assert.Equal(t, 2, s.GetSampleRate(key, 1))
+	for range 6 {
+		s.ApplyMergedCounts(map[string]float64{})
+	}
+	assert.Equal(t, 10, s.GetSampleRate(key, 1),
+		"traffic aged out of the window must return to the bootstrap rate")
+}
+
+// max_keys admission is deterministic (sorted) and overflow keys answer at
+// the bootstrap rate; eviction of old buckets frees slots.
+func TestWindowState_MaxKeysOverflowFallsBack(t *testing.T) {
+	s, err := NewSharedWindowedThroughput(SharedThroughputConfig{
+		GoalThroughputPerSec: 100,
+		InitialSamplingRate:  7,
+		MaxKeys:              2,
+		UpdateFrequency:      time.Second,
+		LookbackFrequency:    2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	s.ApplyMergedCounts(map[string]float64{"a": 1000, "b": 1000, "c": 1000})
+	table := *s.rates.Load()
+	assert.Len(t, table, 2)
+	assert.Contains(t, table, "a")
+	assert.Contains(t, table, "b")
+	assert.Equal(t, 7, s.GetSampleRate("c", 1), "overflow key uses the bootstrap rate")
+
+	// Two empty ticks age out a and b, freeing slots for c.
+	s.ApplyMergedCounts(map[string]float64{})
+	s.ApplyMergedCounts(map[string]float64{})
+	s.ApplyMergedCounts(map[string]float64{"c": 1000})
+	table = *s.rates.Load()
+	assert.Contains(t, table, "c", "aged-out keys free max_keys slots")
+}
+
+// Two windowed instances applying identical merged buckets converge on
+// identical tables, including under max_keys pressure.
+func TestWindowState_TwoInstancesConverge(t *testing.T) {
+	mk := func() *SharedThroughput {
+		s, err := NewSharedWindowedThroughput(SharedThroughputConfig{
+			GoalThroughputPerSec: 50,
+			MaxKeys:              3,
+			UpdateFrequency:      time.Second,
+			LookbackFrequency:    5 * time.Second,
+		})
+		require.NoError(t, err)
+		return s
+	}
+	a, b := mk(), mk()
+	for range 10 {
+		a.ApplyMergedCounts(map[string]float64{"k1": 900, "k2": 600, "k3": 30, "k4": 5})
+		b.ApplyMergedCounts(map[string]float64{"k1": 900, "k2": 600, "k3": 30, "k4": 5})
+	}
+	for _, key := range []string{"k1", "k2", "k3", "k4"} {
+		assert.Equal(t, a.GetSampleRate(key, 1), b.GetSampleRate(key, 1), key)
+	}
+}

--- a/processor/adaptivetailsamplingprocessor/metadata.yaml
+++ b/processor/adaptivetailsamplingprocessor/metadata.yaml
@@ -18,6 +18,14 @@ tests:
 
 telemetry:
   metrics:
+    processor_adaptive_tail_sampling_counter_sync_errors:
+      enabled: true
+      description: Number of counter store sync failures for adaptive_throughput samplers, labelled by rule and operation (add, read). Each failure fails open to this instance's own counts for that interval.
+      unit: "{errors}"
+      sum:
+        value_type: int
+        monotonic: true
+      stability: development
     processor_adaptive_tail_sampling_decision_sample_rate:
       enabled: true
       description: Distribution of effective sample rates produced per rule. Useful for detecting adaptive samplers settling at unexpected rates.

--- a/processor/adaptivetailsamplingprocessor/processor.go
+++ b/processor/adaptivetailsamplingprocessor/processor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/counterstore"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/adaptivetailsamplingprocessor/internal/sampler"
 )
@@ -147,6 +148,11 @@ type adaptiveTailSamplingProcessor struct {
 	// default IsRootSpan(), letting the per-span check skip OTTL entirely.
 	rootSpanFastPath bool
 
+	// syncCancel stops the counter-sync loops Start spawned for throughput
+	// samplers; syncWG waits for them to exit.
+	syncCancel context.CancelFunc
+	syncWG     sync.WaitGroup
+
 	wg sync.WaitGroup
 }
 
@@ -263,22 +269,24 @@ func newSamplerForRule(rc *RuleConfig) (sampler.Sampler, []sampler.Selector, err
 		selectors, err := sampler.ParseSelectors(sc.FingerprintAttributes)
 		return s, selectors, err
 	case AdaptiveThroughput:
+		// Both algorithms run through SharedThroughput: counts published to a
+		// counter store each interval, rates recomputed from the merged
+		// totals. Without shared_counters the store is in-process, giving
+		// per-instance behavior through the same path.
+		stCfg := sampler.SharedThroughputConfig{
+			GoalThroughputPerSec: float64(sc.GoalThroughput),
+			MaxKeys:              sc.MaxKeys,
+			AdjustmentInterval:   sc.AdjustmentInterval,
+			Weight:               sc.Weight,
+			UpdateFrequency:      sc.UpdateFrequency,
+			LookbackFrequency:    sc.LookbackFrequency,
+		}
 		var s sampler.Sampler
 		var err error
 		if sc.effectiveAlgorithm() == AlgorithmWindowed {
-			s, err = sampler.NewWindowedThroughput(sampler.WindowedThroughputConfig{
-				GoalThroughputPerSec: float64(sc.GoalThroughput),
-				UpdateFrequency:      sc.UpdateFrequency,
-				LookbackFrequency:    sc.LookbackFrequency,
-				MaxKeys:              sc.MaxKeys,
-			})
+			s, err = sampler.NewSharedWindowedThroughput(stCfg)
 		} else {
-			s, err = sampler.NewEMAThroughput(sampler.EMAThroughputConfig{
-				GoalThroughputPerSec: sc.GoalThroughput,
-				AdjustmentInterval:   sc.AdjustmentInterval,
-				Weight:               sc.Weight,
-				MaxKeys:              sc.MaxKeys,
-			})
+			s, err = sampler.NewSharedEMAThroughput(stCfg)
 		}
 		if err != nil {
 			return nil, nil, err
@@ -296,14 +304,66 @@ func (*adaptiveTailSamplingProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
-// Start initializes the embedded samplers.
-func (p *adaptiveTailSamplingProcessor) Start(context.Context, component.Host) error {
+// Start initializes the embedded samplers, resolves the counter store for
+// each throughput sampler (the configured extension, or the in-process
+// default), and spawns their counter-sync loops.
+func (p *adaptiveTailSamplingProcessor) Start(_ context.Context, host component.Host) error {
 	for _, r := range p.rules {
 		if err := r.sampler.Start(); err != nil {
 			return fmt.Errorf("rule %q sampler start: %w", r.name, err)
 		}
 	}
+
+	type syncTarget struct {
+		name    string
+		sampler *sampler.SharedThroughput
+		store   counterstore.Store
+	}
+	var targets []syncTarget
+	for i, r := range p.rules {
+		st, ok := r.sampler.(*sampler.SharedThroughput)
+		if !ok {
+			continue
+		}
+		store, err := resolveCounterStore(host, p.cfg.Rules[i].Sampler.SharedCounters)
+		if err != nil {
+			return fmt.Errorf("rule %q: %w", r.name, err)
+		}
+		targets = append(targets, syncTarget{name: r.name, sampler: st, store: store})
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+	// The loops outlive Start's context; Shutdown cancels them.
+	ctx, cancel := context.WithCancel(context.Background())
+	p.syncCancel = cancel
+	for _, t := range targets {
+		p.syncWG.Add(1)
+		go p.runCounterSync(ctx, t.name, t.sampler, t.store)
+	}
 	return nil
+}
+
+// resolveCounterStore returns the counter store a throughput sampler should
+// publish to: the sampler-state extension named by shared_counters, or a
+// fresh in-process store when the block is unset. Extensions satisfy
+// counterstore.Store structurally; they do not import the processor.
+func resolveCounterStore(host component.Host, cfg *SharedCountersConfig) (counterstore.Store, error) {
+	if cfg == nil {
+		return counterstore.NewMemory(), nil
+	}
+	if host == nil {
+		return nil, errors.New("shared_counters: no host available to resolve extensions")
+	}
+	ext, ok := host.GetExtensions()[cfg.Extension]
+	if !ok {
+		return nil, fmt.Errorf("shared_counters: extension %q not found", cfg.Extension)
+	}
+	store, ok := ext.(counterstore.Store)
+	if !ok {
+		return nil, fmt.Errorf("shared_counters: extension %q does not implement the counter store interface (AddCounts/ReadCounts)", cfg.Extension)
+	}
+	return store, nil
 }
 
 // Shutdown cancels any pending decision timers, stops samplers, and waits for
@@ -355,6 +415,14 @@ func (p *adaptiveTailSamplingProcessor) Shutdown(ctx context.Context) error {
 		}
 		pt.triggerReason = triggerShutdown
 		p.decideTrace(ctx, pt)
+	}
+
+	// Stop the counter-sync loops after the drain: samplers answer from their
+	// last table (and bootstrap) regardless, so ordering only affects whether
+	// one final tick can land mid-drain, which is harmless.
+	if p.syncCancel != nil {
+		p.syncCancel()
+		p.syncWG.Wait()
 	}
 
 	var errs error

--- a/processor/adaptivetailsamplingprocessor/processor.go
+++ b/processor/adaptivetailsamplingprocessor/processor.go
@@ -318,6 +318,7 @@ func (p *adaptiveTailSamplingProcessor) Start(_ context.Context, host component.
 		name    string
 		sampler *sampler.SharedThroughput
 		store   counterstore.Store
+		timeout time.Duration
 	}
 	var targets []syncTarget
 	for i, r := range p.rules {
@@ -325,11 +326,16 @@ func (p *adaptiveTailSamplingProcessor) Start(_ context.Context, host component.
 		if !ok {
 			continue
 		}
-		store, err := resolveCounterStore(host, p.cfg.Rules[i].Sampler.SharedCounters)
+		shared := p.cfg.Rules[i].Sampler.SharedCounters
+		store, err := resolveCounterStore(host, shared)
 		if err != nil {
 			return fmt.Errorf("rule %q: %w", r.name, err)
 		}
-		targets = append(targets, syncTarget{name: r.name, sampler: st, store: store})
+		var timeout time.Duration
+		if shared != nil {
+			timeout = shared.SyncTimeout
+		}
+		targets = append(targets, syncTarget{name: r.name, sampler: st, store: store, timeout: timeout})
 	}
 	if len(targets) == 0 {
 		return nil
@@ -339,7 +345,7 @@ func (p *adaptiveTailSamplingProcessor) Start(_ context.Context, host component.
 	p.syncCancel = cancel
 	for _, t := range targets {
 		p.syncWG.Add(1)
-		go p.runCounterSync(ctx, t.name, t.sampler, t.store)
+		go p.runCounterSync(ctx, t.name, t.sampler, t.store, t.timeout)
 	}
 	return nil
 }


### PR DESCRIPTION
#### Description

Adds `shared_counters` to `adaptive_throughput` so `goal_throughput` can be a fleet-wide budget instead of per-instance. Design, rationale and alternatives are in #50577.

Worth flagging for review, since it is not in the issue. `adaptive_throughput` is reimplemented on the new shared path, so the dynsampler throughput constructors are gone and `initial_sampling_percentage` (#50542) now feeds the bootstrap rate through it. That also closes the `max_keys` overflow half of #50538, a behaviour change where overflow keys sample at the bootstrap rate rather than keep-all.

#### Link to tracking issue

Part of #50577.

#### Testing

- Unit: in-memory store, sync loop fail-open (error and timeout), two-instance convergence, extension resolution and ported-math parity against dynsampler-go golden vectors.
- End to end: two collectors sharing Redis converge to the fleet `goal_throughput`.

#### Documentation

README `shared_counters` section and a new `counter_sync_errors` metric.

#### Authorship

- [x] I, a human, wrote this pull request description myself.
